### PR TITLE
fix(mfi-v2-ui): explicitly define types in wallet def

### DIFF
--- a/apps/marginfi-v2-ui/src/hooks/useWalletContext.tsx
+++ b/apps/marginfi-v2-ui/src/hooks/useWalletContext.tsx
@@ -1,6 +1,6 @@
 import { Wallet } from "@mrgnlabs/mrgn-common";
 import { useAnchorWallet, useWallet } from "@solana/wallet-adapter-react";
-import { PublicKey } from "@solana/web3.js";
+import { PublicKey, Transaction, VersionedTransaction } from "@solana/web3.js";
 import { useRouter } from "next/router";
 import { useCallback, useMemo } from "react";
 import { useWeb3AuthWallet } from "./useWeb3AuthWallet";
@@ -27,8 +27,14 @@ const useWalletContext = () => {
       return {
         wallet: {
           ...anchorWallet,
-          publicKey: new PublicKey(override),
+          publicKey: new PublicKey(override) as PublicKey,
           signMessage: walletContextState.signMessage,
+          signTransaction: walletContextState.signTransaction as <T extends Transaction | VersionedTransaction>(
+            transactions: T
+          ) => Promise<T>,
+          signAllTransactions: walletContextState.signTransaction as <T extends Transaction | VersionedTransaction>(
+            transactions: T[]
+          ) => Promise<T[]>,
         },
         isOverride: true,
       };
@@ -36,7 +42,14 @@ const useWalletContext = () => {
     return {
       wallet: {
         ...anchorWallet,
+        publicKey: anchorWallet?.publicKey as PublicKey,
         signMessage: walletContextState.signMessage,
+        signTransaction: walletContextState.signTransaction as <T extends Transaction | VersionedTransaction>(
+          transactions: T
+        ) => Promise<T>,
+        signAllTransactions: walletContextState.signTransaction as <T extends Transaction | VersionedTransaction>(
+          transactions: T[]
+        ) => Promise<T[]>,
       },
       isOverride: false,
     };

--- a/packages/mrgn-common/src/types.ts
+++ b/packages/mrgn-common/src/types.ts
@@ -11,8 +11,8 @@ export type ProgramReadonly<T extends Idl> = AnchorProgram<T>;
 
 export type Amount = BigNumber | number | string;
 
-export type Wallet = Partial<Pick<SignerWalletAdapter, "signAllTransactions" | "signTransaction">> & {
-  publicKey?: PublicKey;
+export type Wallet = Pick<SignerWalletAdapter, "signAllTransactions" | "signTransaction"> & {
+  publicKey: PublicKey;
   signMessage?: (message: Uint8Array) => Promise<Uint8Array>;
 };
 


### PR DESCRIPTION
- fix: signMessage in default adapters, add partial to type def
- chore: more robust type def for wallet variations
