### PR TITLE
Fix #192

### DIFF
--- a/apps/marginfi-v2-ui/src/components/AssetsList/AssetRow/AssetRowInputBox.tsx
+++ b/apps/marginfi-v2-ui/src/components/AssetsList/AssetRow/AssetRowInputBox.tsx
@@ -49,19 +49,23 @@ const AssetRowInputBox: FC<AssetRowInputBox> = ({
   return (
     <div className="flex justify-center">
       <NumericFormat
-        value={value}
-        placeholder="0"
+        value={maxValue ? value : ""}
+        placeholder={maxValue ? "0" : undefined}
         allowNegative={false}
         decimalScale={maxDecimals}
-        disabled={disabled}
+        disabled={disabled || !maxValue}
         onValueChange={onChange}
         thousandSeparator=","
         customInput={TextField}
         size="small"
-        max={maxValue}
+        isAllowed={(values) => {
+          const { floatValue } = values;
+          if (!maxValue) return false;
+          return floatValue ? floatValue < maxValue : true;
+        }}
         InputProps={{
           className: "font-aeonik text-[#e1e1e1] border border-[#4E5257] p-0 m-0 text-sm h-11",
-          endAdornment: <MaxInputAdornment onClick={onMaxClick} disabled={disabled} />,
+          endAdornment: <MaxInputAdornment onClick={onMaxClick} disabled={disabled || !maxValue} />,
         }}
         getInputRef={(el: any) => (inputRefs.current[tokenName] = el)}
       />

--- a/apps/marginfi-v2-ui/src/components/AssetsList/AssetRow/AssetRowInputBox.tsx
+++ b/apps/marginfi-v2-ui/src/components/AssetsList/AssetRow/AssetRowInputBox.tsx
@@ -50,10 +50,10 @@ const AssetRowInputBox: FC<AssetRowInputBox> = ({
     <div className="flex justify-center">
       <NumericFormat
         value={maxValue ? value : ""}
-        placeholder={maxValue ? "0" : undefined}
+        placeholder="0"
         allowNegative={false}
         decimalScale={maxDecimals}
-        disabled={disabled || !maxValue}
+        disabled={disabled}
         onValueChange={onChange}
         thousandSeparator=","
         customInput={TextField}


### PR DESCRIPTION
This PR implements a temporary fix for #192. I would not call this solution complete and it likely needs deeper UX consideration. For example it is now not immediately clear why some input boxes are disabled and others have max buttons. Perhaps we add a tooltip to explain in more detail?

However, this does fix the immediate issue outlined in #192, preventing values > maxValue by using the isAllowed callback as [specified here](https://github.com/s-yadav/react-number-format/issues/747). I also disabled the input and removed the max button as that introduced further confusion, however that brings me to my opening point regarding UX.

Let me know your thoughts, happy to modify further.