### PR TITLE
added a default value of production for the environment

### DIFF
--- a/packages/marginfi-client-v2/src/config.ts
+++ b/packages/marginfi-client-v2/src/config.ts
@@ -93,7 +93,7 @@ function getMarginfiConfig(
  * Retrieve config per environment
  */
 export function getConfig(
-  environment: Environment,
+  environment: Environment = "production",
   overrides?: Partial<Omit<MarginfiConfig, "environment">>
 ): MarginfiConfig {
   return {


### PR DESCRIPTION
After speaking more with @jkbpvsc it is still odd to write

`
const config = getConfig("production")
`

As a consumer, I'm not exactly sure what "production" implies. I also don't have access to the configs from the .env from the core team to see what else is changing. 

With getConfig being the default way I can access a MarginfiConfig object and the usage of getConfig spread out around the rest of the repo, I suggest adding a default parameter of "production" to remove the need for consumers to think about it. 

`
const config = getConfig()
` 

This should

- feel like more natural boiler plate code
- keep parity with internal usage of getConfig
- protect against future improvements to the interface (ex. "mainnet") 

