### PR TITLE
Update README.md

### DIFF
--- a/apps/marginfi-v2-ui/README.md
+++ b/apps/marginfi-v2-ui/README.md
@@ -35,7 +35,7 @@ To get started with the marginfi v2 UI, follow these steps:
 
 ## Contributing
 
-We welcome contributions to the marginfi v2 UI. If you're interested in helping, check out our [contributing guidelines](https://github.com/mrgnlabs/mrgn-ts/blob/main/CONTRIBUTING.md) and join the [mrgn community](https://t.me/mrgncommunity) on Telegram.
+We welcome contributions to the marginfi v2 UI. If you're interested in helping, check out our [contributing guidelines](https://github.com/mrgnlabs/mrgn-ts/blob/main/CONTRIBUTING.md) and join the [mrgn community](https://forum.marginfi.community).
 
 ## License
 


### PR DESCRIPTION
Updated the Contributing section by replacing the Telegram link with the marginfi web forum link, as that is a better-moderated and more reliable platform for contributors at the moment.
The Telegram group linked in the document has a lot of malicious spam links, and that's a security risk.