### PR TITLE
fix: allow user to top-up a dust lending position

### DIFF
--- a/apps/marginfi-v2-ui/src/components/desktop/AssetsList/AssetRow/AssetRow.tsx
+++ b/apps/marginfi-v2-ui/src/components/desktop/AssetsList/AssetRow/AssetRow.tsx
@@ -6,14 +6,12 @@ import { useMrgnlendStore, useUserProfileStore } from "~/store";
 import Badge from "@mui/material/Badge";
 import {
   WSOL_MINT,
-  groupedNumberFormatterDyn,
   numeralFormatter,
   percentFormatter,
-  uiToNative,
   usdFormatter,
 } from "@mrgnlabs/mrgn-common";
 import { ExtendedBankInfo, ActionType, getCurrentAction, ExtendedBankMetadata } from "@mrgnlabs/marginfi-v2-ui-state";
-import { MarginfiAccountWrapper, PriceBias, MarginfiClient } from "@mrgnlabs/marginfi-client-v2";
+import { MarginfiAccountWrapper, PriceBias } from "@mrgnlabs/marginfi-client-v2";
 import { MrgnTooltip } from "~/components/common/MrgnTooltip";
 import { AssetRowInputBox, AssetRowAction, LSTDialogVariants } from "~/components/common/AssetList";
 import { useAssetItemData } from "~/hooks/useAssetItemData";
@@ -92,18 +90,40 @@ const AssetRow: FC<{
     }
   }, [bank, currentAction]);
 
-  const isDust = useMemo(
-    () => bank.isActive && uiToNative(bank.position.amount, bank.info.state.mintDecimals).isZero(),
-    [bank]
-  );
+  const isDisabled = useMemo(() => maxAmount === 0, [maxAmount]);
 
-  const isDisabled = useMemo(
-    () =>
-      (isDust &&
-        uiToNative(bank.userInfo.tokenAccount.balance, bank.info.state.mintDecimals).isZero() &&
-        currentAction == ActionType.Borrow) ||
-      (!isDust && maxAmount === 0),
-    [currentAction, bank, isDust, maxAmount]
+  const actionBorrowOrLend = useCallback(
+    async ({
+      mfiClient,
+      currentAction,
+      bank,
+      borrowOrLendAmount,
+      nativeSolBalance,
+      marginfiAccount,
+      walletContextState,
+    }: BorrowOrLendParams) => {
+      await borrowOrLend({
+        mfiClient,
+        currentAction,
+        bank,
+        borrowOrLendAmount,
+        nativeSolBalance,
+        marginfiAccount,
+        walletContextState,
+      });
+
+      setBorrowOrLendAmount(0);
+
+      // -------- Refresh state
+      try {
+        setIsRefreshingStore(true);
+        await fetchMrgnlendState();
+      } catch (error: any) {
+        console.log("Error while reloading state");
+        console.log(error);
+      }
+    },
+    [fetchMrgnlendState, setIsRefreshingStore]
   );
 
   // Reset b/l amounts on toggle
@@ -172,50 +192,17 @@ const AssetRow: FC<{
       return;
     }
   }, [
-    bank,
-    borrowOrLendAmount,
     currentAction,
-    marginfiAccount,
-    mfiClient,
-    nativeSolBalance,
-    fetchMrgnlendState,
-    setIsRefreshingStore,
+    bank,
+    hasLSTDialogShown,
     showLSTDialog,
+    actionBorrowOrLend,
+    mfiClient,
+    borrowOrLendAmount,
+    nativeSolBalance,
+    marginfiAccount,
+    walletContextState,
   ]);
-
-  const actionBorrowOrLend = useCallback(
-    async ({
-      mfiClient,
-      currentAction,
-      bank,
-      borrowOrLendAmount,
-      nativeSolBalance,
-      marginfiAccount,
-      walletContextState,
-    }: BorrowOrLendParams) => {
-      await borrowOrLend({
-        mfiClient,
-        currentAction,
-        bank,
-        borrowOrLendAmount,
-        nativeSolBalance,
-        marginfiAccount,
-        walletContextState,
-      });
-
-      setBorrowOrLendAmount(0);
-
-      // -------- Refresh state
-      try {
-        setIsRefreshingStore(true);
-        await fetchMrgnlendState();
-      } catch (error: any) {
-        console.log("Error while reloading state");
-        console.log(error);
-      }
-    },
-    []
-  );
 
   return (
     <TableRow className="h-[54px] w-full bg-[#171C1F] border border-[#1E2122]">
@@ -459,7 +446,7 @@ const AssetRow: FC<{
             maxValue={maxAmount}
             maxDecimals={bank.info.state.mintDecimals}
             inputRefs={inputRefs}
-            disabled={isDust || maxAmount === 0}
+            disabled={maxAmount === 0}
             onEnter={handleBorrowOrLend}
           />
         </Badge>
@@ -477,10 +464,10 @@ const AssetRow: FC<{
                   ? "rgb(227, 227, 227)"
                   : "rgba(0,0,0,0)"
               }
-              onClick={isDust ? handleCloseBalance : handleBorrowOrLend}
+              onClick={handleBorrowOrLend}
               disabled={isDisabled}
             >
-              {isDust ? "Close" : currentAction}
+              {currentAction}
             </AssetRowAction>
           </div>
         </Tooltip>


### PR DESCRIPTION
Currently, the logic displaying either "Close" or "Lend"/"Borrow" buttons is applied to both the _positions_ and _assets list_ sections.

It should only be shown in the positions section, since "Close" == "Close position". A side effect is that it currently prevents topping up a lending position that is already dust, on the app.

Change-wise, this PR simply removes all `isDust`-related logic, and also fixes a couple hook ordering & incomplete dependency array.