### PR TITLE
disable input when bot thinking or transaction pending

### DIFF
--- a/apps/omni/src/api/ai/index.ts
+++ b/apps/omni/src/api/ai/index.ts
@@ -5,7 +5,7 @@ const PREFIX = `
   Your role: An autonomous agent that helps humans interact with the Solana blockchain.
 
   Your goals is to perform one of the following tasks depending on the user request, and one only, evaluating them in order:
-    1. If the prompt is a request to perform a deposit/withdraw/stake/superstake/borrow/repay action, determine the relevant amounts and tokens involved. You will reply with a summary of the request, formatted as 'ACTION: <action> <amount> <token> - <protocol>'. If you are unable to determine the relevant amounts and tokens involved, ask the user to rephrase.
+    1. If the prompt is a request to perform a deposit/withdraw/stake/superstake/borrow/repay action, determine the relevant amounts and tokens involved. You will reply with a summary of the request, formatted as 'FORMATTED: <action> <amount> <token> - <protocol>'. If you are unable to determine the relevant amounts and tokens involved, ask the user to rephrase.
     2. If the prompt requests information about the user's account, provide the summary metrics as well as all the non empty token balances, specifying for each the token name, quantity, USD value, and type (deposit/borrow). Use a human-friendly and readable format. Your final response will go directly to the user. Speak as if you're responding to them directly.
     3. If the prompt is a question, answer that question. Use a human-friendly format. Your final response will go directly to the user. Speak as if you're responding to them directly.
     4. If the prompt falls into none of the categories above, ask the user to rephrase, but do it in scottish slang. Your final response will go directly to the user. Speak as if you're responding to them directly.
@@ -28,7 +28,6 @@ const callAI = async ({ input, walletPublicKey }: { input: string; walletPublicK
 };
 
 export { callAI };
-
 
 // A user has a request.
 

--- a/apps/omni/src/pages/api/ai.ts
+++ b/apps/omni/src/pages/api/ai.ts
@@ -34,6 +34,7 @@ const extractVariables = (sentence: string): ExtractVariablesOutput => {
     if (
       [
         "lend",
+        "repay",
         "add",
         "put",
         "give",
@@ -182,8 +183,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     response = {
       output: `
