### PR TITLE
feat(mfi-v2-ui): leaderboard pagination

### DIFF
--- a/apps/marginfi-v2-ui/src/pages/points.tsx
+++ b/apps/marginfi-v2-ui/src/pages/points.tsx
@@ -58,14 +58,16 @@ const Points: FC = () => {
     state.userPointsData,
   ]);
 
-  const [leaderboardData, setLeaderboardData] = useState<LeaderboardRow[]>([]);
+  const [leaderboardData, setLeaderboardData] = useState<LeaderboardRow[] | {}[]>([...new Array(50).fill({})]);
   const fetchLeaderboardPage = useCallback(async () => {
     const queryCursor = leaderboardData.length > 0 ? leaderboardData[leaderboardData.length - 1].doc : undefined;
+    setLeaderboardData((current) => [...current, ...new Array(50).fill({})]);
     fetchLeaderboardData({
       connection,
       queryCursor,
     }).then((data) => {
-      setLeaderboardData((current) => [...current, ...data]);
+      const filtered = [...leaderboardData].filter((row) => row.hasOwnProperty("id"));
+      setLeaderboardData((current) => [...filtered, ...data]);
     });
   }, [connection, leaderboardData, setLeaderboardData]);
 
@@ -90,7 +92,7 @@ const Points: FC = () => {
   }, [connection, walletAddress]);
 
   useEffect(() => {
-    if (!leaderboardData.length) {
+    if (!leaderboardData[0].hasOwnProperty("id")) {
       fetchLeaderboardData({
         connection,
       }).then((data) => {
@@ -361,90 +363,108 @@ const Points: FC = () => {
               </TableRow>
             </TableHead>
             <TableBody>
-              {leaderboardData.map((row: LeaderboardRow, index: number) => (
-                <TableRow key={row.id} className={`${row.id === currentUserId ? "glow" : ""}`}>
-                  <TableCell
-                    align="center"
-                    className={`${index <= 2 ? "text-2xl" : "text-base"} border-none font-aeonik ${
-                      row.id === currentUserId ? "text-[#DCE85D]" : "text-white"
-                    }`}
-                  >
-                    {index === 0 ? "🥇" : index === 1 ? "🥈" : index === 2 ? "🥉" : index + 1}
-                  </TableCell>
-                  <TableCell
-                    className={`text-base border-none font-aeonik ${
-                      row.id === currentUserId ? "text-[#DCE85D]" : "text-white"
-                    }`}
-                    style={{ fontWeight: 400 }}
-                  >
-                    <a
-                      href={`https://solscan.io/account/${row.id}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      style={{ textDecoration: "none", color: "inherit" }}
-                      className="hover:text-[#DCE85D]"
+              {leaderboardData.map((row: LeaderboardRow | {}, index: number) => {
+                if (!row.hasOwnProperty("id")) {
+                  return (
+                    <TableRow key={index}>
+                      {[...new Array(7)].map((_, index) => (
+                        <TableCell className="border-none">
+                          <Skeleton variant="text" animation="pulse" sx={{ fontSize: "1rem", bgcolor: "grey.900" }} />
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                  );
+                }
+
+                const data = row as LeaderboardRow;
+
+                return (
+                  <TableRow key={data.id} className={`${data.id === currentUserId ? "glow" : ""}`}>
+                    <TableCell
+                      align="center"
+                      className={`${index <= 2 ? "text-2xl" : "text-base"} border-none font-aeonik ${
+                        data.id === currentUserId ? "text-[#DCE85D]" : "text-white"
+                      }`}
                     >
-                      {row.id.endsWith(".sol") ? row.id : `${row.id.slice(0, 5)}...${row.id.slice(-5)}`}
-                      <style jsx>{`
-                        a:hover {
-                          text-decoration: underline;
-                        }
-                      `}</style>
-                    </a>
-                  </TableCell>
-                  <TableCell
-                    align="right"
-                    className={`text-base border-none font-aeonik ${
-                      row.id === currentUserId ? "text-[#DCE85D]" : "text-white"
-                    }`}
-                    style={{ fontWeight: 400 }}
-                  >
-                    {groupedNumberFormatterDyn.format(Math.round(row.total_activity_deposit_points))}
-                  </TableCell>
-                  <TableCell
-                    align="right"
-                    className={`text-base border-none font-aeonik ${
-                      row.id === currentUserId ? "text-[#DCE85D]" : "text-white"
-                    }`}
-                    style={{ fontWeight: 400 }}
-                  >
-                    {groupedNumberFormatterDyn.format(Math.round(row.total_activity_borrow_points))}
-                  </TableCell>
-                  <TableCell
-                    align="right"
-                    className={`text-base border-none font-aeonik ${
-                      row.id === currentUserId ? "text-[#DCE85D]" : "text-white"
-                    }`}
-                    style={{ fontWeight: 400 }}
-                  >
-                    {groupedNumberFormatterDyn.format(
-                      Math.round(row.total_referral_deposit_points + row.total_referral_borrow_points)
-                    )}
-                  </TableCell>
-                  <TableCell
-                    align="right"
-                    className={`text-base border-none font-aeonik ${
-                      row.id === currentUserId ? "text-[#DCE85D]" : "text-white"
-                    }`}
-                    style={{ fontWeight: 400 }}
-                  >
-                    {groupedNumberFormatterDyn.format(Math.round(row.socialPoints ? row.socialPoints : 0))}
-                  </TableCell>
-                  <TableCell
-                    align="right"
-                    className={`text-base border-none font-aeonik ${
-                      row.id === currentUserId ? "text-[#DCE85D]" : "text-white"
-                    }`}
-                    style={{ fontWeight: 400 }}
-                  >
-                    {groupedNumberFormatterDyn.format(
-                      Math.round(
-                        row.total_deposit_points + row.total_borrow_points + (row.socialPoints ? row.socialPoints : 0)
-                      )
-                    )}
-                  </TableCell>
-                </TableRow>
-              ))}
+                      {index === 0 ? "🥇" : index === 1 ? "🥈" : index === 2 ? "🥉" : index + 1}
+                    </TableCell>
+                    <TableCell
+                      className={`text-base border-none font-aeonik ${
+                        data.id === currentUserId ? "text-[#DCE85D]" : "text-white"
+                      }`}
+                      style={{ fontWeight: 400 }}
+                    >
+                      <a
+                        href={`https://solscan.io/account/${row.id}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        style={{ textDecoration: "none", color: "inherit" }}
+                        className="hover:text-[#DCE85D]"
+                      >
+                        {data.id.endsWith(".sol") ? data.id : `${data.id.slice(0, 5)}...${data.id.slice(-5)}`}
+                        <style jsx>{`
+                          a:hover {
+                            text-decoration: underline;
+                          }
+                        `}</style>
+                      </a>
+                    </TableCell>
+                    <TableCell
+                      align="right"
+                      className={`text-base border-none font-aeonik ${
+                        data.id === currentUserId ? "text-[#DCE85D]" : "text-white"
+                      }`}
+                      style={{ fontWeight: 400 }}
+                    >
+                      {groupedNumberFormatterDyn.format(Math.round(data.total_activity_deposit_points))}
+                    </TableCell>
+                    <TableCell
+                      align="right"
+                      className={`text-base border-none font-aeonik ${
+                        data.id === currentUserId ? "text-[#DCE85D]" : "text-white"
+                      }`}
+                      style={{ fontWeight: 400 }}
+                    >
+                      {groupedNumberFormatterDyn.format(Math.round(data.total_activity_borrow_points))}
+                    </TableCell>
+                    <TableCell
+                      align="right"
+                      className={`text-base border-none font-aeonik ${
+                        data.id === currentUserId ? "text-[#DCE85D]" : "text-white"
+                      }`}
+                      style={{ fontWeight: 400 }}
+                    >
+                      {groupedNumberFormatterDyn.format(
+                        Math.round(data.total_referral_deposit_points + data.total_referral_borrow_points)
+                      )}
+                    </TableCell>
+                    <TableCell
+                      align="right"
+                      className={`text-base border-none font-aeonik ${
+                        data.id === currentUserId ? "text-[#DCE85D]" : "text-white"
+                      }`}
+                      style={{ fontWeight: 400 }}
+                    >
+                      {groupedNumberFormatterDyn.format(Math.round(data.socialPoints ? data.socialPoints : 0))}
+                    </TableCell>
+                    <TableCell
+                      align="right"
+                      className={`text-base border-none font-aeonik ${
+                        data.id === currentUserId ? "text-[#DCE85D]" : "text-white"
+                      }`}
+                      style={{ fontWeight: 400 }}
+                    >
+                      {groupedNumberFormatterDyn.format(
+                        Math.round(
+                          data.total_deposit_points +
+                            data.total_borrow_points +
+                            (data.socialPoints ? data.socialPoints : 0)
+                        )
+                      )}
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
             </TableBody>
           </Table>
         </TableContainer>

--- a/apps/marginfi-v2-ui/src/pages/points.tsx
+++ b/apps/marginfi-v2-ui/src/pages/points.tsx
@@ -59,7 +59,6 @@ const Points: FC = () => {
   ]);
 
   const [leaderboardData, setLeaderboardData] = useState<LeaderboardRow[]>([]);
-  const [fetchingLeaderboardPage, setFetchingLeaderboardPage] = useState(false);
   const fetchLeaderboardPage = useCallback(async () => {
     const queryCursor = leaderboardData.length > 0 ? leaderboardData[leaderboardData.length - 1].doc : undefined;
     fetchLeaderboardData({
@@ -100,8 +99,6 @@ const Points: FC = () => {
     }
 
     const handleScroll = throttle(() => {
-      if (fetchingLeaderboardPage) return;
-      setFetchingLeaderboardPage(false);
       if (document.body.scrollTop > document.body.scrollHeight * 0.5) {
         fetchLeaderboardPage();
       }
@@ -111,7 +108,7 @@ const Points: FC = () => {
     return () => {
       document.body.removeEventListener("scroll", handleScroll);
     };
-  }, [connection, fetchLeaderboardPage, fetchingLeaderboardPage]);
+  }, [connection, fetchLeaderboardPage]);
 
   return (
     <>

--- a/packages/marginfi-v2-ui-state/src/lib/points.ts
+++ b/packages/marginfi-v2-ui-state/src/lib/points.ts
@@ -11,6 +11,7 @@ import {
   getDoc,
   getCountFromServer,
   where,
+  QueryDocumentSnapshot,
 } from "firebase/firestore";
 import { FavouriteDomain, NAME_OFFERS_ID, reverseLookupBatch } from "@bonfida/spl-name-service";
 import { Connection, PublicKey } from "@solana/web3.js";
@@ -18,6 +19,7 @@ import { firebaseApi } from ".";
 
 type LeaderboardRow = {
   id: string;
+  doc: QueryDocumentSnapshot<DocumentData>;
   total_activity_deposit_points: number;
   total_activity_borrow_points: number;
   total_referral_deposit_points: number;
@@ -33,7 +35,7 @@ async function fetchLeaderboardData({
   pageSize = 50,
 }: {
   connection?: Connection;
-  queryCursor?: string;
+  queryCursor?: QueryDocumentSnapshot<DocumentData>;
   pageSize?: number;
 }): Promise<LeaderboardRow[]> {
   const pointsCollection = collection(firebaseApi.db, "points");
@@ -49,7 +51,7 @@ async function fetchLeaderboardData({
   const leaderboardSlice = querySnapshot.docs
     .filter((item) => item.id !== null && item.id !== undefined && item.id != "None")
     .map((doc) => {
-      const data = { id: doc.id, ...doc.data() } as LeaderboardRow;
+      const data = { id: doc.id, doc, ...doc.data() } as LeaderboardRow;
       return data;
     });
 


### PR DESCRIPTION
This PR adds scroll based pagination to the leaderboard table.

I am currently unable to authenticate locally and therefore this PR has not been tested against database to validate and confirm leaderboard positions.

Potential future improvements
- Jump to user's rank in leaderboard table
- Fetch domain names async for faster page load, wallet addresses can be overwritten incrementally  
- Load all button (will take time but user initiated action so can be managed) 