### PR TITLE
chore(mfi-v2-ui): revert to favorite domain only, fallback to short address

### DIFF
--- a/apps/marginfi-v2-ui/src/components/desktop/Points/PointsLeaderBoard.tsx
+++ b/apps/marginfi-v2-ui/src/components/desktop/Points/PointsLeaderBoard.tsx
@@ -1,11 +1,10 @@
-import React, { FC, useEffect, useState, useCallback, useRef, useMemo } from "react";
+import React, { FC, useEffect, useState, useCallback, useRef } from "react";
 import clsx from "clsx";
 import { Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Skeleton } from "@mui/material";
-import ArrowDropUpIcon from "@mui/icons-material/ArrowDropUp";
-import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import { groupedNumberFormatterDyn } from "@mrgnlabs/mrgn-common";
 import { LeaderboardRow, fetchLeaderboardData, fetchTotalUserCount } from "@mrgnlabs/marginfi-v2-ui-state";
 import { useConnection } from "@solana/wallet-adapter-react";
+import { shortAddress } from "~/utils";
 
 const SortIcon = ({ orderDir }: { orderDir: "asc" | "desc" }) => {
   return (
@@ -44,11 +43,15 @@ export const PointsLeaderBoard: FC<PointsLeaderBoardProps> = ({ currentUserId })
     isFetchingLeaderboardPage: false,
     initialLoad: true,
   });
+
+  // prefill leaderboard data with empty rows for skeleton loading
   const [leaderboardData, setLeaderboardData] = useState<LeaderboardRow[] | {}[]>([
     ...new Array(leaderboardSettings.perPage).fill({}),
   ]);
+  // sentinel element to trigger fetch of new page on scroll
   const leaderboardSentinelRef = useRef<HTMLDivElement>(null);
 
+  // set order column and direction
   const setOrderCol = useCallback(
     (col: string) => {
       setLeaderboardData([...new Array(leaderboardSettings.perPage).fill({})]);
@@ -87,7 +90,6 @@ export const PointsLeaderBoard: FC<PointsLeaderBoardProps> = ({ currentUserId })
     // fetch new page of data with cursor
     const queryCursor = leaderboardData.length > 0 ? lastRow.doc : undefined;
     setLeaderboardData((current) => [...current, ...new Array(50).fill({})]);
-    console.log("Calling for subsequent page");
     fetchLeaderboardData({
       connection,
       queryCursor,
@@ -124,7 +126,6 @@ export const PointsLeaderBoard: FC<PointsLeaderBoardProps> = ({ currentUserId })
       initialLoad: false,
       isFetchingLeaderboardPage: true,
     });
-    console.log("Calling for initial page", leaderboardSettings);
     fetchLeaderboardData({
       connection,
       orderDir: leaderboardSettings.orderDir,
@@ -175,8 +176,6 @@ export const PointsLeaderBoard: FC<PointsLeaderBoardProps> = ({ currentUserId })
     getTotalUserCount();
     initObserver();
   }, []);
-
-  useEffect(() => {}, []);
 
   return (
     <>
@@ -327,7 +326,7 @@ export const PointsLeaderBoard: FC<PointsLeaderBoardProps> = ({ currentUserId })
                         !data.domain && "opacity-80"
                       )}
                     >
-                      {data.domain || data.shortAddress || data.id}
+                      {data.domain || shortAddress(data.id)}
                     </a>
                   </TableCell>
                   <TableCell

--- a/apps/marginfi-v2-ui/src/pages/points.tsx
+++ b/apps/marginfi-v2-ui/src/pages/points.tsx
@@ -21,8 +21,7 @@ import {
 } from "~/components/desktop/Points";
 
 const Points: FC = () => {
-  const { connected, walletAddress } = useWalletContext();
-  const { connection } = useConnection();
+  const { connected } = useWalletContext();
   const { query: routerQuery } = useRouter();
   const [currentFirebaseUser, hasUser, userPointsData] = useUserProfileStore((state) => [
     state.currentFirebaseUser,
@@ -30,26 +29,8 @@ const Points: FC = () => {
     state.userPointsData,
   ]);
 
-  const [domain, setDomain] = useState<string>();
-
-  const currentUserId = useMemo(() => domain ?? currentFirebaseUser?.uid, [currentFirebaseUser, domain]);
   const referralCode = useMemo(() => routerQuery.referralCode as string | undefined, [routerQuery.referralCode]);
   const [isReferralCopied, setIsReferralCopied] = useState(false);
-
-  const resolveDomain = async (connection: Connection, user: PublicKey) => {
-    try {
-      const { reverse } = await getFavoriteDomain(connection, user);
-      setDomain(`${reverse}.sol`);
-    } catch (error) {
-      return;
-    }
-  };
-
-  useEffect(() => {
-    if (connection && walletAddress) {
-      resolveDomain(connection, new PublicKey(walletAddress));
-    }
-  }, [connection, walletAddress]);
 
   return (
     <>
@@ -123,7 +104,7 @@ const Points: FC = () => {
             </Link>
           </div>
         </div>
-        <PointsLeaderBoard currentUserId={currentUserId} />
+        <PointsLeaderBoard currentUserId={currentFirebaseUser?.uid} />
       </div>
     </>
   );

--- a/apps/marginfi-v2-ui/src/utils/mrgnUtils.ts
+++ b/apps/marginfi-v2-ui/src/utils/mrgnUtils.ts
@@ -45,3 +45,7 @@ export function usePrevious<T>(value: T): T | undefined {
   }, [value]);
   return ref.current;
 }
+
+export function shortAddress(address: string) {
+  return `${address.slice(0, 4)}...${address.slice(-4)}`;
+}


### PR DESCRIPTION
- chore: remove deps causing leaderboard fetch to run additional times
- chore: remove unnecessary favorite domain call for connected user
- chore: refactor leaderboard fetch to batch sns domain lookups
- chore: revert all sns domain fetch, default to favorite > short address
