### PR TITLE
feat(mfi-v2-trading): removed oracle staleness check

### DIFF
--- a/apps/marginfi-v2-trading/src/components/common/TradingBox/tradingBox.utils.tsx
+++ b/apps/marginfi-v2-trading/src/components/common/TradingBox/tradingBox.utils.tsx
@@ -482,12 +482,13 @@ function canBeLooped(activeGroup: GroupData, loopingObject: LoopingObject, trade
     }
   }
 
-  if (
-    (activeGroup.pool.token && isBankOracleStale(activeGroup.pool.token)) ||
-    (activeGroup.pool.quoteTokens[0] && isBankOracleStale(activeGroup.pool.quoteTokens[0]))
-  ) {
-    checks.push(STATIC_SIMULATION_ERRORS.STALE_TRADING);
-  }
+  // Banks will always be stale for now
+  // if (
+  //   (activeGroup.pool.token && isBankOracleStale(activeGroup.pool.token)) ||
+  //   (activeGroup.pool.quoteTokens[0] && isBankOracleStale(activeGroup.pool.quoteTokens[0]))
+  // ) {
+  //   checks.push(STATIC_SIMULATION_ERRORS.STALE_TRADING);
+  // }
 
   return checks;
 }


### PR DESCRIPTION
the arena oracles will always be stale so no point of having this check anymore