### PR TITLE
Leaderboard Pagination

### DIFF
--- a/apps/marginfi-v2-ui/package.json
+++ b/apps/marginfi-v2-ui/package.json
@@ -41,6 +41,7 @@
     "firebase": "^9.22.1",
     "firebase-admin": "^11.9.0",
     "jsbi": "^4.3.0",
+    "lodash": "^4.17.21",
     "next": "13.4.19",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/packages/marginfi-v2-ui-state/src/lib/points.ts
+++ b/packages/marginfi-v2-ui-state/src/lib/points.ts
@@ -11,6 +11,7 @@ import {
   getDoc,
   getCountFromServer,
   where,
+  QueryDocumentSnapshot,
 } from "firebase/firestore";
 import { FavouriteDomain, NAME_OFFERS_ID, reverseLookupBatch } from "@bonfida/spl-name-service";
 import { Connection, PublicKey } from "@solana/web3.js";
@@ -18,6 +19,7 @@ import { firebaseApi } from ".";
 
 type LeaderboardRow = {
   id: string;
+  doc: QueryDocumentSnapshot<DocumentData>;
   total_activity_deposit_points: number;
   total_activity_borrow_points: number;
   total_referral_deposit_points: number;
@@ -33,7 +35,7 @@ async function fetchLeaderboardData({
   pageSize = 50,
 }: {
   connection?: Connection;
-  queryCursor?: string;
+  queryCursor?: QueryDocumentSnapshot<DocumentData>;
   pageSize?: number;
 }): Promise<LeaderboardRow[]> {
   const pointsCollection = collection(firebaseApi.db, "points");
@@ -49,7 +51,7 @@ async function fetchLeaderboardData({
   const leaderboardSlice = querySnapshot.docs
     .filter((item) => item.id !== null && item.id !== undefined && item.id != "None")
     .map((doc) => {
-      const data = { id: doc.id, ...doc.data() } as LeaderboardRow;
+      const data = { id: doc.id, doc, ...doc.data() } as LeaderboardRow;
       return data;
     });
 


### PR DESCRIPTION
This PR adds scroll based pagination to the leaderboard table.  

A few notes:
- The leaderboard table would benefit from improved loading states, both initial load and subsequent scroll triggered loads. Adding skeleton cells would require major refactoring of the component and would be best as a separate pr
- Currently I cannot authenticate locally and so this PR does not support jumping to user's position in the table, again can be handled in a separate pr
- The fetchLeaderboardData function did not seem to be used anywhere else, however I want to confirm that as the signature has changed and if so can be reverted for a more backwards compatible version. 