### PR TITLE
Switch out "Mint" for "Stake" page

### DIFF
--- a/apps/marginfi-v2-ui/src/components/common/Mint/MintCardWrapper.tsx
+++ b/apps/marginfi-v2-ui/src/components/common/Mint/MintCardWrapper.tsx
@@ -87,7 +87,7 @@ export const MintCardWrapper: React.FC<MintCardWrapperProps> = ({ mintCard, ...p
                   setRequestedAction(ActionType.MintLST);
                 }}
               >
-                Mint {mintCard.title}
+                Stake {mintCard.title}
               </Button>
               <Button
                 variant="outline"

--- a/apps/marginfi-v2-ui/src/components/common/Navbar/Navbar.tsx
+++ b/apps/marginfi-v2-ui/src/components/common/Navbar/Navbar.tsx
@@ -87,12 +87,12 @@ export const Navbar: FC = () => {
               </Link>
 
               <Link
-                href={"/mint"}
+                href={"/stake"}
                 className={
-                  router.pathname === "/mint" ? "text-primary hover-underline-static" : "hover-underline-animation"
+                  router.pathname === "/stake" ? "text-primary hover-underline-static" : "hover-underline-animation"
                 }
               >
-                mint
+                stake
               </Link>
 
               <Link


### PR DESCRIPTION
Since we're shelving YBX, it's seems appropriate to hide the mint page and switch it out for the stake page: https://mrgn.slack.com/archives/C05R79P0HDK/p1719105302993449