### PR TITLE
add net apy to navbar

### DIFF
--- a/apps/marginfi-v2-ui/src/components/Navbar/Navbar.tsx
+++ b/apps/marginfi-v2-ui/src/components/Navbar/Navbar.tsx
@@ -1,10 +1,10 @@
-import { FC, useEffect, useState } from "react";
+import { FC, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import AirdropZone from "./AirdropZone";
 import { WalletButton } from "./WalletButton";
 import { useWallet } from "@solana/wallet-adapter-react";
-import { groupedNumberFormatterDyn, numeralFormatter } from "~/utils/formatters";
+import { groupedNumberFormatterDyn, numeralFormatter, percentFormatter } from "~/utils/formatters";
 import { useHotkeys } from "react-hotkeys-hook";
 import { useUserAccounts } from "~/context";
 import { useRecoilState } from "recoil";
@@ -125,6 +125,14 @@ const Navbar: FC = () => {
     return () => unsubscribe();
   }, [auth]);
 
+  const netApy = useMemo(() => {
+	if (selectedAccount) {
+		return selectedAccount.computeNetApy();
+	} else {
+		return null;
+	}
+  }, [selectedAccount]);
+
   useEffect(() => {
     if (user && wallet.publicKey?.toBase58()) {
       const fetchData = async () => {
@@ -230,6 +238,11 @@ const Navbar: FC = () => {
           <div
             className="h-full w-1/2 flex justify-end items-center z-10 text-base font-[300] gap-4 lg:gap-8"
           >
+			<div
+              className="glow-on-hover whitespace-nowrap hidden md:block"
+            >
+              Net APY: {netApy ? percentFormatter.format(netApy) : "0.00"}
+            </div>
             <div
               className="glow-uxd whitespace-nowrap cursor-pointer hidden md:block"
               onClick={() => {


### PR DESCRIPTION
As per #149. Haven't tested it out as dev env doesn't fetch mainnet accounts. Added it to navbar instead of a tile in https://github.com/mrgnlabs/mrgn-ts/blob/main/apps/marginfi-v2-ui/src/components/AccountSummary/AccountSummary.tsx as that add a separate tile on a new line. Unnecessary empty space, plus header takes most of the space on the page, which is bad UX imo.   