### PR TITLE
Fix cicd build issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ "main", "test-cicd" ]
+    branches: [ "main" ]
   pull_request:
     types: [ opened, synchronize ]
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "test-cicd" ]
   pull_request:
     types: [ opened, synchronize ]
 

--- a/apps/omni-xnft/App.tsx
+++ b/apps/omni-xnft/App.tsx
@@ -1,0 +1,1 @@
+src/App.tsx


### PR DESCRIPTION
ModuleNotFoundError: Module not found: Error: Can't resolve '../../App' in '/home/runner/work/mrgn-ts/mrgn-ts/apps/omni-xnft/node_modules/expo'
    
[expo / omni-xnft breaks cicd](https://github.com/mrgnlabs/mrgn-ts/actions/runs/5876769463/job/15935592445) and generally triggers my ocd

this PR fixes cicd build issue by creating a symbolic link at root of omni-xnft project `App.tsx` linking to `src/App.tsx`. expo requires App be imported from root of the project directory.

testing performed can be found here: https://github.com/AzothZephyr/mrgn-ts/actions/runs/5898533185