### PR TITLE
fix: use bank decimals to scale emissions calc

### DIFF
--- a/packages/marginfi-client-v2/src/models/balance.ts
+++ b/packages/marginfi-client-v2/src/models/balance.ts
@@ -142,7 +142,7 @@ class Balance {
       const lastUpdate = this.lastUpdate;
       const period = new BigNumber(currentTimestamp - lastUpdate);
       const emissionsRate = new BigNumber(bank.emissionsRate);
-      const emissions = period.times(balanceAmount).times(emissionsRate).div(31_536_000_000_000);
+      const emissions = period.times(balanceAmount).times(emissionsRate).div(31_536_000 * Math.pow(10, bank.mintDecimals));
       const emissionsReal = BigNumber.min(emissions, new BigNumber(bank.emissionsRemaining));
 
       return emissionsReal;


### PR DESCRIPTION
SDK was calculating emissions for non 6 decimal banks incorrectly