### PR TITLE
Resolved UI Issue (discolored bar sitting on the top of the UI)

### DIFF
--- a/apps/marginfi-v2-ui/src/components/common/Navbar/Navbar.tsx
+++ b/apps/marginfi-v2-ui/src/components/common/Navbar/Navbar.tsx
@@ -65,9 +65,9 @@ export const Navbar: FC = () => {
   }, [lipClient, mfiClient, walletAddress]);
 
   return (
-    <header className="h-[64px] mb-4 md:mb-8 lg:mb-14">
+    <header className="mb-10 md:mb-8 lg:mb-24">
       <nav className={cn("fixed w-full top-0 h-[64px] z-50 bg-background", isOraclesStale && "top-16 md:top-10")}>
-        <div className="w-full top-0 flex justify-between items-center h-16 text-sm font-[500] text-[#868E95] z-10 border-b-[0.5px] border-[#1C2125] px-4">
+        <div className="w-full top-1 flex justify-between items-center h-16 text-sm font-[500] text-[#868E95] z-10 border-b-[0.5px] border-[#1C2125] px-4">
           <div className="h-full w-1/2 z-10 flex items-center gap-8">
             <Link
               href="/"

--- a/apps/marginfi-v2-ui/src/components/common/Wallet/components/AuthenticationV2/AuthDialog.tsx
+++ b/apps/marginfi-v2-ui/src/components/common/Wallet/components/AuthenticationV2/AuthDialog.tsx
@@ -141,7 +141,7 @@ export const AuthDialog = () => {
 
   return (
     <div>
-      <Progress value={progress} className="fixed top-0 z-[999] h-1 rounded-none" />
+      <Progress value={progress} className={`fixed top-0 h-1 rounded-none ${isWalletAuthDialogOpen && "z-[999]"}`} />
 
       <Dialog
         open={isWalletAuthDialogOpen}

--- a/apps/marginfi-v2-ui/src/components/mobile/MobileNavbar/MobileNavbar.tsx
+++ b/apps/marginfi-v2-ui/src/components/mobile/MobileNavbar/MobileNavbar.tsx
@@ -68,7 +68,7 @@ const MobileNavbar = () => {
 
   return (
     <footer>
-      <nav className="fixed w-full bottom-0 z-50 bg-[#0F1111]">
+      <nav className="fixed w-full bottom-0 z-50 bg-[#0F1111] border-2 border-blue-500">
         <div className="h-full w-full text-xs font-normal text-[#868E95] z-50 flex justify-around relative lg:gap-8">
           {mobileLinks.map((linkInfo, index) => {
             const isActive = activeLink === `link${index}`;

--- a/apps/marginfi-v2-ui/src/pages/_app.tsx
+++ b/apps/marginfi-v2-ui/src/pages/_app.tsx
@@ -119,18 +119,23 @@ export default function MrgnApp({ Component, pageProps, path }: AppProps & MrgnA
                       </WalletModalProvider>
                     </Desktop>
 
-                    <Mobile>
+                    {/* <Mobile>
                       <MobileNavbar />
                       <div
-                        className={cn("w-full flex flex-col justify-center items-center", isOraclesStale && "pt-16")}
+                        className={cn("w-full flex flex-col justify-center items-center border-2 border-red-500", isOraclesStale && "pt-16")}
                       >
                         <Component {...pageProps} />
                       </div>
-                    </Mobile>
-                    <Analytics />
-                    <Tutorial />
+                    </Mobile> */}
+
+                    {/* <Analytics /> */}
+
+                    {/* <Tutorial /> */}
+
                     <AuthDialog />
+
                     <ToastContainer position="bottom-left" theme="dark" />
+
                   </LipClientProvider>
                 </MrgnlendProvider>
               </MrgnWalletProvider>

--- a/apps/marginfi-v2-ui/src/pages/index.tsx
+++ b/apps/marginfi-v2-ui/src/pages/index.tsx
@@ -96,6 +96,7 @@ export default function HomePage() {
           </>
         )}
       </Mobile>
+      
       {isStoreInitialized && previousTxn && <ActionComplete />}
     </>
   );


### PR DESCRIPTION
## Issue
There was a discolored bar sitting at the very top of the app UI (mobile and desktop)
![image](https://github.com/mrgnlabs/mrgn-ts/assets/155211932/cf400ced-d69a-431c-b265-f1be26d5a338)

## Cause
The `<AuthDialog />` component was using a z-index that placed it on top of the UI, regardless if the user was wallet onboarding or not.
<img width="879" alt="Screenshot 2024-06-23 at 12 41 34 PM" src="https://github.com/mrgnlabs/mrgn-ts/assets/155211932/60b9e50c-72fb-440b-bb91-51e41ad38197">

## Fix
i conditionally rendered the z-index css so that it only renders when the user activates the wallet onboarding