-        It sounds like you want to ${actionDisplayed} ${result.amount} ${result.token}. ${walletPublicKey ? "I'm setting up a transaction for you." : "Connect your wallet and let's get started."
-        }
+        It sounds like you want to ${actionDisplayed} ${result.amount} ${result.token}. ${
+        walletPublicKey ? "I'm setting up a transaction for you." : "Connect your wallet and let's get started."
+      }
       `,
       data: walletPublicKey && {
         action: result.action,
@@ -197,34 +199,33 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       console.log("calling AI");
       response = await callAI({ input, walletPublicKey });
 
-      // // Second string parsing to detect the agent returning an action
-      // const result = extractVariables(response); // todo: parse according to stricter format, to avoid this wrongly returning an action to client
-      // console.log(response.output);
-      // console.log({ result });
+      // Second string parsing to detect the agent returning an action
+      const result = extractVariables(response.output); // todo: parse according to stricter format, to avoid this wrongly returning an action to client
+      console.log(response.output);
+      console.log({ result });
 
-      // // if ((response.output as string).startsWith("ACTION:") && result.action && result.amount && result.token) {
-      // if (result.action && result.amount && result.token) {
-      //   let actionDisplayed;
-      //   if (result.action === "deposit") {
-      //     actionDisplayed = "put in";
-      //   } else if (result.action === "borrow") {
-      //     actionDisplayed = "take out";
-      //   } else {
-      //     actionDisplayed = result.action;
-      //   }
+      if ((response.output as string).startsWith("FORMATTED:") && result.action && result.amount && result.token) {
+        let actionDisplayed;
+        if (result.action === "deposit") {
+          actionDisplayed = "put in";
+        } else if (result.action === "borrow") {
+          actionDisplayed = "take out";
+        } else {
+          actionDisplayed = result.action;
+        }
 
-      //   response = {
-      //     output: `
-      //       It sounds like you want to ${actionDisplayed} ${result.amount} ${result.token}. ${
-      //       walletPublicKey ? "I'm setting up a transaction for you." : "Connect your wallet and let's get started."
-      //     }`,
-      //     data: walletPublicKey && {
-      //       action: result.action,
-      //       amount: result.amount,
-      //       tokenSymbol: result.token,
-      //     },
-      //   };
-      // }
+        response = {
+          output: `
+            It sounds like you want to ${actionDisplayed} ${result.amount} ${result.token}. ${
+            walletPublicKey ? "I'm setting up a transaction for you." : "Connect your wallet and let's get started."
+          }`,
+          data: walletPublicKey && {
+            action: result.action,
+            amount: result.amount,
+            tokenSymbol: result.token,
+          },
+        };
+      }
     } catch (error: any) {
       console.error("Error calling OpenAI API:", error);
       response = {

--- a/apps/omni/src/pages/index.tsx
+++ b/apps/omni/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState, useCallback, useRef } from "react";
+import React, { FC, useState, useCallback, useRef, useMemo } from "react";
 import Image from "next/image";
 import axios from "axios";
 import { TextField } from "@mui/material";
@@ -10,6 +10,23 @@ import { superStake, withdrawSuperstake } from "~/components/superStakeActions";
 import { TypeAnimation } from "react-type-animation";
 import { InputAdornment } from "@mui/material";
 import { FormEventHandler } from "react";
+
+const SAMPLE_PROMPTS = [
+  "Show me my account, fool!",
+  "Deposit 10 USDC into marginfi",
+  "I want to lend 100 usdc on marginfi",
+  "Can I borrow 1 SOL from marginfi?",
+  "Withdraw all my USDC from marginfi",
+  "How much SOL do I have deposited in marginfi?",
+  "How much BONK do I have deposited in marginfi?",
+  "Is DUST supported on marginfi?",
+  "Show me my debt on marginfi",
+  "How is my health calculated on hubble?",
+  "给我查下最新的eth价格",
+  "What is dialect?",
+  "크립토 시장이 성장할 거라고 생각하니?",
+  "Hola, que sabes sobre bitcoin?",
+];
 
 const AiUI: FC = () => {
   const [prompt, setPrompt] = useState<string>("");
@@ -26,9 +43,12 @@ const AiUI: FC = () => {
   const jupiter = useJupiterApiContext();
   const { extendedBankInfos, selectedAccount } = useUserAccounts();
 
+  const samplePrompt = useMemo(() => {
+    return SAMPLE_PROMPTS[Math.floor(Math.random() * SAMPLE_PROMPTS.length)];
+  }, []);
+
   const resetState = useCallback(() => {
     setPrompt("");
-    setResponse("");
     setThinking(false);
     setTransacting(false);
     setFailed(false);
@@ -235,7 +255,7 @@ const AiUI: FC = () => {
               if (response && !thinking && !transacting) resetState();
             }}
             onChange={(e) => setPrompt(e.target.value)}
-            placeholder="Ask me who I am"
+            placeholder={samplePrompt}
             variant="standard"
             InputProps={{
               disableUnderline: true, // <== added this

--- a/apps/omni/src/pages/index.tsx
+++ b/apps/omni/src/pages/index.tsx
@@ -232,7 +232,7 @@ const AiUI: FC = () => {
             // The prompt input only handles value changing.
             // Actual action isn't taken until enter is pressed.
             onClick={() => {
-              if (!thinking && !transacting) resetState();
+              if (response && !thinking && !transacting) resetState();
             }}
             onChange={(e) => setPrompt(e.target.value)}
             placeholder="Ask me who I am"

--- a/apps/omni/src/pages/index.tsx
+++ b/apps/omni/src/pages/index.tsx
@@ -228,9 +228,12 @@ const AiUI: FC = () => {
           <TextField
             fullWidth
             value={prompt}
+            disabled={thinking || transacting}
             // The prompt input only handles value changing.
             // Actual action isn't taken until enter is pressed.
-            onClick={resetState}
+            onClick={() => {
+              if (!thinking && !transacting) resetState();
+            }}
             onChange={(e) => setPrompt(e.target.value)}
             placeholder="Ask me who I am"
             variant="standard"


### PR DESCRIPTION
- disable input when bot thinking or transaction pending
- add "repay" to supported regex
- bring back parsing of AI call for formatted action detection
- make formatted actions parsing stricter to avoid mistaken action trigger (e.g. when receiving a verbose account summary containing all the right keywords)
- make prompt reset less annoying
- add randomized prompt placeholder