### PR TITLE
chore(mfi-v2-ui): switch old dialogs to new shadcn components

### DIFF
--- a/apps/marginfi-v2-ui/src/components/common/AssetList/LSTDialog.tsx
+++ b/apps/marginfi-v2-ui/src/components/common/AssetList/LSTDialog.tsx
@@ -1,8 +1,9 @@
-import { useMemo } from "react";
+import React from "react";
 import Image from "next/image";
 import Link from "next/link";
-import { Button, Dialog, DialogContent } from "@mui/material";
 import { useMrgnlendStore } from "~/store";
+import { Dialog, DialogContent } from "~/components/ui/dialog";
+import { Button } from "~/components/ui/button";
 
 export enum LSTDialogVariants {
   SOL = "SOL",
@@ -18,7 +19,7 @@ type LSTDialogProps = {
 const LSTDialog = ({ variant, open, onClose }: LSTDialogProps) => {
   const [sortedBanks] = useMrgnlendStore((state) => [state.extendedBankInfos]);
 
-  const tokenImage = useMemo(() => {
+  const tokenImage = React.useMemo(() => {
     const bank = sortedBanks.find((bank) => bank.meta.tokenSymbol === variant);
     if (!bank) return null;
 
@@ -26,75 +27,60 @@ const LSTDialog = ({ variant, open, onClose }: LSTDialogProps) => {
   }, [variant, sortedBanks]);
 
   return (
-    <Dialog
-      open={open}
-      onClose={onClose}
-      maxWidth="xl"
-      PaperProps={{
-        style: {
-          backgroundColor: "transparent",
-          boxShadow: "none",
-        },
-      }}
-    >
-      <DialogContent className="bg-[#171C1F] w-full rounded-lg text-white items-center justify-center text-center py-16">
-        <div className="w-full lg:min-w-[900px]">
-          <div className="max-w-[540px] mx-auto flex flex-col gap-6">
-            {tokenImage && (
-              <div className="flex items-center justify-center">
-                <Image
-                  src={tokenImage}
-                  alt={tokenImage}
-                  height={80}
-                  width={80}
-                  className="rounded-full translate-x-4 drop-shadow-lg"
-                />
-                <Image
-                  src="https://storage.googleapis.com/static-marginfi/lst.png"
-                  alt="lst"
-                  height={80}
-                  width={80}
-                  className="rounded-full -translate-x-4 drop-shadow-lg"
-                />
-              </div>
-            )}
-            {variant === LSTDialogVariants.stSOL && (
-              <>
-                <h2 className="text-2xl font-bold">Swap stSOL for LST?</h2>
-                <div className="space-y-4">
-                  <p>Lido is sunsetting stSOL. Swap your stSOL for LST now and earn higher yield</p>
-                  <div className="text-[#DCE85D] space-y-2 font-bold">
-                    <p>LST is the only 8% yielding LST.</p>
-                    <p>LST is the only 0% commission LST.</p>
-                    <p>LST is the only 0 fee LST.</p>
-                  </div>
-                </div>
-              </>
-            )}
-            {variant === LSTDialogVariants.SOL && (
-              <>
-                <h2 className="text-2xl font-bold">Stake for LST?</h2>
-                <div className="space-y-4">
-                  <p>The highest natural yield available from any LST on Solana. By a lot.</p>
-                  <div className="text-[#DCE85D] space-y-2 font-bold">
-                    <p>LST is the only 8% yielding LST.</p>
-                    <p>LST is the only 0% commission LST.</p>
-                    <p>LST is the only 0 fee LST.</p>
-                  </div>
-                </div>
-              </>
-            )}
-            <div className="flex flex-col space-y-4 mt-3">
-              <Link href={variant === LSTDialogVariants.stSOL ? "/stake?deposit=stSOL" : "/stake"}>
-                <Button className="bg-white text-[#020815] normal-case mx-auto px-4 hover:bg-white/80">Mint LST</Button>
-              </Link>
-              <button
-                className=" border-white/50 text-white/50 transition hover:border-white hover:text-white mx-auto text-sm"
-                onClick={() => onClose()}
-              >
-                No thanks, continue
-              </button>
+    <Dialog open={open} onOpenChange={() => onClose()}>
+      <DialogContent className="md:max-w-4xl">
+        <div className="flex flex-col items-center text-center gap-6">
+          {tokenImage && (
+            <div className="flex items-center justify-center">
+              <Image
+                src="https://storage.googleapis.com/static-marginfi/lst.png"
+                alt="lst"
+                height={80}
+                width={80}
+                className="rounded-full translate-x-4 drop-shadow-lg"
+              />
+              <Image
+                src={tokenImage}
+                alt={tokenImage}
+                height={80}
+                width={80}
+                className="rounded-full -translate-x-4 drop-shadow-lg"
+              />
             </div>
+          )}
+          {variant === LSTDialogVariants.stSOL && (
+            <>
+              <h2 className="text-2xl font-bold">Swap stSOL for LST?</h2>
+              <div className="space-y-4">
+                <p>Lido is sunsetting stSOL. Swap your stSOL for LST now and earn higher yield</p>
+                <div className="text-[#DCE85D] space-y-2 font-bold">
+                  <p>LST is the only 8% yielding LST.</p>
+                  <p>LST is the only 0% commission LST.</p>
+                  <p>LST is the only 0 fee LST.</p>
+                </div>
+              </div>
+            </>
+          )}
+          {variant === LSTDialogVariants.SOL && (
+            <>
+              <h2 className="text-2xl font-bold">Stake for LST?</h2>
+              <div className="space-y-4">
+                <p>The highest natural yield available from any LST on Solana. By a lot.</p>
+                <div className="text-[#DCE85D] space-y-2 font-bold">
+                  <p>LST is the only 8% yielding LST.</p>
+                  <p>LST is the only 0% commission LST.</p>
+                  <p>LST is the only 0 fee LST.</p>
+                </div>
+              </div>
+            </>
+          )}
+          <div className="flex flex-col space-y-4 mt-3">
+            <Link href={variant === LSTDialogVariants.stSOL ? "/stake?deposit=stSOL" : "/stake"}>
+              <Button className="bg-white text-[#020815] normal-case mx-auto px-4 hover:bg-white/80">Mint LST</Button>
+            </Link>
+            <Button variant="link" onClick={() => onClose()} className="text-muted-foreground">
+              No thanks, continue
+            </Button>
           </div>
         </div>
       </DialogContent>

--- a/apps/marginfi-v2-ui/src/components/common/Tutorial/Tutorial.tsx
+++ b/apps/marginfi-v2-ui/src/components/common/Tutorial/Tutorial.tsx
@@ -1,14 +1,19 @@
 import React from "react";
 import Link from "next/link";
-import CloseIcon from "@mui/icons-material/Close";
-import ArrowRight from "@mui/icons-material/ArrowRight";
-import { Button, Dialog, DialogContent } from "@mui/material";
-import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import { Swiper, SwiperSlide } from "swiper/react";
 import { Pagination } from "swiper/modules";
 import { useSwiper } from "swiper/react";
 import { PWABanner } from "~/components/mobile/PWABanner";
-import { IconMrgn, IconReceiveMoney, IconAlertTriangle } from "~/components/ui/icons";
+import { Dialog, DialogContent } from "~/components/ui/dialog";
+import { Button } from "~/components/ui/button";
+import {
+  IconMrgn,
+  IconReceiveMoney,
+  IconAlertTriangle,
+  IconChevronRight,
+  IconExternalLink,
+  IconCheck,
+} from "~/components/ui/icons";
 
 type TutorialSlideProps = {
   icon?: React.ReactNode;
@@ -22,8 +27,8 @@ const TutorialSlide = ({ children, icon, heading, next, closeDialog }: TutorialS
   const swiper = useSwiper();
 
   return (
-    <div className="py-16 md:pb-20 md:pt-14 px-4 space-y-8 h-full md:h-auto">
-      <header className="space-y-6 flex flex-col items-center">
+    <div className="pb-16 px-4 space-y-4 md:space-y-8 h-full md:h-auto text-center">
+      <header className="space-y-2 md:space-y-6 flex flex-col items-center">
         {icon && icon}
         {heading && <h2 className="text-3xl font-medium">{heading}</h2>}
       </header>
@@ -31,34 +36,29 @@ const TutorialSlide = ({ children, icon, heading, next, closeDialog }: TutorialS
       {next && (
         <div className="flex items-center justify-center">
           <Button
-            variant="contained"
-            className="bg-white text-black gap-2 flex items-center w-full md:w-auto"
+            className="w-full md:w-auto"
             onClick={() => {
               swiper.slideNext();
             }}
           >
-            {next} <ArrowRight />
+            {next} <IconChevronRight size={16} />
           </Button>
         </div>
       )}
       {!next && (
         <div className="flex flex-col md:flex-row items-center justify-center gap-4">
+          <Link href="https://docs.marginfi.com/" target="_blank" rel="noreferrer">
+            <Button variant="outline" className="w-full md:w-auto">
+              Read docs <IconExternalLink size={16} />
+            </Button>
+          </Link>
           <Button
-            variant="contained"
-            className="bg-transparent text-white border border-solid border-white gap-2 flex items-center w-full md:w-auto"
-          >
-            <Link href="https://docs.marginfi.com/" target="_blank" rel="noreferrer">
-              Read docs <OpenInNewIcon className="text-sm" />
-            </Link>
-          </Button>
-          <Button
-            variant="contained"
-            className="bg-white text-black gap-2 flex items-center w-full md:w-auto"
+            className="w-full md:w-auto"
             onClick={() => {
               if (closeDialog) closeDialog();
             }}
           >
-            Get started
+            Get started <IconCheck size={16} />
           </Button>
         </div>
       )}
@@ -84,30 +84,13 @@ export const Tutorial = () => {
 
   return (
     <>
-      <Dialog
-        open={open}
-        maxWidth="xl"
-        slotProps={{
-          backdrop: {
-            style: {
-              backdropFilter: "blur(4px)",
-            },
-          },
-        }}
-        PaperProps={{
-          style: {
-            backgroundColor: "transparent",
-            boxShadow: "none",
-            margin: 0,
-          },
-        }}
-      >
-        <DialogContent className="bg-[#0F1111] w-full rounded-lg text-white items-center justify-center text-center p-0">
-          <div className="w-full max-w-4xl">
+      <Dialog open={open} onOpenChange={(open) => setOpen(open)}>
+        <DialogContent className="p-4 md:max-w-4xl md:py-8">
+          <div className="max-w-3xl">
             <Swiper modules={[Pagination]} slidesPerView={1} navigation pagination={{ clickable: true }}>
               <SwiperSlide className="h-full">
                 <TutorialSlide icon={<IconMrgn size={48} />} heading="Welcome to marginfi" next="Fees & yield">
-                  <div className="space-y-8 pb-2 max-w-xl mx-auto flex flex-col justify-center">
+                  <div className="space-y-6 md:space-y-8 pb-2 max-w-xl mx-auto flex flex-col justify-center">
                     <p>
                       marginfi is a decentralized lending protocol on Solana that prioritizes risk management to provide
                       a safe and reliable solution for users looking to access leverage and maximize capital efficiency.
@@ -121,7 +104,7 @@ export const Tutorial = () => {
               </SwiperSlide>
               <SwiperSlide className="h-full">
                 <TutorialSlide icon={<IconReceiveMoney size={48} />} heading="Fees & yield" next="Account health">
-                  <div className="space-y-8 pb-2 max-w-[35rem] mx-auto flex flex-col justify-center">
+                  <div className="space-y-6 md:space-y-8 pb-2 max-w-[35rem] mx-auto flex flex-col justify-center">
                     <p>
                       marginfi allows users to lend tokens and earn interest. Interest is paid by borrowers to lenders.
                       All borrowing is over-collateralized.
@@ -144,13 +127,13 @@ export const Tutorial = () => {
                   heading="Account health"
                   closeDialog={handleDialogClose}
                 >
-                  <div className="space-y-8 pb-2 max-w-[44rem] mx-auto flex flex-col justify-center">
-                    <p>
+                  <div className="space-y-6 md:space-y-8 pb-2 max-w-[44rem] mx-auto flex-col justify-center">
+                    <p className="hidden tall:flex">
                       Account health is only for borrowing activity on marginfi. If you&apos;re not borrowing on
                       marginfi, you will always have 100% account health. Your account health is a single value that
                       encapsulates how well-collateralized your account is based on your borrowed liabilities.
                     </p>
-                    <p className="font-bold mx-auto flex items-center gap-3 border border-solid border-white/50 px-4 py-2 rounded-lg">
+                    <p className="text-sm sm:text-base flex font-bold mx-auto items-center gap-3 border border-solid border-white/50 px-4 py-2 rounded-lg">
                       <IconAlertTriangle height={20} className="hidden md:block" />
                       When your account health reaches 0% or below, you are exposed to liquidation.
                     </p>
@@ -163,7 +146,6 @@ export const Tutorial = () => {
                 </TutorialSlide>
               </SwiperSlide>
             </Swiper>
-            <CloseIcon className="absolute top-4 right-4 cursor-pointer z-20 opacity-75" onClick={handleDialogClose} />
           </div>
         </DialogContent>
       </Dialog>

--- a/apps/marginfi-v2-ui/src/components/common/Tutorial/Tutorial.tsx
+++ b/apps/marginfi-v2-ui/src/components/common/Tutorial/Tutorial.tsx
@@ -77,9 +77,9 @@ export const Tutorial = () => {
   };
 
   React.useEffect(() => {
-    if (!localStorage.getItem("tutorialAcknowledged")) {
-      setOpen(true);
-    }
+    // if (!localStorage.getItem("tutorialAcknowledged")) {
+    setOpen(true);
+    // }
   }, []);
 
   return (
@@ -167,7 +167,7 @@ export const Tutorial = () => {
           </div>
         </DialogContent>
       </Dialog>
-      {/* <PWABanner open={pwaBannerOpen} onOpenChange={(open) => setPwaBannerOpen(open)} /> */}
+      <PWABanner open={pwaBannerOpen} onOpenChange={(open) => setPwaBannerOpen(open)} />
     </>
   );
 };

--- a/apps/marginfi-v2-ui/src/components/common/Tutorial/Tutorial.tsx
+++ b/apps/marginfi-v2-ui/src/components/common/Tutorial/Tutorial.tsx
@@ -3,7 +3,6 @@ import Link from "next/link";
 import { Swiper, SwiperSlide } from "swiper/react";
 import { Pagination } from "swiper/modules";
 import { useSwiper } from "swiper/react";
-import { PWABanner } from "~/components/mobile/PWABanner";
 import { Dialog, DialogContent } from "~/components/ui/dialog";
 import { Button } from "~/components/ui/button";
 import {
@@ -68,18 +67,16 @@ const TutorialSlide = ({ children, icon, heading, next, closeDialog }: TutorialS
 
 export const Tutorial = () => {
   const [open, setOpen] = React.useState(false);
-  const [pwaBannerOpen, setPwaBannerOpen] = React.useState(false);
 
   const handleDialogClose = () => {
     localStorage.setItem("tutorialAcknowledged", "true");
     setOpen(false);
-    setPwaBannerOpen(true);
   };
 
   React.useEffect(() => {
-    // if (!localStorage.getItem("tutorialAcknowledged")) {
-    setOpen(true);
-    // }
+    if (!localStorage.getItem("tutorialAcknowledged")) {
+      setOpen(true);
+    }
   }, []);
 
   return (
@@ -149,7 +146,6 @@ export const Tutorial = () => {
           </div>
         </DialogContent>
       </Dialog>
-      <PWABanner open={pwaBannerOpen} onOpenChange={(open) => setPwaBannerOpen(open)} />
     </>
   );
 };

--- a/apps/marginfi-v2-ui/src/components/common/Tutorial/Tutorial.tsx
+++ b/apps/marginfi-v2-ui/src/components/common/Tutorial/Tutorial.tsx
@@ -47,7 +47,7 @@ const TutorialSlide = ({ children, icon, heading, next, closeDialog }: TutorialS
       )}
       {!next && (
         <div className="flex flex-col md:flex-row items-center justify-center gap-4">
-          <Link href="https://docs.marginfi.com/" target="_blank" rel="noreferrer">
+          <Link href="https://docs.marginfi.com/" target="_blank" rel="noreferrer" className="block w-full md:w-auto">
             <Button variant="outline" className="w-full md:w-auto">
               Read docs <IconExternalLink size={16} />
             </Button>

--- a/apps/marginfi-v2-ui/src/components/ui/icons.tsx
+++ b/apps/marginfi-v2-ui/src/components/ui/icons.tsx
@@ -2,6 +2,7 @@ import {
   IconCaretUpDownFilled,
   IconCheck,
   IconChevronDown,
+  IconChevronRight,
   IconBrandX,
   IconBrandApple,
   IconBrandGoogleFilled,
@@ -13,6 +14,7 @@ import {
   IconAlertTriangle,
   IconShare2,
   IconArrowDown,
+  IconExternalLink,
 } from "@tabler/icons-react";
 import { cn } from "~/utils/themeUtils";
 
@@ -281,6 +283,7 @@ export {
   IconCaretUpDownFilled,
   IconCheck,
   IconChevronDown,
+  IconChevronRight,
   IconBrandX,
   IconBrandApple,
   IconBrandGoogleFilled,
@@ -291,6 +294,7 @@ export {
   IconAlertTriangle,
   IconShare2,
   IconArrowDown,
+  IconExternalLink,
 
   // customed icons
   IconBraveWallet,

--- a/apps/marginfi-v2-ui/tailwind.config.js
+++ b/apps/marginfi-v2-ui/tailwind.config.js
@@ -73,6 +73,9 @@ module.exports = {
           foreground: "hsl(var(--card-foreground))",
         },
       },
+      screens: {
+        tall: { raw: "(min-height: 800px)" },
+      },
       maxWidth: {
         "8xl": "90rem",
       },


### PR DESCRIPTION
- chore: uncomment pwa banner, remove tutorial local storage check
- chore: switch LSTDialog to new dialog component
- chore: switch Tutorial to new dialog component
- fix: full width docs button on mobile tutorial
- chore: turn tutorial local storage check back on / remove pwa banner
