### PR TITLE
Adds origination fee and program fee related updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,49 +64,6 @@ We welcome contributions to `mrgn-ts`! Please review our [contributing guideline
 
 ## Updating the IDL
 
-For historical reasons, the IDL file in this repository should be updated using
-the marginfi-v2 CLI tool to ensure the IDL stays in its canonical format.
-This is largely due to changes in the byte packing code used by Anchor,
-and the fact that Rust removed the `#repr(packed)` option in later releases.
-The process is to build the IDL file in the marginfi-v2 repository, patch it,
-then copy it into this repository and format it (via prettier).
+The IDL can be copied directly from the target/deploy folder. Make sure you have built without any feature flags (i.e. `anchor build`). The default configuration is correct for mainnet.
 
-To update the IDL:
-
-1. Checkout the [marginfi-v2-cli](https://github.com/mrgnlabs/marginfi-v2/tree/main)
-   repository and build it. Ensure you are on an x86-64 machine to get the build
-   to succeed. Ensure the [solana](https://docs.solanalabs.com/cli/install) CLI tool is installed,
-   alongside anchor and rust and yarn.
-
-2. Run marginfi-v2/scripts/build-workspace to generate the original IDL (anchor build)
-
-3. Use the [marginfi-v2-cli](https://github.com/mrgnlabs/marginfi-v2/tree/main/clients/rust/marginfi-cli)
-   and run the `patch-idl` command against the generated marginfi.json IDL in the marginfi-v2 repository.
-
-Ensure you are on main branch in marginfi-v2.
-
-For example, run this command from the root of the marginfi-v2 repository,
-
-```
-cargo run \
-            --package marginfi-v2-cli \
-            --features dev \
-            -- patch-idl target
-```
-
-where `target` is the target directory for rust binaries. There should be an idl
-folder with the idl inside of `target`.
-
-This produces a modified marginfi.json file alongside the original file.
-The \_original file can be removed but is useful for checking diffs.
-
-4. Copy the marginfi.json file and the marginfi-types.ts into this repository.
-5. Lint the new IDL file using the prettier linter (.prettierrc) -- in VSCode you
-   can simply use Format Document and it applies the lint automatically.
-
-Review the IDL changes to make sure the new features/types in marginfiv2
-are reflected in the new IDL. For example new instructions or types, should be
-reflected in the new IDL.
-
-Commit the IDL changes and merge in the same mrgn-ts PR that adds features that rely on
-the new IDL. These should be committed together to ensure the new feature works.
+KNOWN BUG: In some instances, anchor will not generate "errors" in idl.json and this needs to be manually copied over and edited.

--- a/packages/marginfi-client-v2/package.json
+++ b/packages/marginfi-client-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mrgnlabs/marginfi-client-v2",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "MIT",

--- a/packages/marginfi-client-v2/src/idl/marginfi-types.ts
+++ b/packages/marginfi-client-v2/src/idl/marginfi-types.ts
@@ -5,741 +5,626 @@
  * IDL can be found at `target/idl/marginfi.json`.
  */
 export type Marginfi = {
-  "address": "",
-  "metadata": {
-    "name": "marginfi",
-    "version": "0.1.0",
-    "spec": "0.1.0",
-    "description": "Created with Anchor"
-  },
-  "instructions": [
+  address: "";
+  metadata: {
+    name: "marginfi";
+    version: "0.1.0";
+    spec: "0.1.0";
+    description: "Created with Anchor";
+  };
+  instructions: [
     {
-      "name": "lendingAccountBorrow",
-      "discriminator": [
-        4,
-        126,
-        116,
-        53,
-        48,
-        5,
-        212,
-        31
-      ],
-      "accounts": [
+      name: "configGroupFee";
+      docs: [
+        "(global fee admin only) Enable or disable program fees for any group. Does not require the",
+        "group admin to sign: the global fee state admin can turn program fees on or off for any",
+        "group"
+      ];
+      discriminator: [231, 205, 66, 242, 220, 87, 145, 38];
+      accounts: [
         {
-          "name": "marginfiGroup"
+          name: "marginfiGroup";
+          writable: true;
         },
         {
-          "name": "marginfiAccount",
-          "writable": true
+          name: "globalFeeAdmin";
+          docs: ["`global_fee_admin` of the FeeState"];
+          signer: true;
+          relations: ["feeState"];
         },
         {
-          "name": "signer",
-          "signer": true
-        },
-        {
-          "name": "bank",
-          "writable": true
-        },
-        {
-          "name": "destinationTokenAccount",
-          "writable": true
-        },
-        {
-          "name": "bankLiquidityVaultAuthority",
-          "writable": true,
-          "pda": {
-            "seeds": [
+          name: "feeState";
+          pda: {
+            seeds: [
               {
-                "kind": "const",
-                "value": [
-                  108,
-                  105,
-                  113,
-                  117,
-                  105,
-                  100,
-                  105,
-                  116,
-                  121,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104
-                ]
-              },
-              {
-                "kind": "account",
-                "path": "bank"
+                kind: "const";
+                value: [102, 101, 101, 115, 116, 97, 116, 101];
               }
-            ]
-          }
-        },
-        {
-          "name": "bankLiquidityVault",
-          "writable": true,
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  108,
-                  105,
-                  113,
-                  117,
-                  105,
-                  100,
-                  105,
-                  116,
-                  121,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116
-                ]
-              },
-              {
-                "kind": "account",
-                "path": "bank"
-              }
-            ]
-          }
-        },
-        {
-          "name": "tokenProgram"
+            ];
+          };
         }
-      ],
-      "args": [
+      ];
+      args: [
         {
-          "name": "amount",
-          "type": "u64"
+          name: "flag";
+          type: "u64";
         }
-      ]
+      ];
     },
     {
-      "name": "lendingAccountCloseBalance",
-      "discriminator": [
-        245,
-        54,
-        41,
-        4,
-        243,
-        202,
-        31,
-        17
-      ],
-      "accounts": [
+      name: "editGlobalFeeState";
+      docs: ["(global fee admin only) Adjust fees or the destination wallet"];
+      discriminator: [52, 62, 35, 129, 93, 69, 165, 202];
+      accounts: [
         {
-          "name": "marginfiGroup"
+          name: "globalFeeAdmin";
+          docs: ["Admin of the global FeeState"];
+          writable: true;
+          signer: true;
+          relations: ["feeState"];
         },
         {
-          "name": "marginfiAccount",
-          "writable": true
-        },
-        {
-          "name": "signer",
-          "signer": true
-        },
-        {
-          "name": "bank",
-          "writable": true
+          name: "feeState";
+          writable: true;
+          pda: {
+            seeds: [
+              {
+                kind: "const";
+                value: [102, 101, 101, 115, 116, 97, 116, 101];
+              }
+            ];
+          };
         }
-      ],
-      "args": []
+      ];
+      args: [
+        {
+          name: "feeWallet";
+          type: "pubkey";
+        },
+        {
+          name: "bankInitFlatSolFee";
+          type: "u32";
+        },
+        {
+          name: "programFeeFixed";
+          type: {
+            defined: {
+              name: "wrappedI80f48";
+            };
+          };
+        },
+        {
+          name: "programFeeRate";
+          type: {
+            defined: {
+              name: "wrappedI80f48";
+            };
+          };
+        }
+      ];
     },
     {
-      "name": "lendingAccountDeposit",
-      "discriminator": [
-        171,
-        94,
-        235,
-        103,
-        82,
-        64,
-        212,
-        140
-      ],
-      "accounts": [
+      name: "initGlobalFeeState";
+      docs: [
+        "(Runs once per program) Configures the fee state account, where the global admin sets fees",
+        "that are assessed to the protocol"
+      ];
+      discriminator: [82, 48, 247, 59, 220, 109, 231, 44];
+      accounts: [
         {
-          "name": "marginfiGroup"
+          name: "payer";
+          docs: ["Pays the init fee"];
+          writable: true;
+          signer: true;
         },
         {
-          "name": "marginfiAccount",
-          "writable": true
-        },
-        {
-          "name": "signer",
-          "signer": true
-        },
-        {
-          "name": "bank",
-          "writable": true
-        },
-        {
-          "name": "signerTokenAccount",
-          "writable": true
-        },
-        {
-          "name": "bankLiquidityVault",
-          "writable": true,
-          "pda": {
-            "seeds": [
+          name: "feeState";
+          writable: true;
+          pda: {
+            seeds: [
               {
-                "kind": "const",
-                "value": [
-                  108,
-                  105,
-                  113,
-                  117,
-                  105,
-                  100,
-                  105,
-                  116,
-                  121,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116
-                ]
-              },
-              {
-                "kind": "account",
-                "path": "bank"
+                kind: "const";
+                value: [102, 101, 101, 115, 116, 97, 116, 101];
               }
-            ]
-          }
+            ];
+          };
         },
         {
-          "name": "tokenProgram"
-        }
-      ],
-      "args": [
+          name: "rent";
+          address: "SysvarRent111111111111111111111111111111111";
+        },
         {
-          "name": "amount",
-          "type": "u64"
+          name: "systemProgram";
+          address: "11111111111111111111111111111111";
         }
-      ]
+      ];
+      args: [
+        {
+          name: "admin";
+          type: "pubkey";
+        },
+        {
+          name: "feeWallet";
+          type: "pubkey";
+        },
+        {
+          name: "bankInitFlatSolFee";
+          type: "u32";
+        },
+        {
+          name: "programFeeFixed";
+          type: {
+            defined: {
+              name: "wrappedI80f48";
+            };
+          };
+        },
+        {
+          name: "programFeeRate";
+          type: {
+            defined: {
+              name: "wrappedI80f48";
+            };
+          };
+        }
+      ];
     },
     {
-      "name": "lendingAccountEndFlashloan",
-      "discriminator": [
-        105,
-        124,
-        201,
-        106,
-        153,
-        2,
-        8,
-        156
-      ],
-      "accounts": [
+      name: "lendingAccountBorrow";
+      discriminator: [4, 126, 116, 53, 48, 5, 212, 31];
+      accounts: [
         {
-          "name": "marginfiAccount",
-          "writable": true
+          name: "marginfiGroup";
         },
         {
-          "name": "signer",
-          "signer": true
+          name: "marginfiAccount";
+          writable: true;
+        },
+        {
+          name: "signer";
+          signer: true;
+        },
+        {
+          name: "bank";
+          writable: true;
+        },
+        {
+          name: "destinationTokenAccount";
+          writable: true;
+        },
+        {
+          name: "bankLiquidityVaultAuthority";
+          writable: true;
+          pda: {
+            seeds: [
+              {
+                kind: "const";
+                value: [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104];
+              },
+              {
+                kind: "account";
+                path: "bank";
+              }
+            ];
+          };
+        },
+        {
+          name: "bankLiquidityVault";
+          writable: true;
+          pda: {
+            seeds: [
+              {
+                kind: "const";
+                value: [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116];
+              },
+              {
+                kind: "account";
+                path: "bank";
+              }
+            ];
+          };
+        },
+        {
+          name: "tokenProgram";
         }
-      ],
-      "args": []
+      ];
+      args: [
+        {
+          name: "amount";
+          type: "u64";
+        }
+      ];
     },
     {
-      "name": "lendingAccountLiquidate",
-      "docs": [
-        "Liquidate a lending account balance of an unhealthy marginfi account"
-      ],
-      "discriminator": [
-        214,
-        169,
-        151,
-        213,
-        251,
-        167,
-        86,
-        219
-      ],
-      "accounts": [
+      name: "lendingAccountCloseBalance";
+      discriminator: [245, 54, 41, 4, 243, 202, 31, 17];
+      accounts: [
         {
-          "name": "marginfiGroup"
+          name: "marginfiGroup";
         },
         {
-          "name": "assetBank",
-          "writable": true
+          name: "marginfiAccount";
+          writable: true;
         },
         {
-          "name": "liabBank",
-          "writable": true
+          name: "signer";
+          signer: true;
         },
         {
-          "name": "liquidatorMarginfiAccount",
-          "writable": true
-        },
-        {
-          "name": "signer",
-          "signer": true
-        },
-        {
-          "name": "liquidateeMarginfiAccount",
-          "writable": true
-        },
-        {
-          "name": "bankLiquidityVaultAuthority",
-          "writable": true,
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  108,
-                  105,
-                  113,
-                  117,
-                  105,
-                  100,
-                  105,
-                  116,
-                  121,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104
-                ]
-              },
-              {
-                "kind": "account",
-                "path": "liabBank"
-              }
-            ]
-          }
-        },
-        {
-          "name": "bankLiquidityVault",
-          "writable": true,
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  108,
-                  105,
-                  113,
-                  117,
-                  105,
-                  100,
-                  105,
-                  116,
-                  121,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116
-                ]
-              },
-              {
-                "kind": "account",
-                "path": "liabBank"
-              }
-            ]
-          }
-        },
-        {
-          "name": "bankInsuranceVault",
-          "writable": true,
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  105,
-                  110,
-                  115,
-                  117,
-                  114,
-                  97,
-                  110,
-                  99,
-                  101,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116
-                ]
-              },
-              {
-                "kind": "account",
-                "path": "liabBank"
-              }
-            ]
-          }
-        },
-        {
-          "name": "tokenProgram"
+          name: "bank";
+          writable: true;
         }
-      ],
-      "args": [
-        {
-          "name": "assetAmount",
-          "type": "u64"
-        }
-      ]
+      ];
+      args: [];
     },
     {
-      "name": "lendingAccountRepay",
-      "discriminator": [
-        79,
-        209,
-        172,
-        177,
-        222,
-        51,
-        173,
-        151
-      ],
-      "accounts": [
+      name: "lendingAccountDeposit";
+      discriminator: [171, 94, 235, 103, 82, 64, 212, 140];
+      accounts: [
         {
-          "name": "marginfiGroup"
+          name: "marginfiGroup";
         },
         {
-          "name": "marginfiAccount",
-          "writable": true
+          name: "marginfiAccount";
+          writable: true;
         },
         {
-          "name": "signer",
-          "signer": true
+          name: "signer";
+          signer: true;
         },
         {
-          "name": "bank",
-          "writable": true
+          name: "bank";
+          writable: true;
         },
         {
-          "name": "signerTokenAccount",
-          "writable": true
+          name: "signerTokenAccount";
+          writable: true;
         },
         {
-          "name": "bankLiquidityVault",
-          "writable": true,
-          "pda": {
-            "seeds": [
+          name: "bankLiquidityVault";
+          writable: true;
+          pda: {
+            seeds: [
               {
-                "kind": "const",
-                "value": [
-                  108,
-                  105,
-                  113,
-                  117,
-                  105,
-                  100,
-                  105,
-                  116,
-                  121,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116
-                ]
+                kind: "const";
+                value: [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116];
               },
               {
-                "kind": "account",
-                "path": "bank"
+                kind: "account";
+                path: "bank";
               }
-            ]
-          }
+            ];
+          };
         },
         {
-          "name": "tokenProgram"
+          name: "tokenProgram";
         }
-      ],
-      "args": [
+      ];
+      args: [
         {
-          "name": "amount",
-          "type": "u64"
-        },
-        {
-          "name": "repayAll",
-          "type": {
-            "option": "bool"
-          }
+          name: "amount";
+          type: "u64";
         }
-      ]
+      ];
     },
     {
-      "name": "lendingAccountSettleEmissions",
-      "discriminator": [
-        161,
-        58,
-        136,
-        174,
-        242,
-        223,
-        156,
-        176
-      ],
-      "accounts": [
+      name: "lendingAccountEndFlashloan";
+      discriminator: [105, 124, 201, 106, 153, 2, 8, 156];
+      accounts: [
         {
-          "name": "marginfiAccount",
-          "writable": true
+          name: "marginfiAccount";
+          writable: true;
         },
         {
-          "name": "bank",
-          "writable": true
+          name: "signer";
+          signer: true;
         }
-      ],
-      "args": []
+      ];
+      args: [];
     },
     {
-      "name": "lendingAccountStartFlashloan",
-      "discriminator": [
-        14,
-        131,
-        33,
-        220,
-        81,
-        186,
-        180,
-        107
-      ],
-      "accounts": [
+      name: "lendingAccountLiquidate";
+      docs: ["Liquidate a lending account balance of an unhealthy marginfi account"];
+      discriminator: [214, 169, 151, 213, 251, 167, 86, 219];
+      accounts: [
         {
-          "name": "marginfiAccount",
-          "writable": true
+          name: "marginfiGroup";
         },
         {
-          "name": "signer",
-          "signer": true
+          name: "assetBank";
+          writable: true;
         },
         {
-          "name": "ixsSysvar",
-          "address": "Sysvar1nstructions1111111111111111111111111"
-        }
-      ],
-      "args": [
+          name: "liabBank";
+          writable: true;
+        },
         {
-          "name": "endIndex",
-          "type": "u64"
+          name: "liquidatorMarginfiAccount";
+          writable: true;
+        },
+        {
+          name: "signer";
+          signer: true;
+        },
+        {
+          name: "liquidateeMarginfiAccount";
+          writable: true;
+        },
+        {
+          name: "bankLiquidityVaultAuthority";
+          writable: true;
+          pda: {
+            seeds: [
+              {
+                kind: "const";
+                value: [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104];
+              },
+              {
+                kind: "account";
+                path: "liabBank";
+              }
+            ];
+          };
+        },
+        {
+          name: "bankLiquidityVault";
+          writable: true;
+          pda: {
+            seeds: [
+              {
+                kind: "const";
+                value: [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116];
+              },
+              {
+                kind: "account";
+                path: "liabBank";
+              }
+            ];
+          };
+        },
+        {
+          name: "bankInsuranceVault";
+          writable: true;
+          pda: {
+            seeds: [
+              {
+                kind: "const";
+                value: [105, 110, 115, 117, 114, 97, 110, 99, 101, 95, 118, 97, 117, 108, 116];
+              },
+              {
+                kind: "account";
+                path: "liabBank";
+              }
+            ];
+          };
+        },
+        {
+          name: "tokenProgram";
         }
-      ]
+      ];
+      args: [
+        {
+          name: "assetAmount";
+          type: "u64";
+        }
+      ];
     },
     {
-      "name": "lendingAccountWithdraw",
-      "discriminator": [
-        36,
-        72,
-        74,
-        19,
-        210,
-        210,
-        192,
-        192
-      ],
-      "accounts": [
+      name: "lendingAccountRepay";
+      discriminator: [79, 209, 172, 177, 222, 51, 173, 151];
+      accounts: [
         {
-          "name": "marginfiGroup"
+          name: "marginfiGroup";
         },
         {
-          "name": "marginfiAccount",
-          "writable": true
+          name: "marginfiAccount";
+          writable: true;
         },
         {
-          "name": "signer",
-          "signer": true
+          name: "signer";
+          signer: true;
         },
         {
-          "name": "bank",
-          "writable": true
+          name: "bank";
+          writable: true;
         },
         {
-          "name": "destinationTokenAccount",
-          "writable": true
+          name: "signerTokenAccount";
+          writable: true;
         },
         {
-          "name": "bankLiquidityVaultAuthority",
-          "writable": true,
-          "pda": {
-            "seeds": [
+          name: "bankLiquidityVault";
+          writable: true;
+          pda: {
+            seeds: [
               {
-                "kind": "const",
-                "value": [
-                  108,
-                  105,
-                  113,
-                  117,
-                  105,
-                  100,
-                  105,
-                  116,
-                  121,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104
-                ]
+                kind: "const";
+                value: [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116];
               },
               {
-                "kind": "account",
-                "path": "bank"
+                kind: "account";
+                path: "bank";
               }
-            ]
-          }
+            ];
+          };
         },
         {
-          "name": "bankLiquidityVault",
-          "writable": true,
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  108,
-                  105,
-                  113,
-                  117,
-                  105,
-                  100,
-                  105,
-                  116,
-                  121,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116
-                ]
-              },
-              {
-                "kind": "account",
-                "path": "bank"
-              }
-            ]
-          }
-        },
-        {
-          "name": "tokenProgram"
+          name: "tokenProgram";
         }
-      ],
-      "args": [
+      ];
+      args: [
         {
-          "name": "amount",
-          "type": "u64"
+          name: "amount";
+          type: "u64";
         },
         {
-          "name": "withdrawAll",
-          "type": {
-            "option": "bool"
-          }
+          name: "repayAll";
+          type: {
+            option: "bool";
+          };
         }
-      ]
+      ];
     },
     {
-      "name": "lendingAccountWithdrawEmissions",
-      "discriminator": [
-        234,
-        22,
-        84,
-        214,
-        118,
-        176,
-        140,
-        170
-      ],
-      "accounts": [
+      name: "lendingAccountSettleEmissions";
+      discriminator: [161, 58, 136, 174, 242, 223, 156, 176];
+      accounts: [
         {
-          "name": "marginfiGroup"
+          name: "marginfiAccount";
+          writable: true;
         },
         {
-          "name": "marginfiAccount",
-          "writable": true
+          name: "bank";
+          writable: true;
+        }
+      ];
+      args: [];
+    },
+    {
+      name: "lendingAccountStartFlashloan";
+      discriminator: [14, 131, 33, 220, 81, 186, 180, 107];
+      accounts: [
+        {
+          name: "marginfiAccount";
+          writable: true;
         },
         {
-          "name": "signer",
-          "signer": true
+          name: "signer";
+          signer: true;
         },
         {
-          "name": "bank",
-          "writable": true
+          name: "ixsSysvar";
+          address: "Sysvar1nstructions1111111111111111111111111";
+        }
+      ];
+      args: [
+        {
+          name: "endIndex";
+          type: "u64";
+        }
+      ];
+    },
+    {
+      name: "lendingAccountWithdraw";
+      discriminator: [36, 72, 74, 19, 210, 210, 192, 192];
+      accounts: [
+        {
+          name: "marginfiGroup";
         },
         {
-          "name": "emissionsMint"
+          name: "marginfiAccount";
+          writable: true;
         },
         {
-          "name": "emissionsAuth",
-          "pda": {
-            "seeds": [
+          name: "signer";
+          signer: true;
+        },
+        {
+          name: "bank";
+          writable: true;
+        },
+        {
+          name: "destinationTokenAccount";
+          writable: true;
+        },
+        {
+          name: "bankLiquidityVaultAuthority";
+          writable: true;
+          pda: {
+            seeds: [
               {
-                "kind": "const",
-                "value": [
-                  101,
-                  109,
-                  105,
-                  115,
-                  115,
-                  105,
-                  111,
-                  110,
-                  115,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  95,
-                  115,
-                  101,
-                  101,
-                  100
-                ]
+                kind: "const";
+                value: [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104];
               },
               {
-                "kind": "account",
-                "path": "bank"
-              },
-              {
-                "kind": "account",
-                "path": "emissionsMint"
+                kind: "account";
+                path: "bank";
               }
-            ]
-          }
+            ];
+          };
         },
         {
-          "name": "emissionsVault",
-          "writable": true,
-          "pda": {
-            "seeds": [
+          name: "bankLiquidityVault";
+          writable: true;
+          pda: {
+            seeds: [
               {
-                "kind": "const",
-                "value": [
+                kind: "const";
+                value: [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116];
+              },
+              {
+                kind: "account";
+                path: "bank";
+              }
+            ];
+          };
+        },
+        {
+          name: "tokenProgram";
+        }
+      ];
+      args: [
+        {
+          name: "amount";
+          type: "u64";
+        },
+        {
+          name: "withdrawAll";
+          type: {
+            option: "bool";
+          };
+        }
+      ];
+    },
+    {
+      name: "lendingAccountWithdrawEmissions";
+      discriminator: [234, 22, 84, 214, 118, 176, 140, 170];
+      accounts: [
+        {
+          name: "marginfiGroup";
+        },
+        {
+          name: "marginfiAccount";
+          writable: true;
+        },
+        {
+          name: "signer";
+          signer: true;
+        },
+        {
+          name: "bank";
+          writable: true;
+        },
+        {
+          name: "emissionsMint";
+        },
+        {
+          name: "emissionsAuth";
+          pda: {
+            seeds: [
+              {
+                kind: "const";
+                value: [101, 109, 105, 115, 115, 105, 111, 110, 115, 95, 97, 117, 116, 104, 95, 115, 101, 101, 100];
+              },
+              {
+                kind: "account";
+                path: "bank";
+              },
+              {
+                kind: "account";
+                path: "emissionsMint";
+              }
+            ];
+          };
+        },
+        {
+          name: "emissionsVault";
+          writable: true;
+          pda: {
+            seeds: [
+              {
+                kind: "const";
+                value: [
                   101,
                   109,
                   105,
@@ -768,974 +653,628 @@ export type Marginfi = {
                   101,
                   101,
                   100
-                ]
+                ];
               },
               {
-                "kind": "account",
-                "path": "bank"
+                kind: "account";
+                path: "bank";
               },
               {
-                "kind": "account",
-                "path": "emissionsMint"
+                kind: "account";
+                path: "emissionsMint";
               }
-            ]
-          }
+            ];
+          };
         },
         {
-          "name": "destinationAccount",
-          "writable": true
+          name: "destinationAccount";
+          writable: true;
         },
         {
-          "name": "tokenProgram"
+          name: "tokenProgram";
         }
-      ],
-      "args": []
+      ];
+      args: [];
     },
     {
-      "name": "lendingPoolAccrueBankInterest",
-      "discriminator": [
-        108,
-        201,
-        30,
-        87,
-        47,
-        65,
-        97,
-        188
-      ],
-      "accounts": [
+      name: "lendingPoolAccrueBankInterest";
+      discriminator: [108, 201, 30, 87, 47, 65, 97, 188];
+      accounts: [
         {
-          "name": "marginfiGroup"
+          name: "marginfiGroup";
         },
         {
-          "name": "bank",
-          "writable": true
+          name: "bank";
+          writable: true;
         }
-      ],
-      "args": []
+      ];
+      args: [];
     },
     {
-      "name": "lendingPoolAddBank",
-      "discriminator": [
-        215,
-        68,
-        72,
-        78,
-        208,
-        218,
-        103,
-        182
-      ],
-      "accounts": [
+      name: "lendingPoolAddBank";
+      discriminator: [215, 68, 72, 78, 208, 218, 103, 182];
+      accounts: [
         {
-          "name": "marginfiGroup"
+          name: "marginfiGroup";
         },
         {
-          "name": "admin",
-          "writable": true,
-          "signer": true
+          name: "admin";
+          writable: true;
+          signer: true;
         },
         {
-          "name": "feePayer",
-          "writable": true,
-          "signer": true
+          name: "feePayer";
+          docs: ["Pays to init accounts and pays `fee_state.bank_init_flat_sol_fee` lamports to the protocol"];
+          writable: true;
+          signer: true;
         },
         {
-          "name": "bankMint"
-        },
-        {
-          "name": "bank",
-          "writable": true,
-          "signer": true
-        },
-        {
-          "name": "liquidityVaultAuthority",
-          "pda": {
-            "seeds": [
+          name: "feeState";
+          pda: {
+            seeds: [
               {
-                "kind": "const",
-                "value": [
-                  108,
-                  105,
-                  113,
-                  117,
-                  105,
-                  100,
-                  105,
-                  116,
-                  121,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104
-                ]
+                kind: "const";
+                value: [102, 101, 101, 115, 116, 97, 116, 101];
+              }
+            ];
+          };
+        },
+        {
+          name: "globalFeeWallet";
+          writable: true;
+          relations: ["feeState"];
+        },
+        {
+          name: "bankMint";
+        },
+        {
+          name: "bank";
+          writable: true;
+          signer: true;
+        },
+        {
+          name: "liquidityVaultAuthority";
+          pda: {
+            seeds: [
+              {
+                kind: "const";
+                value: [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104];
               },
               {
-                "kind": "account",
-                "path": "bank"
+                kind: "account";
+                path: "bank";
               }
-            ]
-          }
+            ];
+          };
         },
         {
-          "name": "liquidityVault",
-          "writable": true,
-          "pda": {
-            "seeds": [
+          name: "liquidityVault";
+          writable: true;
+          pda: {
+            seeds: [
               {
-                "kind": "const",
-                "value": [
-                  108,
-                  105,
-                  113,
-                  117,
-                  105,
-                  100,
-                  105,
-                  116,
-                  121,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116
-                ]
+                kind: "const";
+                value: [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116];
               },
               {
-                "kind": "account",
-                "path": "bank"
+                kind: "account";
+                path: "bank";
               }
-            ]
-          }
+            ];
+          };
         },
         {
-          "name": "insuranceVaultAuthority",
-          "pda": {
-            "seeds": [
+          name: "insuranceVaultAuthority";
+          pda: {
+            seeds: [
               {
-                "kind": "const",
-                "value": [
-                  105,
-                  110,
-                  115,
-                  117,
-                  114,
-                  97,
-                  110,
-                  99,
-                  101,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104
-                ]
+                kind: "const";
+                value: [105, 110, 115, 117, 114, 97, 110, 99, 101, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104];
               },
               {
-                "kind": "account",
-                "path": "bank"
+                kind: "account";
+                path: "bank";
               }
-            ]
-          }
+            ];
+          };
         },
         {
-          "name": "insuranceVault",
-          "writable": true,
-          "pda": {
-            "seeds": [
+          name: "insuranceVault";
+          writable: true;
+          pda: {
+            seeds: [
               {
-                "kind": "const",
-                "value": [
-                  105,
-                  110,
-                  115,
-                  117,
-                  114,
-                  97,
-                  110,
-                  99,
-                  101,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116
-                ]
+                kind: "const";
+                value: [105, 110, 115, 117, 114, 97, 110, 99, 101, 95, 118, 97, 117, 108, 116];
               },
               {
-                "kind": "account",
-                "path": "bank"
+                kind: "account";
+                path: "bank";
               }
-            ]
-          }
+            ];
+          };
         },
         {
-          "name": "feeVaultAuthority",
-          "pda": {
-            "seeds": [
+          name: "feeVaultAuthority";
+          pda: {
+            seeds: [
               {
-                "kind": "const",
-                "value": [
-                  102,
-                  101,
-                  101,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104
-                ]
+                kind: "const";
+                value: [102, 101, 101, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104];
               },
               {
-                "kind": "account",
-                "path": "bank"
+                kind: "account";
+                path: "bank";
               }
-            ]
-          }
+            ];
+          };
         },
         {
-          "name": "feeVault",
-          "writable": true,
-          "pda": {
-            "seeds": [
+          name: "feeVault";
+          writable: true;
+          pda: {
+            seeds: [
               {
-                "kind": "const",
-                "value": [
-                  102,
-                  101,
-                  101,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116
-                ]
+                kind: "const";
+                value: [102, 101, 101, 95, 118, 97, 117, 108, 116];
               },
               {
-                "kind": "account",
-                "path": "bank"
+                kind: "account";
+                path: "bank";
               }
-            ]
-          }
+            ];
+          };
         },
         {
-          "name": "rent",
-          "address": "SysvarRent111111111111111111111111111111111"
+          name: "rent";
+          address: "SysvarRent111111111111111111111111111111111";
         },
         {
-          "name": "tokenProgram"
+          name: "tokenProgram";
         },
         {
-          "name": "systemProgram",
-          "address": "11111111111111111111111111111111"
+          name: "systemProgram";
+          address: "11111111111111111111111111111111";
         }
-      ],
-      "args": [
+      ];
+      args: [
         {
-          "name": "bankConfig",
-          "type": {
-            "defined": {
-              "name": "bankConfigCompact"
-            }
-          }
+          name: "bankConfig";
+          type: {
+            defined: {
+              name: "bankConfigCompact";
+            };
+          };
         }
-      ]
+      ];
     },
     {
-      "name": "lendingPoolAddBankWithSeed",
-      "docs": [
+      name: "lendingPoolAddBankWithSeed";
+      docs: [
         "A copy of lending_pool_add_bank with an additional bank seed.",
         "This seed is used to create a PDA for the bank's signature.",
         "lending_pool_add_bank is preserved for backwards compatibility."
-      ],
-      "discriminator": [
-        76,
-        211,
-        213,
-        171,
-        117,
-        78,
-        158,
-        76
-      ],
-      "accounts": [
+      ];
+      discriminator: [76, 211, 213, 171, 117, 78, 158, 76];
+      accounts: [
         {
-          "name": "marginfiGroup"
+          name: "marginfiGroup";
         },
         {
-          "name": "admin",
-          "writable": true,
-          "signer": true
+          name: "admin";
+          writable: true;
+          signer: true;
         },
         {
-          "name": "feePayer",
-          "writable": true,
-          "signer": true
+          name: "feePayer";
+          docs: ["Pays to init accounts and pays `fee_state.bank_init_flat_sol_fee` lamports to the protocol"];
+          writable: true;
+          signer: true;
         },
         {
-          "name": "bankMint"
-        },
-        {
-          "name": "bank",
-          "writable": true,
-          "pda": {
-            "seeds": [
+          name: "feeState";
+          pda: {
+            seeds: [
               {
-                "kind": "account",
-                "path": "marginfiGroup"
-              },
-              {
-                "kind": "account",
-                "path": "bankMint"
-              },
-              {
-                "kind": "arg",
-                "path": "bankSeed"
+                kind: "const";
+                value: [102, 101, 101, 115, 116, 97, 116, 101];
               }
-            ]
-          }
+            ];
+          };
         },
         {
-          "name": "liquidityVaultAuthority",
-          "pda": {
-            "seeds": [
+          name: "globalFeeWallet";
+          writable: true;
+          relations: ["feeState"];
+        },
+        {
+          name: "bankMint";
+        },
+        {
+          name: "bank";
+          writable: true;
+          pda: {
+            seeds: [
               {
-                "kind": "const",
-                "value": [
-                  108,
-                  105,
-                  113,
-                  117,
-                  105,
-                  100,
-                  105,
-                  116,
-                  121,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104
-                ]
+                kind: "account";
+                path: "marginfiGroup";
               },
               {
-                "kind": "account",
-                "path": "bank"
-              }
-            ]
-          }
-        },
-        {
-          "name": "liquidityVault",
-          "writable": true,
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  108,
-                  105,
-                  113,
-                  117,
-                  105,
-                  100,
-                  105,
-                  116,
-                  121,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116
-                ]
+                kind: "account";
+                path: "bankMint";
               },
               {
-                "kind": "account",
-                "path": "bank"
+                kind: "arg";
+                path: "bankSeed";
               }
-            ]
-          }
+            ];
+          };
         },
         {
-          "name": "insuranceVaultAuthority",
-          "pda": {
-            "seeds": [
+          name: "liquidityVaultAuthority";
+          pda: {
+            seeds: [
               {
-                "kind": "const",
-                "value": [
-                  105,
-                  110,
-                  115,
-                  117,
-                  114,
-                  97,
-                  110,
-                  99,
-                  101,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104
-                ]
+                kind: "const";
+                value: [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104];
               },
               {
-                "kind": "account",
-                "path": "bank"
+                kind: "account";
+                path: "bank";
               }
-            ]
-          }
+            ];
+          };
         },
         {
-          "name": "insuranceVault",
-          "writable": true,
-          "pda": {
-            "seeds": [
+          name: "liquidityVault";
+          writable: true;
+          pda: {
+            seeds: [
               {
-                "kind": "const",
-                "value": [
-                  105,
-                  110,
-                  115,
-                  117,
-                  114,
-                  97,
-                  110,
-                  99,
-                  101,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116
-                ]
+                kind: "const";
+                value: [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116];
               },
               {
-                "kind": "account",
-                "path": "bank"
+                kind: "account";
+                path: "bank";
               }
-            ]
-          }
+            ];
+          };
         },
         {
-          "name": "feeVaultAuthority",
-          "pda": {
-            "seeds": [
+          name: "insuranceVaultAuthority";
+          pda: {
+            seeds: [
               {
-                "kind": "const",
-                "value": [
-                  102,
-                  101,
-                  101,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104
-                ]
+                kind: "const";
+                value: [105, 110, 115, 117, 114, 97, 110, 99, 101, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104];
               },
               {
-                "kind": "account",
-                "path": "bank"
+                kind: "account";
+                path: "bank";
               }
-            ]
-          }
+            ];
+          };
         },
         {
-          "name": "feeVault",
-          "writable": true,
-          "pda": {
-            "seeds": [
+          name: "insuranceVault";
+          writable: true;
+          pda: {
+            seeds: [
               {
-                "kind": "const",
-                "value": [
-                  102,
-                  101,
-                  101,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116
-                ]
+                kind: "const";
+                value: [105, 110, 115, 117, 114, 97, 110, 99, 101, 95, 118, 97, 117, 108, 116];
               },
               {
-                "kind": "account",
-                "path": "bank"
+                kind: "account";
+                path: "bank";
               }
-            ]
-          }
+            ];
+          };
         },
         {
-          "name": "rent",
-          "address": "SysvarRent111111111111111111111111111111111"
+          name: "feeVaultAuthority";
+          pda: {
+            seeds: [
+              {
+                kind: "const";
+                value: [102, 101, 101, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104];
+              },
+              {
+                kind: "account";
+                path: "bank";
+              }
+            ];
+          };
         },
         {
-          "name": "tokenProgram"
+          name: "feeVault";
+          writable: true;
+          pda: {
+            seeds: [
+              {
+                kind: "const";
+                value: [102, 101, 101, 95, 118, 97, 117, 108, 116];
+              },
+              {
+                kind: "account";
+                path: "bank";
+              }
+            ];
+          };
         },
         {
-          "name": "systemProgram",
-          "address": "11111111111111111111111111111111"
+          name: "rent";
+          address: "SysvarRent111111111111111111111111111111111";
+        },
+        {
+          name: "tokenProgram";
+        },
+        {
+          name: "systemProgram";
+          address: "11111111111111111111111111111111";
         }
-      ],
-      "args": [
+      ];
+      args: [
         {
-          "name": "bankConfig",
-          "type": {
-            "defined": {
-              "name": "bankConfigCompact"
-            }
-          }
+          name: "bankConfig";
+          type: {
+            defined: {
+              name: "bankConfigCompact";
+            };
+          };
         },
         {
-          "name": "bankSeed",
-          "type": "u64"
+          name: "bankSeed";
+          type: "u64";
         }
-      ]
+      ];
     },
     {
-      "name": "lendingPoolCollectBankFees",
-      "discriminator": [
-        201,
-        5,
-        215,
-        116,
-        230,
-        92,
-        75,
-        150
-      ],
-      "accounts": [
+      name: "lendingPoolCollectBankFees";
+      discriminator: [201, 5, 215, 116, 230, 92, 75, 150];
+      accounts: [
         {
-          "name": "marginfiGroup"
+          name: "marginfiGroup";
         },
         {
-          "name": "bank",
-          "writable": true
+          name: "bank";
+          writable: true;
         },
         {
-          "name": "liquidityVaultAuthority",
-          "pda": {
-            "seeds": [
+          name: "liquidityVaultAuthority";
+          pda: {
+            seeds: [
               {
-                "kind": "const",
-                "value": [
-                  108,
-                  105,
-                  113,
-                  117,
-                  105,
-                  100,
-                  105,
-                  116,
-                  121,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104
-                ]
+                kind: "const";
+                value: [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104];
               },
               {
-                "kind": "account",
-                "path": "bank"
+                kind: "account";
+                path: "bank";
               }
-            ]
-          }
+            ];
+          };
         },
         {
-          "name": "liquidityVault",
-          "writable": true,
-          "pda": {
-            "seeds": [
+          name: "liquidityVault";
+          writable: true;
+          pda: {
+            seeds: [
               {
-                "kind": "const",
-                "value": [
-                  108,
-                  105,
-                  113,
-                  117,
-                  105,
-                  100,
-                  105,
-                  116,
-                  121,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116
-                ]
+                kind: "const";
+                value: [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116];
               },
               {
-                "kind": "account",
-                "path": "bank"
+                kind: "account";
+                path: "bank";
               }
-            ]
-          }
+            ];
+          };
         },
         {
-          "name": "insuranceVault",
-          "writable": true,
-          "pda": {
-            "seeds": [
+          name: "insuranceVault";
+          writable: true;
+          pda: {
+            seeds: [
               {
-                "kind": "const",
-                "value": [
-                  105,
-                  110,
-                  115,
-                  117,
-                  114,
-                  97,
-                  110,
-                  99,
-                  101,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116
-                ]
+                kind: "const";
+                value: [105, 110, 115, 117, 114, 97, 110, 99, 101, 95, 118, 97, 117, 108, 116];
               },
               {
-                "kind": "account",
-                "path": "bank"
+                kind: "account";
+                path: "bank";
               }
-            ]
-          }
+            ];
+          };
         },
         {
-          "name": "feeVault",
-          "writable": true,
-          "pda": {
-            "seeds": [
+          name: "feeVault";
+          writable: true;
+          pda: {
+            seeds: [
               {
-                "kind": "const",
-                "value": [
-                  102,
-                  101,
-                  101,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116
-                ]
+                kind: "const";
+                value: [102, 101, 101, 95, 118, 97, 117, 108, 116];
               },
               {
-                "kind": "account",
-                "path": "bank"
+                kind: "account";
+                path: "bank";
               }
-            ]
-          }
+            ];
+          };
         },
         {
-          "name": "tokenProgram"
+          name: "feeState";
+          pda: {
+            seeds: [
+              {
+                kind: "const";
+                value: [102, 101, 101, 115, 116, 97, 116, 101];
+              }
+            ];
+          };
+        },
+        {
+          name: "feeAta";
+          docs: [
+            "(validated in handler). Must already exist, may require initializing the ATA if it does not",
+            "already exist prior to this ix."
+          ];
+          writable: true;
+        },
+        {
+          name: "tokenProgram";
         }
-      ],
-      "args": []
+      ];
+      args: [];
     },
     {
-      "name": "lendingPoolConfigureBank",
-      "discriminator": [
-        121,
-        173,
-        156,
-        40,
-        93,
-        148,
-        56,
-        237
-      ],
-      "accounts": [
+      name: "lendingPoolConfigureBank";
+      discriminator: [121, 173, 156, 40, 93, 148, 56, 237];
+      accounts: [
         {
-          "name": "marginfiGroup"
+          name: "marginfiGroup";
         },
         {
-          "name": "admin",
-          "signer": true
+          name: "admin";
+          signer: true;
         },
         {
-          "name": "bank",
-          "writable": true
+          name: "bank";
+          writable: true;
         }
-      ],
-      "args": [
+      ];
+      args: [
         {
-          "name": "bankConfigOpt",
-          "type": {
-            "defined": {
-              "name": "bankConfigOpt"
-            }
-          }
+          name: "bankConfigOpt";
+          type: {
+            defined: {
+              name: "bankConfigOpt";
+            };
+          };
         }
-      ]
+      ];
     },
     {
-      "name": "lendingPoolHandleBankruptcy",
-      "docs": [
-        "Handle bad debt of a bankrupt marginfi account for a given bank."
-      ],
-      "discriminator": [
-        162,
-        11,
-        56,
-        139,
-        90,
-        128,
-        70,
-        173
-      ],
-      "accounts": [
+      name: "lendingPoolHandleBankruptcy";
+      docs: ["Handle bad debt of a bankrupt marginfi account for a given bank."];
+      discriminator: [162, 11, 56, 139, 90, 128, 70, 173];
+      accounts: [
         {
-          "name": "marginfiGroup"
+          name: "marginfiGroup";
         },
         {
-          "name": "signer",
-          "signer": true
+          name: "signer";
+          signer: true;
         },
         {
-          "name": "bank",
-          "writable": true
+          name: "bank";
+          writable: true;
         },
         {
-          "name": "marginfiAccount",
-          "writable": true
+          name: "marginfiAccount";
+          writable: true;
         },
         {
-          "name": "liquidityVault",
-          "writable": true,
-          "pda": {
-            "seeds": [
+          name: "liquidityVault";
+          writable: true;
+          pda: {
+            seeds: [
               {
-                "kind": "const",
-                "value": [
-                  108,
-                  105,
-                  113,
-                  117,
-                  105,
-                  100,
-                  105,
-                  116,
-                  121,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116
-                ]
+                kind: "const";
+                value: [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116];
               },
               {
-                "kind": "account",
-                "path": "bank"
+                kind: "account";
+                path: "bank";
               }
-            ]
-          }
+            ];
+          };
         },
         {
-          "name": "insuranceVault",
-          "writable": true,
-          "pda": {
-            "seeds": [
+          name: "insuranceVault";
+          writable: true;
+          pda: {
+            seeds: [
               {
-                "kind": "const",
-                "value": [
-                  105,
-                  110,
-                  115,
-                  117,
-                  114,
-                  97,
-                  110,
-                  99,
-                  101,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116
-                ]
+                kind: "const";
+                value: [105, 110, 115, 117, 114, 97, 110, 99, 101, 95, 118, 97, 117, 108, 116];
               },
               {
-                "kind": "account",
-                "path": "bank"
+                kind: "account";
+                path: "bank";
               }
-            ]
-          }
+            ];
+          };
         },
         {
-          "name": "insuranceVaultAuthority",
-          "pda": {
-            "seeds": [
+          name: "insuranceVaultAuthority";
+          pda: {
+            seeds: [
               {
-                "kind": "const",
-                "value": [
-                  105,
-                  110,
-                  115,
-                  117,
-                  114,
-                  97,
-                  110,
-                  99,
-                  101,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104
-                ]
+                kind: "const";
+                value: [105, 110, 115, 117, 114, 97, 110, 99, 101, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104];
               },
               {
-                "kind": "account",
-                "path": "bank"
+                kind: "account";
+                path: "bank";
               }
-            ]
-          }
+            ];
+          };
         },
         {
-          "name": "tokenProgram"
+          name: "tokenProgram";
         }
-      ],
-      "args": []
+      ];
+      args: [];
     },
     {
-      "name": "lendingPoolSetupEmissions",
-      "discriminator": [
-        206,
-        97,
-        120,
-        172,
-        113,
-        204,
-        169,
-        70
-      ],
-      "accounts": [
+      name: "lendingPoolSetupEmissions";
+      discriminator: [206, 97, 120, 172, 113, 204, 169, 70];
+      accounts: [
         {
-          "name": "marginfiGroup"
+          name: "marginfiGroup";
         },
         {
-          "name": "admin",
-          "writable": true,
-          "signer": true
+          name: "admin";
+          writable: true;
+          signer: true;
         },
         {
-          "name": "bank",
-          "writable": true
+          name: "bank";
+          writable: true;
         },
         {
-          "name": "emissionsMint"
+          name: "emissionsMint";
         },
         {
-          "name": "emissionsAuth",
-          "pda": {
-            "seeds": [
+          name: "emissionsAuth";
+          pda: {
+            seeds: [
               {
-                "kind": "const",
-                "value": [
-                  101,
-                  109,
-                  105,
-                  115,
-                  115,
-                  105,
-                  111,
-                  110,
-                  115,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  95,
-                  115,
-                  101,
-                  101,
-                  100
-                ]
+                kind: "const";
+                value: [101, 109, 105, 115, 115, 105, 111, 110, 115, 95, 97, 117, 116, 104, 95, 115, 101, 101, 100];
               },
               {
-                "kind": "account",
-                "path": "bank"
+                kind: "account";
+                path: "bank";
               },
               {
-                "kind": "account",
-                "path": "emissionsMint"
+                kind: "account";
+                path: "emissionsMint";
               }
-            ]
-          }
+            ];
+          };
         },
         {
-          "name": "emissionsTokenAccount",
-          "writable": true,
-          "pda": {
-            "seeds": [
+          name: "emissionsTokenAccount";
+          writable: true;
+          pda: {
+            seeds: [
               {
-                "kind": "const",
-                "value": [
+                kind: "const";
+                value: [
                   101,
                   109,
                   105,
@@ -1764,82 +1303,73 @@ export type Marginfi = {
                   101,
                   101,
                   100
-                ]
+                ];
               },
               {
-                "kind": "account",
-                "path": "bank"
+                kind: "account";
+                path: "bank";
               },
               {
-                "kind": "account",
-                "path": "emissionsMint"
+                kind: "account";
+                path: "emissionsMint";
               }
-            ]
-          }
+            ];
+          };
         },
         {
-          "name": "emissionsFundingAccount",
-          "writable": true
+          name: "emissionsFundingAccount";
+          writable: true;
         },
         {
-          "name": "tokenProgram"
+          name: "tokenProgram";
         },
         {
-          "name": "systemProgram",
-          "address": "11111111111111111111111111111111"
+          name: "systemProgram";
+          address: "11111111111111111111111111111111";
         }
-      ],
-      "args": [
+      ];
+      args: [
         {
-          "name": "flags",
-          "type": "u64"
+          name: "flags";
+          type: "u64";
         },
         {
-          "name": "rate",
-          "type": "u64"
+          name: "rate";
+          type: "u64";
         },
         {
-          "name": "totalEmissions",
-          "type": "u64"
+          name: "totalEmissions";
+          type: "u64";
         }
-      ]
+      ];
     },
     {
-      "name": "lendingPoolUpdateEmissionsParameters",
-      "discriminator": [
-        55,
-        213,
-        224,
-        168,
-        153,
-        53,
-        197,
-        40
-      ],
-      "accounts": [
+      name: "lendingPoolUpdateEmissionsParameters";
+      discriminator: [55, 213, 224, 168, 153, 53, 197, 40];
+      accounts: [
         {
-          "name": "marginfiGroup"
+          name: "marginfiGroup";
         },
         {
-          "name": "admin",
-          "writable": true,
-          "signer": true
+          name: "admin";
+          writable: true;
+          signer: true;
         },
         {
-          "name": "bank",
-          "writable": true
+          name: "bank";
+          writable: true;
         },
         {
-          "name": "emissionsMint"
+          name: "emissionsMint";
         },
         {
-          "name": "emissionsTokenAccount",
-          "writable": true,
-          "pda": {
-            "seeds": [
+          name: "emissionsTokenAccount";
+          writable: true;
+          pda: {
+            seeds: [
               {
-                "kind": "const",
-                "value": [
+                kind: "const";
+                value: [
                   101,
                   109,
                   105,
@@ -1868,1362 +1398,785 @@ export type Marginfi = {
                   101,
                   101,
                   100
-                ]
+                ];
               },
               {
-                "kind": "account",
-                "path": "bank"
+                kind: "account";
+                path: "bank";
               },
               {
-                "kind": "account",
-                "path": "emissionsMint"
+                kind: "account";
+                path: "emissionsMint";
               }
-            ]
-          }
+            ];
+          };
         },
         {
-          "name": "emissionsFundingAccount",
-          "writable": true
+          name: "emissionsFundingAccount";
+          writable: true;
         },
         {
-          "name": "tokenProgram"
+          name: "tokenProgram";
         }
-      ],
-      "args": [
+      ];
+      args: [
         {
-          "name": "emissionsFlags",
-          "type": {
-            "option": "u64"
-          }
+          name: "emissionsFlags";
+          type: {
+            option: "u64";
+          };
         },
         {
-          "name": "emissionsRate",
-          "type": {
-            "option": "u64"
-          }
+          name: "emissionsRate";
+          type: {
+            option: "u64";
+          };
         },
         {
-          "name": "additionalEmissions",
-          "type": {
-            "option": "u64"
-          }
+          name: "additionalEmissions";
+          type: {
+            option: "u64";
+          };
         }
-      ]
+      ];
     },
     {
-      "name": "lendingPoolWithdrawFees",
-      "discriminator": [
-        92,
-        140,
-        215,
-        254,
-        170,
-        0,
-        83,
-        174
-      ],
-      "accounts": [
+      name: "lendingPoolWithdrawFees";
+      discriminator: [92, 140, 215, 254, 170, 0, 83, 174];
+      accounts: [
         {
-          "name": "marginfiGroup"
+          name: "marginfiGroup";
         },
         {
-          "name": "bank"
+          name: "bank";
         },
         {
-          "name": "admin",
-          "signer": true
+          name: "admin";
+          signer: true;
         },
         {
-          "name": "feeVault",
-          "writable": true,
-          "pda": {
-            "seeds": [
+          name: "feeVault";
+          writable: true;
+          pda: {
+            seeds: [
               {
-                "kind": "const",
-                "value": [
-                  102,
-                  101,
-                  101,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116
-                ]
+                kind: "const";
+                value: [102, 101, 101, 95, 118, 97, 117, 108, 116];
               },
               {
-                "kind": "account",
-                "path": "bank"
+                kind: "account";
+                path: "bank";
               }
-            ]
-          }
+            ];
+          };
         },
         {
-          "name": "feeVaultAuthority",
-          "pda": {
-            "seeds": [
+          name: "feeVaultAuthority";
+          pda: {
+            seeds: [
               {
-                "kind": "const",
-                "value": [
-                  102,
-                  101,
-                  101,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104
-                ]
+                kind: "const";
+                value: [102, 101, 101, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104];
               },
               {
-                "kind": "account",
-                "path": "bank"
+                kind: "account";
+                path: "bank";
               }
-            ]
-          }
+            ];
+          };
         },
         {
-          "name": "dstTokenAccount",
-          "writable": true
+          name: "dstTokenAccount";
+          writable: true;
         },
         {
-          "name": "tokenProgram"
+          name: "tokenProgram";
         }
-      ],
-      "args": [
+      ];
+      args: [
         {
-          "name": "amount",
-          "type": "u64"
+          name: "amount";
+          type: "u64";
         }
-      ]
+      ];
     },
     {
-      "name": "lendingPoolWithdrawInsurance",
-      "discriminator": [
-        108,
-        60,
-        60,
-        246,
-        104,
-        79,
-        159,
-        243
-      ],
-      "accounts": [
+      name: "lendingPoolWithdrawInsurance";
+      discriminator: [108, 60, 60, 246, 104, 79, 159, 243];
+      accounts: [
         {
-          "name": "marginfiGroup"
+          name: "marginfiGroup";
         },
         {
-          "name": "bank"
+          name: "bank";
         },
         {
-          "name": "admin",
-          "signer": true
+          name: "admin";
+          signer: true;
         },
         {
-          "name": "insuranceVault",
-          "writable": true,
-          "pda": {
-            "seeds": [
+          name: "insuranceVault";
+          writable: true;
+          pda: {
+            seeds: [
               {
-                "kind": "const",
-                "value": [
-                  105,
-                  110,
-                  115,
-                  117,
-                  114,
-                  97,
-                  110,
-                  99,
-                  101,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116
-                ]
+                kind: "const";
+                value: [105, 110, 115, 117, 114, 97, 110, 99, 101, 95, 118, 97, 117, 108, 116];
               },
               {
-                "kind": "account",
-                "path": "bank"
+                kind: "account";
+                path: "bank";
               }
-            ]
-          }
+            ];
+          };
         },
         {
-          "name": "insuranceVaultAuthority",
-          "pda": {
-            "seeds": [
+          name: "insuranceVaultAuthority";
+          pda: {
+            seeds: [
               {
-                "kind": "const",
-                "value": [
-                  105,
-                  110,
-                  115,
-                  117,
-                  114,
-                  97,
-                  110,
-                  99,
-                  101,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104
-                ]
+                kind: "const";
+                value: [105, 110, 115, 117, 114, 97, 110, 99, 101, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104];
               },
               {
-                "kind": "account",
-                "path": "bank"
+                kind: "account";
+                path: "bank";
               }
-            ]
-          }
+            ];
+          };
         },
         {
-          "name": "dstTokenAccount",
-          "writable": true
+          name: "dstTokenAccount";
+          writable: true;
         },
         {
-          "name": "tokenProgram"
+          name: "tokenProgram";
         }
-      ],
-      "args": [
+      ];
+      args: [
         {
-          "name": "amount",
-          "type": "u64"
+          name: "amount";
+          type: "u64";
         }
-      ]
+      ];
     },
     {
-      "name": "marginfiAccountClose",
-      "discriminator": [
-        186,
-        221,
-        93,
-        34,
-        50,
-        97,
-        194,
-        241
-      ],
-      "accounts": [
+      name: "marginfiAccountClose";
+      discriminator: [186, 221, 93, 34, 50, 97, 194, 241];
+      accounts: [
         {
-          "name": "marginfiAccount",
-          "writable": true
+          name: "marginfiAccount";
+          writable: true;
         },
         {
-          "name": "authority",
-          "signer": true
+          name: "authority";
+          signer: true;
         },
         {
-          "name": "feePayer",
-          "writable": true,
-          "signer": true
+          name: "feePayer";
+          writable: true;
+          signer: true;
         }
-      ],
-      "args": []
+      ];
+      args: [];
     },
     {
-      "name": "marginfiAccountInitialize",
-      "docs": [
-        "Initialize a marginfi account for a given group"
-      ],
-      "discriminator": [
-        43,
-        78,
-        61,
-        255,
-        148,
-        52,
-        249,
-        154
-      ],
-      "accounts": [
+      name: "marginfiAccountInitialize";
+      docs: ["Initialize a marginfi account for a given group"];
+      discriminator: [43, 78, 61, 255, 148, 52, 249, 154];
+      accounts: [
         {
-          "name": "marginfiGroup"
+          name: "marginfiGroup";
         },
         {
-          "name": "marginfiAccount",
-          "writable": true,
-          "signer": true
+          name: "marginfiAccount";
+          writable: true;
+          signer: true;
         },
         {
-          "name": "authority",
-          "signer": true
+          name: "authority";
+          signer: true;
         },
         {
-          "name": "feePayer",
-          "writable": true,
-          "signer": true
+          name: "feePayer";
+          writable: true;
+          signer: true;
         },
         {
-          "name": "systemProgram",
-          "address": "11111111111111111111111111111111"
+          name: "systemProgram";
+          address: "11111111111111111111111111111111";
         }
-      ],
-      "args": []
+      ];
+      args: [];
     },
     {
-      "name": "marginfiGroupConfigure",
-      "discriminator": [
-        62,
-        199,
-        81,
-        78,
-        33,
-        13,
-        236,
-        61
-      ],
-      "accounts": [
+      name: "marginfiGroupConfigure";
+      discriminator: [62, 199, 81, 78, 33, 13, 236, 61];
+      accounts: [
         {
-          "name": "marginfiGroup",
-          "writable": true
+          name: "marginfiGroup";
+          writable: true;
         },
         {
-          "name": "admin",
-          "signer": true
+          name: "admin";
+          signer: true;
         }
-      ],
-      "args": [
+      ];
+      args: [
         {
-          "name": "config",
-          "type": {
-            "defined": {
-              "name": "groupConfig"
-            }
-          }
+          name: "config";
+          type: {
+            defined: {
+              name: "groupConfig";
+            };
+          };
         }
-      ]
+      ];
     },
     {
-      "name": "marginfiGroupInitialize",
-      "discriminator": [
-        255,
-        67,
-        67,
-        26,
-        94,
-        31,
-        34,
-        20
-      ],
-      "accounts": [
+      name: "marginfiGroupInitialize";
+      discriminator: [255, 67, 67, 26, 94, 31, 34, 20];
+      accounts: [
         {
-          "name": "marginfiGroup",
-          "writable": true,
-          "signer": true
+          name: "marginfiGroup";
+          writable: true;
+          signer: true;
         },
         {
-          "name": "admin",
-          "writable": true,
-          "signer": true
+          name: "admin";
+          writable: true;
+          signer: true;
         },
         {
-          "name": "systemProgram",
-          "address": "11111111111111111111111111111111"
+          name: "feeState";
+          pda: {
+            seeds: [
+              {
+                kind: "const";
+                value: [102, 101, 101, 115, 116, 97, 116, 101];
+              }
+            ];
+          };
+        },
+        {
+          name: "systemProgram";
+          address: "11111111111111111111111111111111";
         }
-      ],
-      "args": []
+      ];
+      args: [];
     },
     {
-      "name": "setAccountFlag",
-      "discriminator": [
-        56,
-        238,
-        18,
-        207,
-        193,
-        82,
-        138,
-        174
-      ],
-      "accounts": [
+      name: "propagateFeeState";
+      docs: ["(Permissionless) Force any group to adopt the current FeeState settings"];
+      discriminator: [64, 3, 166, 194, 129, 21, 101, 155];
+      accounts: [
         {
-          "name": "marginfiGroup"
+          name: "feeState";
+          pda: {
+            seeds: [
+              {
+                kind: "const";
+                value: [102, 101, 101, 115, 116, 97, 116, 101];
+              }
+            ];
+          };
         },
         {
-          "name": "marginfiAccount",
-          "writable": true
-        },
-        {
-          "name": "admin",
-          "docs": [
-            "Admin only"
-          ],
-          "signer": true
+          name: "marginfiGroup";
+          docs: ["Any group, this ix is permisionless and can propogate the fee to any group"];
+          writable: true;
         }
-      ],
-      "args": [
-        {
-          "name": "flag",
-          "type": "u64"
-        }
-      ]
+      ];
+      args: [];
     },
     {
-      "name": "setNewAccountAuthority",
-      "discriminator": [
-        153,
-        162,
-        50,
-        84,
-        182,
-        201,
-        74,
-        179
-      ],
-      "accounts": [
+      name: "setAccountFlag";
+      discriminator: [56, 238, 18, 207, 193, 82, 138, 174];
+      accounts: [
         {
-          "name": "marginfiAccount",
-          "writable": true
+          name: "marginfiGroup";
         },
         {
-          "name": "marginfiGroup"
+          name: "marginfiAccount";
+          writable: true;
         },
         {
-          "name": "signer",
-          "signer": true
-        },
-        {
-          "name": "newAuthority"
-        },
-        {
-          "name": "feePayer",
-          "writable": true,
-          "signer": true
+          name: "admin";
+          docs: ["Admin only"];
+          signer: true;
         }
-      ],
-      "args": []
+      ];
+      args: [
+        {
+          name: "flag";
+          type: "u64";
+        }
+      ];
     },
     {
-      "name": "unsetAccountFlag",
-      "discriminator": [
-        56,
-        81,
-        56,
-        85,
-        92,
-        49,
-        255,
-        70
-      ],
-      "accounts": [
+      name: "setNewAccountAuthority";
+      discriminator: [153, 162, 50, 84, 182, 201, 74, 179];
+      accounts: [
         {
-          "name": "marginfiGroup"
+          name: "marginfiAccount";
+          writable: true;
         },
         {
-          "name": "marginfiAccount",
-          "writable": true
+          name: "marginfiGroup";
         },
         {
-          "name": "admin",
-          "docs": [
-            "Admin only"
-          ],
-          "signer": true
-        }
-      ],
-      "args": [
+          name: "signer";
+          signer: true;
+        },
         {
-          "name": "flag",
-          "type": "u64"
+          name: "newAuthority";
+        },
+        {
+          name: "feePayer";
+          writable: true;
+          signer: true;
         }
-      ]
+      ];
+      args: [];
+    },
+    {
+      name: "unsetAccountFlag";
+      discriminator: [56, 81, 56, 85, 92, 49, 255, 70];
+      accounts: [
+        {
+          name: "marginfiGroup";
+        },
+        {
+          name: "marginfiAccount";
+          writable: true;
+        },
+        {
+          name: "admin";
+          docs: ["Admin only"];
+          signer: true;
+        }
+      ];
+      args: [
+        {
+          name: "flag";
+          type: "u64";
+        }
+      ];
     }
-  ],
-  "accounts": [
+  ];
+  accounts: [
     {
-      "name": "bank",
-      "discriminator": [
-        142,
-        49,
-        166,
-        242,
-        50,
-        66,
-        97,
-        188
-      ]
+      name: "bank";
+      discriminator: [142, 49, 166, 242, 50, 66, 97, 188];
     },
     {
-      "name": "marginfiAccount",
-      "discriminator": [
-        67,
-        178,
-        130,
-        109,
-        126,
-        114,
-        28,
-        42
-      ]
+      name: "feeState";
+      discriminator: [63, 224, 16, 85, 193, 36, 235, 220];
     },
     {
-      "name": "marginfiGroup",
-      "discriminator": [
-        182,
-        23,
-        173,
-        240,
-        151,
-        206,
-        182,
-        67
-      ]
+      name: "marginfiAccount";
+      discriminator: [67, 178, 130, 109, 126, 114, 28, 42];
+    },
+    {
+      name: "marginfiGroup";
+      discriminator: [182, 23, 173, 240, 151, 206, 182, 67];
     }
-  ],
-  "events": [
+  ];
+  types: [
     {
-      "name": "lendingAccountBorrowEvent",
-      "discriminator": [
-        223,
-        96,
-        81,
-        10,
-        156,
-        99,
-        26,
-        59
-      ]
-    },
-    {
-      "name": "lendingAccountDepositEvent",
-      "discriminator": [
-        161,
-        54,
-        237,
-        217,
-        105,
-        248,
-        122,
-        151
-      ]
-    },
-    {
-      "name": "lendingAccountLiquidateEvent",
-      "discriminator": [
-        166,
-        160,
-        249,
-        154,
-        183,
-        39,
-        23,
-        242
-      ]
-    },
-    {
-      "name": "lendingAccountRepayEvent",
-      "discriminator": [
-        16,
-        220,
-        55,
-        111,
-        7,
-        80,
-        16,
-        25
-      ]
-    },
-    {
-      "name": "lendingAccountWithdrawEvent",
-      "discriminator": [
-        3,
-        220,
-        148,
-        243,
-        33,
-        249,
-        54,
-        88
-      ]
-    },
-    {
-      "name": "lendingPoolBankAccrueInterestEvent",
-      "discriminator": [
-        104,
-        117,
-        187,
-        156,
-        111,
-        154,
-        106,
-        186
-      ]
-    },
-    {
-      "name": "lendingPoolBankCollectFeesEvent",
-      "discriminator": [
-        101,
-        119,
-        97,
-        250,
-        169,
-        175,
-        156,
-        253
-      ]
-    },
-    {
-      "name": "lendingPoolBankConfigureEvent",
-      "discriminator": [
-        246,
-        35,
-        233,
-        110,
-        93,
-        152,
-        235,
-        40
-      ]
-    },
-    {
-      "name": "lendingPoolBankCreateEvent",
-      "discriminator": [
-        236,
-        220,
-        201,
-        63,
-        239,
-        126,
-        136,
-        249
-      ]
-    },
-    {
-      "name": "lendingPoolBankHandleBankruptcyEvent",
-      "discriminator": [
-        166,
-        77,
-        41,
-        140,
-        36,
-        94,
-        10,
-        57
-      ]
-    },
-    {
-      "name": "marginfiAccountCreateEvent",
-      "discriminator": [
-        183,
-        5,
-        117,
-        104,
-        122,
-        199,
-        68,
-        51
-      ]
-    },
-    {
-      "name": "marginfiAccountTransferAccountAuthorityEvent",
-      "discriminator": [
-        112,
-        61,
-        140,
-        132,
-        251,
-        92,
-        90,
-        202
-      ]
-    },
-    {
-      "name": "marginfiGroupConfigureEvent",
-      "discriminator": [
-        241,
-        104,
-        172,
-        167,
-        41,
-        195,
-        199,
-        170
-      ]
-    },
-    {
-      "name": "marginfiGroupCreateEvent",
-      "discriminator": [
-        233,
-        125,
-        61,
-        14,
-        98,
-        240,
-        136,
-        253
-      ]
-    }
-  ],
-  "errors": [
-    {
-      "code": 6000,
-      "name": "mathError",
-      "msg": "Math error"
-    },
-    {
-      "code": 6001,
-      "name": "bankNotFound",
-      "msg": "Invalid bank index"
-    },
-    {
-      "code": 6002,
-      "name": "lendingAccountBalanceNotFound",
-      "msg": "Lending account balance not found"
-    },
-    {
-      "code": 6003,
-      "name": "bankAssetCapacityExceeded",
-      "msg": "Bank deposit capacity exceeded"
-    },
-    {
-      "code": 6004,
-      "name": "invalidTransfer",
-      "msg": "Invalid transfer"
-    },
-    {
-      "code": 6005,
-      "name": "missingPythOrBankAccount",
-      "msg": "Missing Pyth or Bank account"
-    },
-    {
-      "code": 6006,
-      "name": "missingPythAccount",
-      "msg": "Missing Pyth account"
-    },
-    {
-      "code": 6007,
-      "name": "invalidOracleAccount",
-      "msg": "Invalid Pyth account"
-    },
-    {
-      "code": 6008,
-      "name": "missingBankAccount",
-      "msg": "Missing Bank account"
-    },
-    {
-      "code": 6009,
-      "name": "invalidBankAccount",
-      "msg": "Invalid Bank account"
-    },
-    {
-      "code": 6010,
-      "name": "riskEngineInitRejected",
-      "msg": "RiskEngine rejected due to either bad health or stale oracles"
-    },
-    {
-      "code": 6011,
-      "name": "lendingAccountBalanceSlotsFull",
-      "msg": "Lending account balance slots are full"
-    },
-    {
-      "code": 6012,
-      "name": "bankAlreadyExists",
-      "msg": "Bank already exists"
-    },
-    {
-      "code": 6013,
-      "name": "illegalLiquidation",
-      "msg": "Illegal liquidation"
-    },
-    {
-      "code": 6014,
-      "name": "accountNotBankrupt",
-      "msg": "Account is not bankrupt"
-    },
-    {
-      "code": 6015,
-      "name": "balanceNotBadDebt",
-      "msg": "Account balance is not bad debt"
-    },
-    {
-      "code": 6016,
-      "name": "invalidConfig",
-      "msg": "Invalid group config"
-    },
-    {
-      "code": 6017,
-      "name": "staleOracle",
-      "msg": "Stale oracle data"
-    },
-    {
-      "code": 6018,
-      "name": "bankPaused",
-      "msg": "Bank paused"
-    },
-    {
-      "code": 6019,
-      "name": "bankReduceOnly",
-      "msg": "Bank is ReduceOnly mode"
-    },
-    {
-      "code": 6020,
-      "name": "bankAccountNotFound",
-      "msg": "Bank is missing"
-    },
-    {
-      "code": 6021,
-      "name": "operationDepositOnly",
-      "msg": "Operation is deposit-only"
-    },
-    {
-      "code": 6022,
-      "name": "operationWithdrawOnly",
-      "msg": "Operation is withdraw-only"
-    },
-    {
-      "code": 6023,
-      "name": "operationBorrowOnly",
-      "msg": "Operation is borrow-only"
-    },
-    {
-      "code": 6024,
-      "name": "operationRepayOnly",
-      "msg": "Operation is repay-only"
-    },
-    {
-      "code": 6025,
-      "name": "noAssetFound",
-      "msg": "No asset found"
-    },
-    {
-      "code": 6026,
-      "name": "noLiabilityFound",
-      "msg": "No liability found"
-    },
-    {
-      "code": 6027,
-      "name": "invalidOracleSetup",
-      "msg": "Invalid oracle setup"
-    },
-    {
-      "code": 6028,
-      "name": "illegalUtilizationRatio",
-      "msg": "Invalid bank utilization ratio"
-    },
-    {
-      "code": 6029,
-      "name": "bankLiabilityCapacityExceeded",
-      "msg": "Bank borrow cap exceeded"
-    },
-    {
-      "code": 6030,
-      "name": "invalidPrice",
-      "msg": "Invalid Price"
-    },
-    {
-      "code": 6031,
-      "name": "isolatedAccountIllegalState",
-      "msg": "Account can have only one liability when account is under isolated risk"
-    },
-    {
-      "code": 6032,
-      "name": "emissionsAlreadySetup",
-      "msg": "Emissions already setup"
-    },
-    {
-      "code": 6033,
-      "name": "oracleNotSetup",
-      "msg": "Oracle is not set"
-    },
-    {
-      "code": 6034,
-      "name": "invalidSwitchboardDecimalConversion",
-      "msg": "Invalid switchboard decimal conversion"
-    },
-    {
-      "code": 6035,
-      "name": "cannotCloseOutstandingEmissions",
-      "msg": "Cannot close balance because of outstanding emissions"
-    },
-    {
-      "code": 6036,
-      "name": "emissionsUpdateError",
-      "msg": "Update emissions error"
-    },
-    {
-      "code": 6037,
-      "name": "accountDisabled",
-      "msg": "Account disabled"
-    },
-    {
-      "code": 6038,
-      "name": "accountTempActiveBalanceLimitExceeded",
-      "msg": "Account can't temporarily open 3 balances, please close a balance first"
-    },
-    {
-      "code": 6039,
-      "name": "accountInFlashloan",
-      "msg": "Illegal action during flashloan"
-    },
-    {
-      "code": 6040,
-      "name": "illegalFlashloan",
-      "msg": "Illegal flashloan"
-    },
-    {
-      "code": 6041,
-      "name": "illegalFlag",
-      "msg": "Illegal flag"
-    },
-    {
-      "code": 6042,
-      "name": "illegalBalanceState",
-      "msg": "Illegal balance state"
-    },
-    {
-      "code": 6043,
-      "name": "illegalAccountAuthorityTransfer",
-      "msg": "Illegal account authority transfer"
-    },
-    {
-      "code": 6044,
-      "name": "unauthorized",
-      "msg": "unauthorized"
-    },
-    {
-      "code": 6045,
-      "name": "illegalAction",
-      "msg": "Invalid account authority"
-    },
-    {
-      "code": 6046,
-      "name": "t22MintRequired",
-      "msg": "Token22 Banks require mint account as first remaining account"
-    }
-  ],
-  "types": [
-    {
-      "name": "accountEventHeader",
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: "accountEventHeader";
+      type: {
+        kind: "struct";
+        fields: [
           {
-            "name": "signer",
-            "type": {
-              "option": "pubkey"
-            }
+            name: "signer";
+            type: {
+              option: "pubkey";
+            };
           },
           {
-            "name": "marginfiAccount",
-            "type": "pubkey"
+            name: "marginfiAccount";
+            type: "pubkey";
           },
           {
-            "name": "marginfiAccountAuthority",
-            "type": "pubkey"
+            name: "marginfiAccountAuthority";
+            type: "pubkey";
           },
           {
-            "name": "marginfiGroup",
-            "type": "pubkey"
+            name: "marginfiGroup";
+            type: "pubkey";
           }
-        ]
-      }
+        ];
+      };
     },
     {
-      "name": "balance",
-      "serialization": "bytemuckunsafe",
-      "repr": {
-        "kind": "c"
-      },
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: "balance";
+      serialization: "bytemuckunsafe";
+      repr: {
+        kind: "c";
+      };
+      type: {
+        kind: "struct";
+        fields: [
           {
-            "name": "active",
-            "type": "bool"
+            name: "active";
+            type: "bool";
           },
           {
-            "name": "bankPk",
-            "type": "pubkey"
+            name: "bankPk";
+            type: "pubkey";
           },
           {
-            "name": "pad0",
-            "type": {
-              "array": [
-                "u8",
-                7
-              ]
-            }
+            name: "pad0";
+            type: {
+              array: ["u8", 7];
+            };
           },
           {
-            "name": "assetShares",
-            "type": {
-              "defined": {
-                "name": "wrappedI80f48"
-              }
-            }
+            name: "assetShares";
+            type: {
+              defined: {
+                name: "wrappedI80f48";
+              };
+            };
           },
           {
-            "name": "liabilityShares",
-            "type": {
-              "defined": {
-                "name": "wrappedI80f48"
-              }
-            }
+            name: "liabilityShares";
+            type: {
+              defined: {
+                name: "wrappedI80f48";
+              };
+            };
           },
           {
-            "name": "emissionsOutstanding",
-            "type": {
-              "defined": {
-                "name": "wrappedI80f48"
-              }
-            }
+            name: "emissionsOutstanding";
+            type: {
+              defined: {
+                name: "wrappedI80f48";
+              };
+            };
           },
           {
-            "name": "lastUpdate",
-            "type": "u64"
+            name: "lastUpdate";
+            type: "u64";
           },
           {
-            "name": "padding",
-            "type": {
-              "array": [
-                "u64",
-                1
-              ]
-            }
+            name: "padding";
+            type: {
+              array: ["u64", 1];
+            };
           }
-        ]
-      }
+        ];
+      };
     },
     {
-      "name": "bank",
-      "serialization": "bytemuckunsafe",
-      "repr": {
-        "kind": "c"
-      },
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: "bank";
+      serialization: "bytemuckunsafe";
+      repr: {
+        kind: "c";
+      };
+      type: {
+        kind: "struct";
+        fields: [
           {
-            "name": "mint",
-            "type": "pubkey"
+            name: "mint";
+            type: "pubkey";
           },
           {
-            "name": "mintDecimals",
-            "type": "u8"
+            name: "mintDecimals";
+            type: "u8";
           },
           {
-            "name": "group",
-            "type": "pubkey"
+            name: "group";
+            type: "pubkey";
           },
           {
-            "name": "pad0",
-            "type": {
-              "array": [
-                "u8",
-                7
-              ]
-            }
+            name: "pad0";
+            type: {
+              array: ["u8", 7];
+            };
           },
           {
-            "name": "assetShareValue",
-            "type": {
-              "defined": {
-                "name": "wrappedI80f48"
-              }
-            }
+            name: "assetShareValue";
+            type: {
+              defined: {
+                name: "wrappedI80f48";
+              };
+            };
           },
           {
-            "name": "liabilityShareValue",
-            "type": {
-              "defined": {
-                "name": "wrappedI80f48"
-              }
-            }
+            name: "liabilityShareValue";
+            type: {
+              defined: {
+                name: "wrappedI80f48";
+              };
+            };
           },
           {
-            "name": "liquidityVault",
-            "type": "pubkey"
+            name: "liquidityVault";
+            type: "pubkey";
           },
           {
-            "name": "liquidityVaultBump",
-            "type": "u8"
+            name: "liquidityVaultBump";
+            type: "u8";
           },
           {
-            "name": "liquidityVaultAuthorityBump",
-            "type": "u8"
+            name: "liquidityVaultAuthorityBump";
+            type: "u8";
           },
           {
-            "name": "insuranceVault",
-            "type": "pubkey"
+            name: "insuranceVault";
+            type: "pubkey";
           },
           {
-            "name": "insuranceVaultBump",
-            "type": "u8"
+            name: "insuranceVaultBump";
+            type: "u8";
           },
           {
-            "name": "insuranceVaultAuthorityBump",
-            "type": "u8"
+            name: "insuranceVaultAuthorityBump";
+            type: "u8";
           },
           {
-            "name": "pad1",
-            "type": {
-              "array": [
-                "u8",
-                4
-              ]
-            }
+            name: "pad1";
+            type: {
+              array: ["u8", 4];
+            };
           },
           {
-            "name": "collectedInsuranceFeesOutstanding",
-            "type": {
-              "defined": {
-                "name": "wrappedI80f48"
-              }
-            }
+            name: "collectedInsuranceFeesOutstanding";
+            docs: ["Fees collected and pending withdraw for the `insurance_vault`"];
+            type: {
+              defined: {
+                name: "wrappedI80f48";
+              };
+            };
           },
           {
-            "name": "feeVault",
-            "type": "pubkey"
+            name: "feeVault";
+            type: "pubkey";
           },
           {
-            "name": "feeVaultBump",
-            "type": "u8"
+            name: "feeVaultBump";
+            type: "u8";
           },
           {
-            "name": "feeVaultAuthorityBump",
-            "type": "u8"
+            name: "feeVaultAuthorityBump";
+            type: "u8";
           },
           {
-            "name": "pad2",
-            "type": {
-              "array": [
-                "u8",
-                6
-              ]
-            }
+            name: "pad2";
+            type: {
+              array: ["u8", 6];
+            };
           },
           {
-            "name": "collectedGroupFeesOutstanding",
-            "type": {
-              "defined": {
-                "name": "wrappedI80f48"
-              }
-            }
+            name: "collectedGroupFeesOutstanding";
+            docs: ["Fees collected and pending withdraw for the `fee_vault`"];
+            type: {
+              defined: {
+                name: "wrappedI80f48";
+              };
+            };
           },
           {
-            "name": "totalLiabilityShares",
-            "type": {
-              "defined": {
-                "name": "wrappedI80f48"
-              }
-            }
+            name: "totalLiabilityShares";
+            type: {
+              defined: {
+                name: "wrappedI80f48";
+              };
+            };
           },
           {
-            "name": "totalAssetShares",
-            "type": {
-              "defined": {
-                "name": "wrappedI80f48"
-              }
-            }
+            name: "totalAssetShares";
+            type: {
+              defined: {
+                name: "wrappedI80f48";
+              };
+            };
           },
           {
-            "name": "lastUpdate",
-            "type": "i64"
+            name: "lastUpdate";
+            type: "i64";
           },
           {
-            "name": "config",
-            "type": {
-              "defined": {
-                "name": "bankConfig"
-              }
-            }
+            name: "config";
+            type: {
+              defined: {
+                name: "bankConfig";
+              };
+            };
           },
           {
-            "name": "flags",
-            "docs": [
+            name: "flags";
+            docs: [
               "Bank Config Flags",
               "",
               "- EMISSIONS_FLAG_BORROW_ACTIVE: 1",
               "- EMISSIONS_FLAG_LENDING_ACTIVE: 2",
               "- PERMISSIONLESS_BAD_DEBT_SETTLEMENT: 4",
               ""
-            ],
-            "type": "u64"
+            ];
+            type: "u64";
           },
           {
-            "name": "emissionsRate",
-            "docs": [
+            name: "emissionsRate";
+            docs: [
               "Emissions APR.",
               "Number of emitted tokens (emissions_mint) per 1e(bank.mint_decimal) tokens (bank mint) (native amount) per 1 YEAR."
-            ],
-            "type": "u64"
+            ];
+            type: "u64";
           },
           {
-            "name": "emissionsRemaining",
-            "type": {
-              "defined": {
-                "name": "wrappedI80f48"
-              }
-            }
+            name: "emissionsRemaining";
+            type: {
+              defined: {
+                name: "wrappedI80f48";
+              };
+            };
           },
           {
-            "name": "emissionsMint",
-            "type": "pubkey"
+            name: "emissionsMint";
+            type: "pubkey";
           },
           {
-            "name": "padding0",
-            "type": {
-              "array": [
+            name: "collectedProgramFeesOutstanding";
+            docs: [
+              "Fees collected and pending withdraw for the `FeeState.global_fee_wallet`'s cannonical ATA for `mint`"
+            ];
+            type: {
+              defined: {
+                name: "wrappedI80f48";
+              };
+            };
+          },
+          {
+            name: "padding0";
+            type: {
+              array: [
                 {
-                  "array": [
-                    "u64",
-                    2
-                  ]
+                  array: ["u64", 2];
                 },
-                28
-              ]
-            }
+                27
+              ];
+            };
           },
           {
-            "name": "padding1",
-            "type": {
-              "array": [
+            name: "padding1";
+            type: {
+              array: [
                 {
-                  "array": [
-                    "u64",
-                    2
-                  ]
+                  array: ["u64", 2];
                 },
                 32
-              ]
-            }
+              ];
+            };
           }
-        ]
-      }
+        ];
+      };
     },
     {
-      "name": "bankConfig",
-      "docs": [
-        "TODO: Convert weights to (u64, u64) to avoid precision loss (maybe?)"
-      ],
-      "serialization": "bytemuckunsafe",
-      "repr": {
-        "kind": "c"
-      },
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: "bankConfig";
+      docs: ["TODO: Convert weights to (u64, u64) to avoid precision loss (maybe?)"];
+      serialization: "bytemuckunsafe";
+      repr: {
+        kind: "c";
+      };
+      type: {
+        kind: "struct";
+        fields: [
           {
-            "name": "assetWeightInit",
-            "type": {
-              "defined": {
-                "name": "wrappedI80f48"
-              }
-            }
+            name: "assetWeightInit";
+            type: {
+              defined: {
+                name: "wrappedI80f48";
+              };
+            };
           },
           {
-            "name": "assetWeightMaint",
-            "type": {
-              "defined": {
-                "name": "wrappedI80f48"
-              }
-            }
+            name: "assetWeightMaint";
+            type: {
+              defined: {
+                name: "wrappedI80f48";
+              };
+            };
           },
           {
-            "name": "liabilityWeightInit",
-            "type": {
-              "defined": {
-                "name": "wrappedI80f48"
-              }
-            }
+            name: "liabilityWeightInit";
+            type: {
+              defined: {
+                name: "wrappedI80f48";
+              };
+            };
           },
           {
-            "name": "liabilityWeightMaint",
-            "type": {
-              "defined": {
-                "name": "wrappedI80f48"
-              }
-            }
+            name: "liabilityWeightMaint";
+            type: {
+              defined: {
+                name: "wrappedI80f48";
+              };
+            };
           },
           {
-            "name": "depositLimit",
-            "type": "u64"
+            name: "depositLimit";
+            type: "u64";
           },
           {
-            "name": "interestRateConfig",
-            "type": {
-              "defined": {
-                "name": "interestRateConfig"
-              }
-            }
+            name: "interestRateConfig";
+            type: {
+              defined: {
+                name: "interestRateConfig";
+              };
+            };
           },
           {
-            "name": "operationalState",
-            "type": {
-              "defined": {
-                "name": "bankOperationalState"
-              }
-            }
+            name: "operationalState";
+            type: {
+              defined: {
+                name: "bankOperationalState";
+              };
+            };
           },
           {
-            "name": "oracleSetup",
-            "type": {
-              "defined": {
-                "name": "oracleSetup"
-              }
-            }
+            name: "oracleSetup";
+            type: {
+              defined: {
+                name: "oracleSetup";
+              };
+            };
           },
           {
-            "name": "oracleKeys",
-            "type": {
-              "array": [
-                "pubkey",
-                5
-              ]
-            }
+            name: "oracleKeys";
+            type: {
+              array: ["pubkey", 5];
+            };
           },
           {
-            "name": "pad0",
-            "type": {
-              "array": [
-                "u8",
-                6
-              ]
-            }
+            name: "pad0";
+            type: {
+              array: ["u8", 6];
+            };
           },
           {
-            "name": "borrowLimit",
-            "type": "u64"
+            name: "borrowLimit";
+            type: "u64";
           },
           {
-            "name": "riskTier",
-            "type": {
-              "defined": {
-                "name": "riskTier"
-              }
-            }
+            name: "riskTier";
+            type: {
+              defined: {
+                name: "riskTier";
+              };
+            };
           },
           {
-            "name": "pad1",
-            "type": {
-              "array": [
-                "u8",
-                7
-              ]
-            }
+            name: "pad1";
+            type: {
+              array: ["u8", 7];
+            };
           },
           {
-            "name": "totalAssetValueInitLimit",
-            "docs": [
+            name: "totalAssetValueInitLimit";
+            docs: [
               "USD denominated limit for calculating asset value for initialization margin requirements.",
               "Example, if total SOL deposits are equal to $1M and the limit it set to $500K,",
               "then SOL assets will be discounted by 50%.",
@@ -3232,127 +2185,117 @@ export type Marginfi = {
               "This is useful for limiting the damage of orcale attacks.",
               "",
               "Value is UI USD value, for example value 100 -> $100"
-            ],
-            "type": "u64"
+            ];
+            type: "u64";
           },
           {
-            "name": "oracleMaxAge",
-            "docs": [
-              "Time window in seconds for the oracle price feed to be considered live."
-            ],
-            "type": "u16"
+            name: "oracleMaxAge";
+            docs: ["Time window in seconds for the oracle price feed to be considered live."];
+            type: "u16";
           },
           {
-            "name": "padding",
-            "type": {
-              "array": [
-                "u8",
-                38
-              ]
-            }
+            name: "padding";
+            type: {
+              array: ["u8", 38];
+            };
           }
-        ]
-      }
+        ];
+      };
     },
     {
-      "name": "bankConfigCompact",
-      "docs": [
-        "TODO: Convert weights to (u64, u64) to avoid precision loss (maybe?)"
-      ],
-      "repr": {
-        "kind": "c"
-      },
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: "bankConfigCompact";
+      docs: ["TODO: Convert weights to (u64, u64) to avoid precision loss (maybe?)"];
+      repr: {
+        kind: "c";
+      };
+      type: {
+        kind: "struct";
+        fields: [
           {
-            "name": "assetWeightInit",
-            "type": {
-              "defined": {
-                "name": "wrappedI80f48"
-              }
-            }
+            name: "assetWeightInit";
+            type: {
+              defined: {
+                name: "wrappedI80f48";
+              };
+            };
           },
           {
-            "name": "assetWeightMaint",
-            "type": {
-              "defined": {
-                "name": "wrappedI80f48"
-              }
-            }
+            name: "assetWeightMaint";
+            type: {
+              defined: {
+                name: "wrappedI80f48";
+              };
+            };
           },
           {
-            "name": "liabilityWeightInit",
-            "type": {
-              "defined": {
-                "name": "wrappedI80f48"
-              }
-            }
+            name: "liabilityWeightInit";
+            type: {
+              defined: {
+                name: "wrappedI80f48";
+              };
+            };
           },
           {
-            "name": "liabilityWeightMaint",
-            "type": {
-              "defined": {
-                "name": "wrappedI80f48"
-              }
-            }
+            name: "liabilityWeightMaint";
+            type: {
+              defined: {
+                name: "wrappedI80f48";
+              };
+            };
           },
           {
-            "name": "depositLimit",
-            "type": "u64"
+            name: "depositLimit";
+            type: "u64";
           },
           {
-            "name": "interestRateConfig",
-            "type": {
-              "defined": {
-                "name": "interestRateConfigCompact"
-              }
-            }
+            name: "interestRateConfig";
+            type: {
+              defined: {
+                name: "interestRateConfigCompact";
+              };
+            };
           },
           {
-            "name": "operationalState",
-            "type": {
-              "defined": {
-                "name": "bankOperationalState"
-              }
-            }
+            name: "operationalState";
+            type: {
+              defined: {
+                name: "bankOperationalState";
+              };
+            };
           },
           {
-            "name": "oracleSetup",
-            "type": {
-              "defined": {
-                "name": "oracleSetup"
-              }
-            }
+            name: "oracleSetup";
+            type: {
+              defined: {
+                name: "oracleSetup";
+              };
+            };
           },
           {
-            "name": "oracleKey",
-            "type": "pubkey"
+            name: "oracleKey";
+            type: "pubkey";
           },
           {
-            "name": "borrowLimit",
-            "type": "u64"
+            name: "borrowLimit";
+            type: "u64";
           },
           {
-            "name": "riskTier",
-            "type": {
-              "defined": {
-                "name": "riskTier"
-              }
-            }
+            name: "riskTier";
+            type: {
+              defined: {
+                name: "riskTier";
+              };
+            };
           },
           {
-            "name": "pad0",
-            "type": {
-              "array": [
-                "u8",
-                7
-              ]
-            }
+            name: "pad0";
+            type: {
+              array: ["u8", 7];
+            };
           },
           {
-            "name": "totalAssetValueInitLimit",
-            "docs": [
+            name: "totalAssetValueInitLimit";
+            docs: [
               "USD denominated limit for calculating asset value for initialization margin requirements.",
               "Example, if total SOL deposits are equal to $1M and the limit it set to $500K,",
               "then SOL assets will be discounted by 50%.",
@@ -3361,1088 +2304,1240 @@ export type Marginfi = {
               "This is useful for limiting the damage of orcale attacks.",
               "",
               "Value is UI USD value, for example value 100 -> $100"
-            ],
-            "type": "u64"
+            ];
+            type: "u64";
           },
           {
-            "name": "oracleMaxAge",
-            "docs": [
-              "Time window in seconds for the oracle price feed to be considered live."
-            ],
-            "type": "u16"
+            name: "oracleMaxAge";
+            docs: ["Time window in seconds for the oracle price feed to be considered live."];
+            type: "u16";
           }
-        ]
-      }
+        ];
+      };
     },
     {
-      "name": "bankConfigOpt",
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: "bankConfigOpt";
+      type: {
+        kind: "struct";
+        fields: [
           {
-            "name": "assetWeightInit",
-            "type": {
-              "option": {
-                "defined": {
-                  "name": "wrappedI80f48"
-                }
-              }
-            }
+            name: "assetWeightInit";
+            type: {
+              option: {
+                defined: {
+                  name: "wrappedI80f48";
+                };
+              };
+            };
           },
           {
-            "name": "assetWeightMaint",
-            "type": {
-              "option": {
-                "defined": {
-                  "name": "wrappedI80f48"
-                }
-              }
-            }
+            name: "assetWeightMaint";
+            type: {
+              option: {
+                defined: {
+                  name: "wrappedI80f48";
+                };
+              };
+            };
           },
           {
-            "name": "liabilityWeightInit",
-            "type": {
-              "option": {
-                "defined": {
-                  "name": "wrappedI80f48"
-                }
-              }
-            }
+            name: "liabilityWeightInit";
+            type: {
+              option: {
+                defined: {
+                  name: "wrappedI80f48";
+                };
+              };
+            };
           },
           {
-            "name": "liabilityWeightMaint",
-            "type": {
-              "option": {
-                "defined": {
-                  "name": "wrappedI80f48"
-                }
-              }
-            }
+            name: "liabilityWeightMaint";
+            type: {
+              option: {
+                defined: {
+                  name: "wrappedI80f48";
+                };
+              };
+            };
           },
           {
-            "name": "depositLimit",
-            "type": {
-              "option": "u64"
-            }
+            name: "depositLimit";
+            type: {
+              option: "u64";
+            };
           },
           {
-            "name": "borrowLimit",
-            "type": {
-              "option": "u64"
-            }
+            name: "borrowLimit";
+            type: {
+              option: "u64";
+            };
           },
           {
-            "name": "operationalState",
-            "type": {
-              "option": {
-                "defined": {
-                  "name": "bankOperationalState"
-                }
-              }
-            }
+            name: "operationalState";
+            type: {
+              option: {
+                defined: {
+                  name: "bankOperationalState";
+                };
+              };
+            };
           },
           {
-            "name": "oracle",
-            "type": {
-              "option": {
-                "defined": {
-                  "name": "oracleConfig"
-                }
-              }
-            }
+            name: "oracle";
+            type: {
+              option: {
+                defined: {
+                  name: "oracleConfig";
+                };
+              };
+            };
           },
           {
-            "name": "interestRateConfig",
-            "type": {
-              "option": {
-                "defined": {
-                  "name": "interestRateConfigOpt"
-                }
-              }
-            }
+            name: "interestRateConfig";
+            type: {
+              option: {
+                defined: {
+                  name: "interestRateConfigOpt";
+                };
+              };
+            };
           },
           {
-            "name": "riskTier",
-            "type": {
-              "option": {
-                "defined": {
-                  "name": "riskTier"
-                }
-              }
-            }
+            name: "riskTier";
+            type: {
+              option: {
+                defined: {
+                  name: "riskTier";
+                };
+              };
+            };
           },
           {
-            "name": "totalAssetValueInitLimit",
-            "type": {
-              "option": "u64"
-            }
+            name: "totalAssetValueInitLimit";
+            type: {
+              option: "u64";
+            };
           },
           {
-            "name": "oracleMaxAge",
-            "type": {
-              "option": "u16"
-            }
+            name: "oracleMaxAge";
+            type: {
+              option: "u16";
+            };
           },
           {
-            "name": "permissionlessBadDebtSettlement",
-            "type": {
-              "option": "bool"
-            }
+            name: "permissionlessBadDebtSettlement";
+            type: {
+              option: "bool";
+            };
           }
-        ]
-      }
+        ];
+      };
     },
     {
-      "name": "bankOperationalState",
-      "repr": {
-        "kind": "rust"
-      },
-      "type": {
-        "kind": "enum",
-        "variants": [
+      name: "bankOperationalState";
+      repr: {
+        kind: "rust";
+      };
+      type: {
+        kind: "enum";
+        variants: [
           {
-            "name": "paused"
+            name: "paused";
           },
           {
-            "name": "operational"
+            name: "operational";
           },
           {
-            "name": "reduceOnly"
+            name: "reduceOnly";
           }
-        ]
-      }
+        ];
+      };
     },
     {
-      "name": "groupConfig",
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: "feeState";
+      docs: ["Unique per-program. The Program Owner uses this account to administrate fees collected by the protocol"];
+      serialization: "bytemuck";
+      repr: {
+        kind: "c";
+      };
+      type: {
+        kind: "struct";
+        fields: [
           {
-            "name": "admin",
-            "type": {
-              "option": "pubkey"
-            }
+            name: "key";
+            docs: ['The fee state\'s own key. A PDA derived from just `b"feestate"`'];
+            type: "pubkey";
+          },
+          {
+            name: "globalFeeAdmin";
+            docs: ["Can modify fees"];
+            type: "pubkey";
+          },
+          {
+            name: "globalFeeWallet";
+            docs: [
+              "The base wallet for all protocol fees. All SOL fees go to this wallet. All non-SOL fees go",
+              "to the cannonical ATA of this wallet for that asset."
+            ];
+            type: "pubkey";
+          },
+          {
+            name: "placeholder0";
+            type: "u64";
+          },
+          {
+            name: "bankInitFlatSolFee";
+            docs: ["Flat fee assessed when a new bank is initialized, in lamports.", "* In SOL, in native decimals."];
+            type: "u32";
+          },
+          {
+            name: "bumpSeed";
+            type: "u8";
+          },
+          {
+            name: "padding0";
+            type: {
+              array: ["u8", 4];
+            };
+          },
+          {
+            name: "padding1";
+            type: {
+              array: ["u8", 15];
+            };
+          },
+          {
+            name: "programFeeFixed";
+            docs: ["Fee collected by the program owner from all groups"];
+            type: {
+              defined: {
+                name: "wrappedI80f48";
+              };
+            };
+          },
+          {
+            name: "programFeeRate";
+            docs: ["Fee collected by the program owner from all groups"];
+            type: {
+              defined: {
+                name: "wrappedI80f48";
+              };
+            };
+          },
+          {
+            name: "reserved0";
+            type: {
+              array: ["u8", 32];
+            };
+          },
+          {
+            name: "reserved1";
+            type: {
+              array: ["u8", 64];
+            };
           }
-        ]
-      }
+        ];
+      };
     },
     {
-      "name": "groupEventHeader",
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: "feeStateCache";
+      repr: {
+        kind: "c";
+      };
+      type: {
+        kind: "struct";
+        fields: [
           {
-            "name": "signer",
-            "type": {
-              "option": "pubkey"
-            }
+            name: "globalFeeWallet";
+            type: "pubkey";
           },
           {
-            "name": "marginfiGroup",
-            "type": "pubkey"
+            name: "programFeeFixed";
+            type: {
+              defined: {
+                name: "wrappedI80f48";
+              };
+            };
+          },
+          {
+            name: "programFeeRate";
+            type: {
+              defined: {
+                name: "wrappedI80f48";
+              };
+            };
           }
-        ]
-      }
+        ];
+      };
     },
     {
-      "name": "interestRateConfig",
-      "serialization": "bytemuck",
-      "repr": {
-        "kind": "c"
-      },
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: "groupConfig";
+      type: {
+        kind: "struct";
+        fields: [
           {
-            "name": "optimalUtilizationRate",
-            "type": {
-              "defined": {
-                "name": "wrappedI80f48"
-              }
-            }
+            name: "admin";
+            type: {
+              option: "pubkey";
+            };
+          }
+        ];
+      };
+    },
+    {
+      name: "groupEventHeader";
+      type: {
+        kind: "struct";
+        fields: [
+          {
+            name: "signer";
+            type: {
+              option: "pubkey";
+            };
           },
           {
-            "name": "plateauInterestRate",
-            "type": {
-              "defined": {
-                "name": "wrappedI80f48"
-              }
-            }
+            name: "marginfiGroup";
+            type: "pubkey";
+          }
+        ];
+      };
+    },
+    {
+      name: "interestRateConfig";
+      serialization: "bytemuck";
+      repr: {
+        kind: "c";
+      };
+      type: {
+        kind: "struct";
+        fields: [
+          {
+            name: "optimalUtilizationRate";
+            type: {
+              defined: {
+                name: "wrappedI80f48";
+              };
+            };
           },
           {
-            "name": "maxInterestRate",
-            "type": {
-              "defined": {
-                "name": "wrappedI80f48"
-              }
-            }
+            name: "plateauInterestRate";
+            type: {
+              defined: {
+                name: "wrappedI80f48";
+              };
+            };
           },
           {
-            "name": "insuranceFeeFixedApr",
-            "type": {
-              "defined": {
-                "name": "wrappedI80f48"
-              }
-            }
+            name: "maxInterestRate";
+            type: {
+              defined: {
+                name: "wrappedI80f48";
+              };
+            };
           },
           {
-            "name": "insuranceIrFee",
-            "type": {
-              "defined": {
-                "name": "wrappedI80f48"
-              }
-            }
+            name: "insuranceFeeFixedApr";
+            docs: ["Goes to insurance, funds `collected_insurance_fees_outstanding`"];
+            type: {
+              defined: {
+                name: "wrappedI80f48";
+              };
+            };
           },
           {
-            "name": "protocolFixedFeeApr",
-            "type": {
-              "defined": {
-                "name": "wrappedI80f48"
-              }
-            }
+            name: "insuranceIrFee";
+            docs: ["Goes to insurance, funds `collected_insurance_fees_outstanding`"];
+            type: {
+              defined: {
+                name: "wrappedI80f48";
+              };
+            };
           },
           {
-            "name": "protocolIrFee",
-            "type": {
-              "defined": {
-                "name": "wrappedI80f48"
-              }
-            }
+            name: "protocolFixedFeeApr";
+            docs: ["Earned by the group, goes to `collected_group_fees_outstanding`"];
+            type: {
+              defined: {
+                name: "wrappedI80f48";
+              };
+            };
           },
           {
-            "name": "padding",
-            "type": {
-              "array": [
+            name: "protocolIrFee";
+            docs: ["Earned by the group, goes to `collected_group_fees_outstanding`"];
+            type: {
+              defined: {
+                name: "wrappedI80f48";
+              };
+            };
+          },
+          {
+            name: "protocolOriginationFee";
+            type: {
+              defined: {
+                name: "wrappedI80f48";
+              };
+            };
+          },
+          {
+            name: "padding0";
+            type: {
+              array: ["u8", 16];
+            };
+          },
+          {
+            name: "padding1";
+            type: {
+              array: [
                 {
-                  "array": [
-                    "u64",
-                    2
-                  ]
+                  array: ["u8", 32];
                 },
-                8
-              ]
-            }
+                3
+              ];
+            };
           }
-        ]
-      }
+        ];
+      };
     },
     {
-      "name": "interestRateConfigCompact",
-      "repr": {
-        "kind": "c"
-      },
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: "interestRateConfigCompact";
+      repr: {
+        kind: "c";
+      };
+      type: {
+        kind: "struct";
+        fields: [
           {
-            "name": "optimalUtilizationRate",
-            "type": {
-              "defined": {
-                "name": "wrappedI80f48"
-              }
-            }
+            name: "optimalUtilizationRate";
+            type: {
+              defined: {
+                name: "wrappedI80f48";
+              };
+            };
           },
           {
-            "name": "plateauInterestRate",
-            "type": {
-              "defined": {
-                "name": "wrappedI80f48"
-              }
-            }
+            name: "plateauInterestRate";
+            type: {
+              defined: {
+                name: "wrappedI80f48";
+              };
+            };
           },
           {
-            "name": "maxInterestRate",
-            "type": {
-              "defined": {
-                "name": "wrappedI80f48"
-              }
-            }
+            name: "maxInterestRate";
+            type: {
+              defined: {
+                name: "wrappedI80f48";
+              };
+            };
           },
           {
-            "name": "insuranceFeeFixedApr",
-            "type": {
-              "defined": {
-                "name": "wrappedI80f48"
-              }
-            }
+            name: "insuranceFeeFixedApr";
+            type: {
+              defined: {
+                name: "wrappedI80f48";
+              };
+            };
           },
           {
-            "name": "insuranceIrFee",
-            "type": {
-              "defined": {
-                "name": "wrappedI80f48"
-              }
-            }
+            name: "insuranceIrFee";
+            type: {
+              defined: {
+                name: "wrappedI80f48";
+              };
+            };
           },
           {
-            "name": "protocolFixedFeeApr",
-            "type": {
-              "defined": {
-                "name": "wrappedI80f48"
-              }
-            }
+            name: "protocolFixedFeeApr";
+            type: {
+              defined: {
+                name: "wrappedI80f48";
+              };
+            };
           },
           {
-            "name": "protocolIrFee",
-            "type": {
-              "defined": {
-                "name": "wrappedI80f48"
-              }
-            }
+            name: "protocolIrFee";
+            type: {
+              defined: {
+                name: "wrappedI80f48";
+              };
+            };
+          },
+          {
+            name: "protocolOriginationFee";
+            type: {
+              defined: {
+                name: "wrappedI80f48";
+              };
+            };
           }
-        ]
-      }
+        ];
+      };
     },
     {
-      "name": "interestRateConfigOpt",
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: "interestRateConfigOpt";
+      type: {
+        kind: "struct";
+        fields: [
           {
-            "name": "optimalUtilizationRate",
-            "type": {
-              "option": {
-                "defined": {
-                  "name": "wrappedI80f48"
-                }
-              }
-            }
+            name: "optimalUtilizationRate";
+            type: {
+              option: {
+                defined: {
+                  name: "wrappedI80f48";
+                };
+              };
+            };
           },
           {
-            "name": "plateauInterestRate",
-            "type": {
-              "option": {
-                "defined": {
-                  "name": "wrappedI80f48"
-                }
-              }
-            }
+            name: "plateauInterestRate";
+            type: {
+              option: {
+                defined: {
+                  name: "wrappedI80f48";
+                };
+              };
+            };
           },
           {
-            "name": "maxInterestRate",
-            "type": {
-              "option": {
-                "defined": {
-                  "name": "wrappedI80f48"
-                }
-              }
-            }
+            name: "maxInterestRate";
+            type: {
+              option: {
+                defined: {
+                  name: "wrappedI80f48";
+                };
+              };
+            };
           },
           {
-            "name": "insuranceFeeFixedApr",
-            "type": {
-              "option": {
-                "defined": {
-                  "name": "wrappedI80f48"
-                }
-              }
-            }
+            name: "insuranceFeeFixedApr";
+            type: {
+              option: {
+                defined: {
+                  name: "wrappedI80f48";
+                };
+              };
+            };
           },
           {
-            "name": "insuranceIrFee",
-            "type": {
-              "option": {
-                "defined": {
-                  "name": "wrappedI80f48"
-                }
-              }
-            }
+            name: "insuranceIrFee";
+            type: {
+              option: {
+                defined: {
+                  name: "wrappedI80f48";
+                };
+              };
+            };
           },
           {
-            "name": "protocolFixedFeeApr",
-            "type": {
-              "option": {
-                "defined": {
-                  "name": "wrappedI80f48"
-                }
-              }
-            }
+            name: "protocolFixedFeeApr";
+            type: {
+              option: {
+                defined: {
+                  name: "wrappedI80f48";
+                };
+              };
+            };
           },
           {
-            "name": "protocolIrFee",
-            "type": {
-              "option": {
-                "defined": {
-                  "name": "wrappedI80f48"
-                }
-              }
-            }
+            name: "protocolIrFee";
+            type: {
+              option: {
+                defined: {
+                  name: "wrappedI80f48";
+                };
+              };
+            };
+          },
+          {
+            name: "protocolOriginationFee";
+            type: {
+              option: {
+                defined: {
+                  name: "wrappedI80f48";
+                };
+              };
+            };
           }
-        ]
-      }
+        ];
+      };
     },
     {
-      "name": "lendingAccount",
-      "serialization": "bytemuckunsafe",
-      "repr": {
-        "kind": "c"
-      },
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: "lendingAccount";
+      serialization: "bytemuckunsafe";
+      repr: {
+        kind: "c";
+      };
+      type: {
+        kind: "struct";
+        fields: [
           {
-            "name": "balances",
-            "type": {
-              "array": [
+            name: "balances";
+            type: {
+              array: [
                 {
-                  "defined": {
-                    "name": "balance"
-                  }
+                  defined: {
+                    name: "balance";
+                  };
                 },
                 16
-              ]
-            }
+              ];
+            };
           },
           {
-            "name": "padding",
-            "type": {
-              "array": [
-                "u64",
-                8
-              ]
-            }
+            name: "padding";
+            type: {
+              array: ["u64", 8];
+            };
           }
-        ]
-      }
+        ];
+      };
     },
     {
-      "name": "lendingAccountBorrowEvent",
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: "lendingAccountBorrowEvent";
+      type: {
+        kind: "struct";
+        fields: [
           {
-            "name": "header",
-            "type": {
-              "defined": {
-                "name": "accountEventHeader"
-              }
-            }
+            name: "header";
+            type: {
+              defined: {
+                name: "accountEventHeader";
+              };
+            };
           },
           {
-            "name": "bank",
-            "type": "pubkey"
+            name: "bank";
+            type: "pubkey";
           },
           {
-            "name": "mint",
-            "type": "pubkey"
+            name: "mint";
+            type: "pubkey";
           },
           {
-            "name": "amount",
-            "type": "u64"
+            name: "amount";
+            type: "u64";
           }
-        ]
-      }
+        ];
+      };
     },
     {
-      "name": "lendingAccountDepositEvent",
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: "lendingAccountDepositEvent";
+      type: {
+        kind: "struct";
+        fields: [
           {
-            "name": "header",
-            "type": {
-              "defined": {
-                "name": "accountEventHeader"
-              }
-            }
+            name: "header";
+            type: {
+              defined: {
+                name: "accountEventHeader";
+              };
+            };
           },
           {
-            "name": "bank",
-            "type": "pubkey"
+            name: "bank";
+            type: "pubkey";
           },
           {
-            "name": "mint",
-            "type": "pubkey"
+            name: "mint";
+            type: "pubkey";
           },
           {
-            "name": "amount",
-            "type": "u64"
+            name: "amount";
+            type: "u64";
           }
-        ]
-      }
+        ];
+      };
     },
     {
-      "name": "lendingAccountLiquidateEvent",
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: "lendingAccountLiquidateEvent";
+      type: {
+        kind: "struct";
+        fields: [
           {
-            "name": "header",
-            "type": {
-              "defined": {
-                "name": "accountEventHeader"
-              }
-            }
+            name: "header";
+            type: {
+              defined: {
+                name: "accountEventHeader";
+              };
+            };
           },
           {
-            "name": "liquidateeMarginfiAccount",
-            "type": "pubkey"
+            name: "liquidateeMarginfiAccount";
+            type: "pubkey";
           },
           {
-            "name": "liquidateeMarginfiAccountAuthority",
-            "type": "pubkey"
+            name: "liquidateeMarginfiAccountAuthority";
+            type: "pubkey";
           },
           {
-            "name": "assetBank",
-            "type": "pubkey"
+            name: "assetBank";
+            type: "pubkey";
           },
           {
-            "name": "assetMint",
-            "type": "pubkey"
+            name: "assetMint";
+            type: "pubkey";
           },
           {
-            "name": "liabilityBank",
-            "type": "pubkey"
+            name: "liabilityBank";
+            type: "pubkey";
           },
           {
-            "name": "liabilityMint",
-            "type": "pubkey"
+            name: "liabilityMint";
+            type: "pubkey";
           },
           {
-            "name": "liquidateePreHealth",
-            "type": "f64"
+            name: "liquidateePreHealth";
+            type: "f64";
           },
           {
-            "name": "liquidateePostHealth",
-            "type": "f64"
+            name: "liquidateePostHealth";
+            type: "f64";
           },
           {
-            "name": "preBalances",
-            "type": {
-              "defined": {
-                "name": "liquidationBalances"
-              }
-            }
+            name: "preBalances";
+            type: {
+              defined: {
+                name: "liquidationBalances";
+              };
+            };
           },
           {
-            "name": "postBalances",
-            "type": {
-              "defined": {
-                "name": "liquidationBalances"
-              }
-            }
+            name: "postBalances";
+            type: {
+              defined: {
+                name: "liquidationBalances";
+              };
+            };
           }
-        ]
-      }
+        ];
+      };
     },
     {
-      "name": "lendingAccountRepayEvent",
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: "lendingAccountRepayEvent";
+      type: {
+        kind: "struct";
+        fields: [
           {
-            "name": "header",
-            "type": {
-              "defined": {
-                "name": "accountEventHeader"
-              }
-            }
+            name: "header";
+            type: {
+              defined: {
+                name: "accountEventHeader";
+              };
+            };
           },
           {
-            "name": "bank",
-            "type": "pubkey"
+            name: "bank";
+            type: "pubkey";
           },
           {
-            "name": "mint",
-            "type": "pubkey"
+            name: "mint";
+            type: "pubkey";
           },
           {
-            "name": "amount",
-            "type": "u64"
+            name: "amount";
+            type: "u64";
           },
           {
-            "name": "closeBalance",
-            "type": "bool"
+            name: "closeBalance";
+            type: "bool";
           }
-        ]
-      }
+        ];
+      };
     },
     {
-      "name": "lendingAccountWithdrawEvent",
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: "lendingAccountWithdrawEvent";
+      type: {
+        kind: "struct";
+        fields: [
           {
-            "name": "header",
-            "type": {
-              "defined": {
-                "name": "accountEventHeader"
-              }
-            }
+            name: "header";
+            type: {
+              defined: {
+                name: "accountEventHeader";
+              };
+            };
           },
           {
-            "name": "bank",
-            "type": "pubkey"
+            name: "bank";
+            type: "pubkey";
           },
           {
-            "name": "mint",
-            "type": "pubkey"
+            name: "mint";
+            type: "pubkey";
           },
           {
-            "name": "amount",
-            "type": "u64"
+            name: "amount";
+            type: "u64";
           },
           {
-            "name": "closeBalance",
-            "type": "bool"
+            name: "closeBalance";
+            type: "bool";
           }
-        ]
-      }
+        ];
+      };
     },
     {
-      "name": "lendingPoolBankAccrueInterestEvent",
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: "lendingPoolBankAccrueInterestEvent";
+      type: {
+        kind: "struct";
+        fields: [
           {
-            "name": "header",
-            "type": {
-              "defined": {
-                "name": "groupEventHeader"
-              }
-            }
+            name: "header";
+            type: {
+              defined: {
+                name: "groupEventHeader";
+              };
+            };
           },
           {
-            "name": "bank",
-            "type": "pubkey"
+            name: "bank";
+            type: "pubkey";
           },
           {
-            "name": "mint",
-            "type": "pubkey"
+            name: "mint";
+            type: "pubkey";
           },
           {
-            "name": "delta",
-            "type": "u64"
+            name: "delta";
+            type: "u64";
           },
           {
-            "name": "feesCollected",
-            "type": "f64"
+            name: "feesCollected";
+            type: "f64";
           },
           {
-            "name": "insuranceCollected",
-            "type": "f64"
+            name: "insuranceCollected";
+            type: "f64";
           }
-        ]
-      }
+        ];
+      };
     },
     {
-      "name": "lendingPoolBankCollectFeesEvent",
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: "lendingPoolBankCollectFeesEvent";
+      type: {
+        kind: "struct";
+        fields: [
           {
-            "name": "header",
-            "type": {
-              "defined": {
-                "name": "groupEventHeader"
-              }
-            }
+            name: "header";
+            type: {
+              defined: {
+                name: "groupEventHeader";
+              };
+            };
           },
           {
-            "name": "bank",
-            "type": "pubkey"
+            name: "bank";
+            type: "pubkey";
           },
           {
-            "name": "mint",
-            "type": "pubkey"
+            name: "mint";
+            type: "pubkey";
           },
           {
-            "name": "groupFeesCollected",
-            "type": "f64"
+            name: "groupFeesCollected";
+            type: "f64";
           },
           {
-            "name": "groupFeesOutstanding",
-            "type": "f64"
+            name: "groupFeesOutstanding";
+            type: "f64";
           },
           {
-            "name": "insuranceFeesCollected",
-            "type": "f64"
+            name: "insuranceFeesCollected";
+            type: "f64";
           },
           {
-            "name": "insuranceFeesOutstanding",
-            "type": "f64"
+            name: "insuranceFeesOutstanding";
+            type: "f64";
           }
-        ]
-      }
+        ];
+      };
     },
     {
-      "name": "lendingPoolBankConfigureEvent",
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: "lendingPoolBankConfigureEvent";
+      type: {
+        kind: "struct";
+        fields: [
           {
-            "name": "header",
-            "type": {
-              "defined": {
-                "name": "groupEventHeader"
-              }
-            }
+            name: "header";
+            type: {
+              defined: {
+                name: "groupEventHeader";
+              };
+            };
           },
           {
-            "name": "bank",
-            "type": "pubkey"
+            name: "bank";
+            type: "pubkey";
           },
           {
-            "name": "mint",
-            "type": "pubkey"
+            name: "mint";
+            type: "pubkey";
           },
           {
-            "name": "config",
-            "type": {
-              "defined": {
-                "name": "bankConfigOpt"
-              }
-            }
+            name: "config";
+            type: {
+              defined: {
+                name: "bankConfigOpt";
+              };
+            };
           }
-        ]
-      }
+        ];
+      };
     },
     {
-      "name": "lendingPoolBankCreateEvent",
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: "lendingPoolBankCreateEvent";
+      type: {
+        kind: "struct";
+        fields: [
           {
-            "name": "header",
-            "type": {
-              "defined": {
-                "name": "groupEventHeader"
-              }
-            }
+            name: "header";
+            type: {
+              defined: {
+                name: "groupEventHeader";
+              };
+            };
           },
           {
-            "name": "bank",
-            "type": "pubkey"
+            name: "bank";
+            type: "pubkey";
           },
           {
-            "name": "mint",
-            "type": "pubkey"
+            name: "mint";
+            type: "pubkey";
           }
-        ]
-      }
+        ];
+      };
     },
     {
-      "name": "lendingPoolBankHandleBankruptcyEvent",
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: "lendingPoolBankHandleBankruptcyEvent";
+      type: {
+        kind: "struct";
+        fields: [
           {
-            "name": "header",
-            "type": {
-              "defined": {
-                "name": "accountEventHeader"
-              }
-            }
+            name: "header";
+            type: {
+              defined: {
+                name: "accountEventHeader";
+              };
+            };
           },
           {
-            "name": "bank",
-            "type": "pubkey"
+            name: "bank";
+            type: "pubkey";
           },
           {
-            "name": "mint",
-            "type": "pubkey"
+            name: "mint";
+            type: "pubkey";
           },
           {
-            "name": "badDebt",
-            "type": "f64"
+            name: "badDebt";
+            type: "f64";
           },
           {
-            "name": "coveredAmount",
-            "type": "f64"
+            name: "coveredAmount";
+            type: "f64";
           },
           {
-            "name": "socializedAmount",
-            "type": "f64"
+            name: "socializedAmount";
+            type: "f64";
           }
-        ]
-      }
+        ];
+      };
     },
     {
-      "name": "liquidationBalances",
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: "liquidationBalances";
+      type: {
+        kind: "struct";
+        fields: [
           {
-            "name": "liquidateeAssetBalance",
-            "type": "f64"
+            name: "liquidateeAssetBalance";
+            type: "f64";
           },
           {
-            "name": "liquidateeLiabilityBalance",
-            "type": "f64"
+            name: "liquidateeLiabilityBalance";
+            type: "f64";
           },
           {
-            "name": "liquidatorAssetBalance",
-            "type": "f64"
+            name: "liquidatorAssetBalance";
+            type: "f64";
           },
           {
-            "name": "liquidatorLiabilityBalance",
-            "type": "f64"
+            name: "liquidatorLiabilityBalance";
+            type: "f64";
           }
-        ]
-      }
+        ];
+      };
     },
     {
-      "name": "marginfiAccount",
-      "serialization": "bytemuckunsafe",
-      "repr": {
-        "kind": "c"
-      },
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: "marginfiAccount";
+      serialization: "bytemuckunsafe";
+      repr: {
+        kind: "c";
+      };
+      type: {
+        kind: "struct";
+        fields: [
           {
-            "name": "group",
-            "type": "pubkey"
+            name: "group";
+            type: "pubkey";
           },
           {
-            "name": "authority",
-            "type": "pubkey"
+            name: "authority";
+            type: "pubkey";
           },
           {
-            "name": "lendingAccount",
-            "type": {
-              "defined": {
-                "name": "lendingAccount"
-              }
-            }
+            name: "lendingAccount";
+            type: {
+              defined: {
+                name: "lendingAccount";
+              };
+            };
           },
           {
-            "name": "accountFlags",
-            "docs": [
+            name: "accountFlags";
+            docs: [
               "The flags that indicate the state of the account.",
               "This is u64 bitfield, where each bit represents a flag.",
               "",
               "Flags:",
               "- DISABLED_FLAG = 1 << 0 = 1 - This flag indicates that the account is disabled,",
               "and no further actions can be taken on it."
-            ],
-            "type": "u64"
+            ];
+            type: "u64";
           },
           {
-            "name": "padding",
-            "type": {
-              "array": [
-                "u64",
-                63
-              ]
-            }
+            name: "padding";
+            type: {
+              array: ["u64", 63];
+            };
           }
-        ]
-      }
+        ];
+      };
     },
     {
-      "name": "marginfiAccountCreateEvent",
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: "marginfiAccountCreateEvent";
+      type: {
+        kind: "struct";
+        fields: [
           {
-            "name": "header",
-            "type": {
-              "defined": {
-                "name": "accountEventHeader"
-              }
-            }
+            name: "header";
+            type: {
+              defined: {
+                name: "accountEventHeader";
+              };
+            };
           }
-        ]
-      }
+        ];
+      };
     },
     {
-      "name": "marginfiAccountTransferAccountAuthorityEvent",
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: "marginfiAccountTransferAccountAuthorityEvent";
+      type: {
+        kind: "struct";
+        fields: [
           {
-            "name": "header",
-            "type": {
-              "defined": {
-                "name": "accountEventHeader"
-              }
-            }
+            name: "header";
+            type: {
+              defined: {
+                name: "accountEventHeader";
+              };
+            };
           },
           {
-            "name": "oldAccountAuthority",
-            "type": "pubkey"
+            name: "oldAccountAuthority";
+            type: "pubkey";
           },
           {
-            "name": "newAccountAuthority",
-            "type": "pubkey"
+            name: "newAccountAuthority";
+            type: "pubkey";
           }
-        ]
-      }
+        ];
+      };
     },
     {
-      "name": "marginfiGroup",
-      "serialization": "bytemuck",
-      "repr": {
-        "kind": "c"
-      },
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: "marginfiGroup";
+      serialization: "bytemuck";
+      repr: {
+        kind: "c";
+      };
+      type: {
+        kind: "struct";
+        fields: [
           {
-            "name": "admin",
-            "type": "pubkey"
+            name: "admin";
+            type: "pubkey";
           },
           {
-            "name": "padding0",
-            "type": {
-              "array": [
+            name: "groupFlags";
+            docs: [
+              "Bitmask for group settings flags.",
+              "* Bit 0: If set, program-level fees are enabled.",
+              "* Bits 1-63: Reserved for future use."
+            ];
+            type: "u64";
+          },
+          {
+            name: "feeStateCache";
+            docs: ["Caches information from the global `FeeState` so the FeeState can be omitted on certain ixes"];
+            type: {
+              defined: {
+                name: "feeStateCache";
+              };
+            };
+          },
+          {
+            name: "padding0";
+            type: {
+              array: [
                 {
-                  "array": [
-                    "u64",
-                    2
-                  ]
+                  array: ["u64", 2];
+                },
+                27
+              ];
+            };
+          },
+          {
+            name: "padding1";
+            type: {
+              array: [
+                {
+                  array: ["u64", 2];
                 },
                 32
-              ]
-            }
+              ];
+            };
           },
           {
-            "name": "padding1",
-            "type": {
-              "array": [
-                {
-                  "array": [
-                    "u64",
-                    2
-                  ]
-                },
-                32
-              ]
-            }
+            name: "padding3";
+            type: "u64";
           }
-        ]
-      }
+        ];
+      };
     },
     {
-      "name": "marginfiGroupConfigureEvent",
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: "marginfiGroupConfigureEvent";
+      type: {
+        kind: "struct";
+        fields: [
           {
-            "name": "header",
-            "type": {
-              "defined": {
-                "name": "groupEventHeader"
-              }
-            }
+            name: "header";
+            type: {
+              defined: {
+                name: "groupEventHeader";
+              };
+            };
           },
           {
-            "name": "config",
-            "type": {
-              "defined": {
-                "name": "groupConfig"
-              }
-            }
+            name: "config";
+            type: {
+              defined: {
+                name: "groupConfig";
+              };
+            };
           }
-        ]
-      }
+        ];
+      };
     },
     {
-      "name": "marginfiGroupCreateEvent",
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: "marginfiGroupCreateEvent";
+      type: {
+        kind: "struct";
+        fields: [
           {
-            "name": "header",
-            "type": {
-              "defined": {
-                "name": "groupEventHeader"
-              }
-            }
+            name: "header";
+            type: {
+              defined: {
+                name: "groupEventHeader";
+              };
+            };
           }
-        ]
-      }
+        ];
+      };
     },
     {
-      "name": "oracleConfig",
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: "oracleConfig";
+      type: {
+        kind: "struct";
+        fields: [
           {
-            "name": "setup",
-            "type": {
-              "defined": {
-                "name": "oracleSetup"
-              }
-            }
+            name: "setup";
+            type: {
+              defined: {
+                name: "oracleSetup";
+              };
+            };
           },
           {
-            "name": "keys",
-            "type": {
-              "array": [
-                "pubkey",
-                5
-              ]
-            }
+            name: "keys";
+            type: {
+              array: ["pubkey", 5];
+            };
           }
-        ]
-      }
+        ];
+      };
     },
     {
-      "name": "oracleSetup",
-      "repr": {
-        "kind": "rust"
-      },
-      "type": {
-        "kind": "enum",
-        "variants": [
+      name: "oracleSetup";
+      repr: {
+        kind: "rust";
+      };
+      type: {
+        kind: "enum";
+        variants: [
           {
-            "name": "none"
+            name: "none";
           },
           {
-            "name": "pythLegacy"
+            name: "pythLegacy";
           },
           {
-            "name": "switchboardV2"
+            name: "switchboardV2";
           },
           {
-            "name": "pythPushOracle"
+            name: "pythPushOracle";
           },
           {
-            "name": "switchboardPull"
+            name: "switchboardPull";
           }
-        ]
-      }
+        ];
+      };
     },
     {
-      "name": "riskTier",
-      "repr": {
-        "kind": "rust"
-      },
-      "type": {
-        "kind": "enum",
-        "variants": [
+      name: "riskTier";
+      repr: {
+        kind: "rust";
+      };
+      type: {
+        kind: "enum";
+        variants: [
           {
-            "name": "collateral"
+            name: "collateral";
           },
           {
-            "name": "isolated"
+            name: "isolated";
           }
-        ]
-      }
+        ];
+      };
     },
     {
-      "name": "wrappedI80f48",
-      "serialization": "bytemuck",
-      "repr": {
-        "kind": "c",
-        "align": 8
-      },
-      "type": {
-        "kind": "struct",
-        "fields": [
+      name: "wrappedI80f48";
+      serialization: "bytemuck";
+      repr: {
+        kind: "c";
+        align: 8;
+      };
+      type: {
+        kind: "struct";
+        fields: [
           {
-            "name": "value",
-            "type": {
-              "array": [
-                "u8",
-                16
-              ]
-            }
+            name: "value";
+            type: {
+              array: ["u8", 16];
+            };
           }
-        ]
-      }
+        ];
+      };
     }
-  ]
+  ];
 };

--- a/packages/marginfi-client-v2/src/idl/marginfi.json
+++ b/packages/marginfi-client-v2/src/idl/marginfi.json
@@ -8,17 +8,164 @@
   },
   "instructions": [
     {
-      "name": "lending_account_borrow",
-      "discriminator": [
-        4,
-        126,
-        116,
-        53,
-        48,
-        5,
-        212,
-        31
+      "name": "config_group_fee",
+      "docs": [
+        "(global fee admin only) Enable or disable program fees for any group. Does not require the",
+        "group admin to sign: the global fee state admin can turn program fees on or off for any",
+        "group"
       ],
+      "discriminator": [231, 205, 66, 242, 220, 87, 145, 38],
+      "accounts": [
+        {
+          "name": "marginfi_group",
+          "writable": true
+        },
+        {
+          "name": "global_fee_admin",
+          "docs": ["`global_fee_admin` of the FeeState"],
+          "signer": true,
+          "relations": ["fee_state"]
+        },
+        {
+          "name": "fee_state",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 115, 116, 97, 116, 101]
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "flag",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "edit_global_fee_state",
+      "docs": ["(global fee admin only) Adjust fees or the destination wallet"],
+      "discriminator": [52, 62, 35, 129, 93, 69, 165, 202],
+      "accounts": [
+        {
+          "name": "global_fee_admin",
+          "docs": ["Admin of the global FeeState"],
+          "writable": true,
+          "signer": true,
+          "relations": ["fee_state"]
+        },
+        {
+          "name": "fee_state",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 115, 116, 97, 116, 101]
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "fee_wallet",
+          "type": "pubkey"
+        },
+        {
+          "name": "bank_init_flat_sol_fee",
+          "type": "u32"
+        },
+        {
+          "name": "program_fee_fixed",
+          "type": {
+            "defined": {
+              "name": "WrappedI80F48"
+            }
+          }
+        },
+        {
+          "name": "program_fee_rate",
+          "type": {
+            "defined": {
+              "name": "WrappedI80F48"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "init_global_fee_state",
+      "docs": [
+        "(Runs once per program) Configures the fee state account, where the global admin sets fees",
+        "that are assessed to the protocol"
+      ],
+      "discriminator": [82, 48, 247, 59, 220, 109, 231, 44],
+      "accounts": [
+        {
+          "name": "payer",
+          "docs": ["Pays the init fee"],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "fee_state",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 115, 116, 97, 116, 101]
+              }
+            ]
+          }
+        },
+        {
+          "name": "rent",
+          "address": "SysvarRent111111111111111111111111111111111"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "admin",
+          "type": "pubkey"
+        },
+        {
+          "name": "fee_wallet",
+          "type": "pubkey"
+        },
+        {
+          "name": "bank_init_flat_sol_fee",
+          "type": "u32"
+        },
+        {
+          "name": "program_fee_fixed",
+          "type": {
+            "defined": {
+              "name": "WrappedI80F48"
+            }
+          }
+        },
+        {
+          "name": "program_fee_rate",
+          "type": {
+            "defined": {
+              "name": "WrappedI80F48"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "lending_account_borrow",
+      "discriminator": [4, 126, 116, 53, 48, 5, 212, 31],
       "accounts": [
         {
           "name": "marginfi_group"
@@ -47,26 +194,7 @@
               {
                 "kind": "const",
                 "value": [
-                  108,
-                  105,
-                  113,
-                  117,
-                  105,
-                  100,
-                  105,
-                  116,
-                  121,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104
+                  108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104
                 ]
               },
               {
@@ -83,23 +211,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  108,
-                  105,
-                  113,
-                  117,
-                  105,
-                  100,
-                  105,
-                  116,
-                  121,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116
-                ]
+                "value": [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116]
               },
               {
                 "kind": "account",
@@ -121,16 +233,7 @@
     },
     {
       "name": "lending_account_close_balance",
-      "discriminator": [
-        245,
-        54,
-        41,
-        4,
-        243,
-        202,
-        31,
-        17
-      ],
+      "discriminator": [245, 54, 41, 4, 243, 202, 31, 17],
       "accounts": [
         {
           "name": "marginfi_group"
@@ -152,16 +255,7 @@
     },
     {
       "name": "lending_account_deposit",
-      "discriminator": [
-        171,
-        94,
-        235,
-        103,
-        82,
-        64,
-        212,
-        140
-      ],
+      "discriminator": [171, 94, 235, 103, 82, 64, 212, 140],
       "accounts": [
         {
           "name": "marginfi_group"
@@ -189,23 +283,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  108,
-                  105,
-                  113,
-                  117,
-                  105,
-                  100,
-                  105,
-                  116,
-                  121,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116
-                ]
+                "value": [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116]
               },
               {
                 "kind": "account",
@@ -227,16 +305,7 @@
     },
     {
       "name": "lending_account_end_flashloan",
-      "discriminator": [
-        105,
-        124,
-        201,
-        106,
-        153,
-        2,
-        8,
-        156
-      ],
+      "discriminator": [105, 124, 201, 106, 153, 2, 8, 156],
       "accounts": [
         {
           "name": "marginfi_account",
@@ -251,19 +320,8 @@
     },
     {
       "name": "lending_account_liquidate",
-      "docs": [
-        "Liquidate a lending account balance of an unhealthy marginfi account"
-      ],
-      "discriminator": [
-        214,
-        169,
-        151,
-        213,
-        251,
-        167,
-        86,
-        219
-      ],
+      "docs": ["Liquidate a lending account balance of an unhealthy marginfi account"],
+      "discriminator": [214, 169, 151, 213, 251, 167, 86, 219],
       "accounts": [
         {
           "name": "marginfi_group"
@@ -296,26 +354,7 @@
               {
                 "kind": "const",
                 "value": [
-                  108,
-                  105,
-                  113,
-                  117,
-                  105,
-                  100,
-                  105,
-                  116,
-                  121,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104
+                  108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104
                 ]
               },
               {
@@ -332,23 +371,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  108,
-                  105,
-                  113,
-                  117,
-                  105,
-                  100,
-                  105,
-                  116,
-                  121,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116
-                ]
+                "value": [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116]
               },
               {
                 "kind": "account",
@@ -364,23 +387,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  105,
-                  110,
-                  115,
-                  117,
-                  114,
-                  97,
-                  110,
-                  99,
-                  101,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116
-                ]
+                "value": [105, 110, 115, 117, 114, 97, 110, 99, 101, 95, 118, 97, 117, 108, 116]
               },
               {
                 "kind": "account",
@@ -402,16 +409,7 @@
     },
     {
       "name": "lending_account_repay",
-      "discriminator": [
-        79,
-        209,
-        172,
-        177,
-        222,
-        51,
-        173,
-        151
-      ],
+      "discriminator": [79, 209, 172, 177, 222, 51, 173, 151],
       "accounts": [
         {
           "name": "marginfi_group"
@@ -439,23 +437,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  108,
-                  105,
-                  113,
-                  117,
-                  105,
-                  100,
-                  105,
-                  116,
-                  121,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116
-                ]
+                "value": [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116]
               },
               {
                 "kind": "account",
@@ -483,16 +465,7 @@
     },
     {
       "name": "lending_account_settle_emissions",
-      "discriminator": [
-        161,
-        58,
-        136,
-        174,
-        242,
-        223,
-        156,
-        176
-      ],
+      "discriminator": [161, 58, 136, 174, 242, 223, 156, 176],
       "accounts": [
         {
           "name": "marginfi_account",
@@ -507,16 +480,7 @@
     },
     {
       "name": "lending_account_start_flashloan",
-      "discriminator": [
-        14,
-        131,
-        33,
-        220,
-        81,
-        186,
-        180,
-        107
-      ],
+      "discriminator": [14, 131, 33, 220, 81, 186, 180, 107],
       "accounts": [
         {
           "name": "marginfi_account",
@@ -540,16 +504,7 @@
     },
     {
       "name": "lending_account_withdraw",
-      "discriminator": [
-        36,
-        72,
-        74,
-        19,
-        210,
-        210,
-        192,
-        192
-      ],
+      "discriminator": [36, 72, 74, 19, 210, 210, 192, 192],
       "accounts": [
         {
           "name": "marginfi_group"
@@ -578,26 +533,7 @@
               {
                 "kind": "const",
                 "value": [
-                  108,
-                  105,
-                  113,
-                  117,
-                  105,
-                  100,
-                  105,
-                  116,
-                  121,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104
+                  108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104
                 ]
               },
               {
@@ -614,23 +550,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  108,
-                  105,
-                  113,
-                  117,
-                  105,
-                  100,
-                  105,
-                  116,
-                  121,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116
-                ]
+                "value": [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116]
               },
               {
                 "kind": "account",
@@ -658,16 +578,7 @@
     },
     {
       "name": "lending_account_withdraw_emissions",
-      "discriminator": [
-        234,
-        22,
-        84,
-        214,
-        118,
-        176,
-        140,
-        170
-      ],
+      "discriminator": [234, 22, 84, 214, 118, 176, 140, 170],
       "accounts": [
         {
           "name": "marginfi_group"
@@ -693,27 +604,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  101,
-                  109,
-                  105,
-                  115,
-                  115,
-                  105,
-                  111,
-                  110,
-                  115,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  95,
-                  115,
-                  101,
-                  101,
-                  100
-                ]
+                "value": [101, 109, 105, 115, 115, 105, 111, 110, 115, 95, 97, 117, 116, 104, 95, 115, 101, 101, 100]
               },
               {
                 "kind": "account",
@@ -734,34 +625,8 @@
               {
                 "kind": "const",
                 "value": [
-                  101,
-                  109,
-                  105,
-                  115,
-                  115,
-                  105,
-                  111,
-                  110,
-                  115,
-                  95,
-                  116,
-                  111,
-                  107,
-                  101,
-                  110,
-                  95,
-                  97,
-                  99,
-                  99,
-                  111,
-                  117,
-                  110,
-                  116,
-                  95,
-                  115,
-                  101,
-                  101,
-                  100
+                  101, 109, 105, 115, 115, 105, 111, 110, 115, 95, 116, 111, 107, 101, 110, 95, 97, 99, 99, 111, 117,
+                  110, 116, 95, 115, 101, 101, 100
                 ]
               },
               {
@@ -787,16 +652,7 @@
     },
     {
       "name": "lending_pool_accrue_bank_interest",
-      "discriminator": [
-        108,
-        201,
-        30,
-        87,
-        47,
-        65,
-        97,
-        188
-      ],
+      "discriminator": [108, 201, 30, 87, 47, 65, 97, 188],
       "accounts": [
         {
           "name": "marginfi_group"
@@ -810,16 +666,7 @@
     },
     {
       "name": "lending_pool_add_bank",
-      "discriminator": [
-        215,
-        68,
-        72,
-        78,
-        208,
-        218,
-        103,
-        182
-      ],
+      "discriminator": [215, 68, 72, 78, 208, 218, 103, 182],
       "accounts": [
         {
           "name": "marginfi_group"
@@ -831,8 +678,25 @@
         },
         {
           "name": "fee_payer",
+          "docs": ["Pays to init accounts and pays `fee_state.bank_init_flat_sol_fee` lamports to the protocol"],
           "writable": true,
           "signer": true
+        },
+        {
+          "name": "fee_state",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 115, 116, 97, 116, 101]
+              }
+            ]
+          }
+        },
+        {
+          "name": "global_fee_wallet",
+          "writable": true,
+          "relations": ["fee_state"]
         },
         {
           "name": "bank_mint"
@@ -849,26 +713,7 @@
               {
                 "kind": "const",
                 "value": [
-                  108,
-                  105,
-                  113,
-                  117,
-                  105,
-                  100,
-                  105,
-                  116,
-                  121,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104
+                  108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104
                 ]
               },
               {
@@ -885,23 +730,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  108,
-                  105,
-                  113,
-                  117,
-                  105,
-                  100,
-                  105,
-                  116,
-                  121,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116
-                ]
+                "value": [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116]
               },
               {
                 "kind": "account",
@@ -916,28 +745,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  105,
-                  110,
-                  115,
-                  117,
-                  114,
-                  97,
-                  110,
-                  99,
-                  101,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104
-                ]
+                "value": [105, 110, 115, 117, 114, 97, 110, 99, 101, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104]
               },
               {
                 "kind": "account",
@@ -953,23 +761,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  105,
-                  110,
-                  115,
-                  117,
-                  114,
-                  97,
-                  110,
-                  99,
-                  101,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116
-                ]
+                "value": [105, 110, 115, 117, 114, 97, 110, 99, 101, 95, 118, 97, 117, 108, 116]
               },
               {
                 "kind": "account",
@@ -984,22 +776,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  102,
-                  101,
-                  101,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104
-                ]
+                "value": [102, 101, 101, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104]
               },
               {
                 "kind": "account",
@@ -1015,17 +792,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  102,
-                  101,
-                  101,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116
-                ]
+                "value": [102, 101, 101, 95, 118, 97, 117, 108, 116]
               },
               {
                 "kind": "account",
@@ -1064,16 +831,7 @@
         "This seed is used to create a PDA for the bank's signature.",
         "lending_pool_add_bank is preserved for backwards compatibility."
       ],
-      "discriminator": [
-        76,
-        211,
-        213,
-        171,
-        117,
-        78,
-        158,
-        76
-      ],
+      "discriminator": [76, 211, 213, 171, 117, 78, 158, 76],
       "accounts": [
         {
           "name": "marginfi_group"
@@ -1085,8 +843,25 @@
         },
         {
           "name": "fee_payer",
+          "docs": ["Pays to init accounts and pays `fee_state.bank_init_flat_sol_fee` lamports to the protocol"],
           "writable": true,
           "signer": true
+        },
+        {
+          "name": "fee_state",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 115, 116, 97, 116, 101]
+              }
+            ]
+          }
+        },
+        {
+          "name": "global_fee_wallet",
+          "writable": true,
+          "relations": ["fee_state"]
         },
         {
           "name": "bank_mint"
@@ -1118,26 +893,7 @@
               {
                 "kind": "const",
                 "value": [
-                  108,
-                  105,
-                  113,
-                  117,
-                  105,
-                  100,
-                  105,
-                  116,
-                  121,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104
+                  108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104
                 ]
               },
               {
@@ -1154,23 +910,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  108,
-                  105,
-                  113,
-                  117,
-                  105,
-                  100,
-                  105,
-                  116,
-                  121,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116
-                ]
+                "value": [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116]
               },
               {
                 "kind": "account",
@@ -1185,28 +925,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  105,
-                  110,
-                  115,
-                  117,
-                  114,
-                  97,
-                  110,
-                  99,
-                  101,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104
-                ]
+                "value": [105, 110, 115, 117, 114, 97, 110, 99, 101, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104]
               },
               {
                 "kind": "account",
@@ -1222,23 +941,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  105,
-                  110,
-                  115,
-                  117,
-                  114,
-                  97,
-                  110,
-                  99,
-                  101,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116
-                ]
+                "value": [105, 110, 115, 117, 114, 97, 110, 99, 101, 95, 118, 97, 117, 108, 116]
               },
               {
                 "kind": "account",
@@ -1253,22 +956,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  102,
-                  101,
-                  101,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104
-                ]
+                "value": [102, 101, 101, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104]
               },
               {
                 "kind": "account",
@@ -1284,17 +972,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  102,
-                  101,
-                  101,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116
-                ]
+                "value": [102, 101, 101, 95, 118, 97, 117, 108, 116]
               },
               {
                 "kind": "account",
@@ -1332,16 +1010,7 @@
     },
     {
       "name": "lending_pool_collect_bank_fees",
-      "discriminator": [
-        201,
-        5,
-        215,
-        116,
-        230,
-        92,
-        75,
-        150
-      ],
+      "discriminator": [201, 5, 215, 116, 230, 92, 75, 150],
       "accounts": [
         {
           "name": "marginfi_group"
@@ -1357,26 +1026,7 @@
               {
                 "kind": "const",
                 "value": [
-                  108,
-                  105,
-                  113,
-                  117,
-                  105,
-                  100,
-                  105,
-                  116,
-                  121,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104
+                  108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104
                 ]
               },
               {
@@ -1393,23 +1043,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  108,
-                  105,
-                  113,
-                  117,
-                  105,
-                  100,
-                  105,
-                  116,
-                  121,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116
-                ]
+                "value": [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116]
               },
               {
                 "kind": "account",
@@ -1425,23 +1059,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  105,
-                  110,
-                  115,
-                  117,
-                  114,
-                  97,
-                  110,
-                  99,
-                  101,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116
-                ]
+                "value": [105, 110, 115, 117, 114, 97, 110, 99, 101, 95, 118, 97, 117, 108, 116]
               },
               {
                 "kind": "account",
@@ -1457,17 +1075,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  102,
-                  101,
-                  101,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116
-                ]
+                "value": [102, 101, 101, 95, 118, 97, 117, 108, 116]
               },
               {
                 "kind": "account",
@@ -1477,6 +1085,25 @@
           }
         },
         {
+          "name": "fee_state",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 115, 116, 97, 116, 101]
+              }
+            ]
+          }
+        },
+        {
+          "name": "fee_ata",
+          "docs": [
+            "(validated in handler). Must already exist, may require initializing the ATA if it does not",
+            "already exist prior to this ix."
+          ],
+          "writable": true
+        },
+        {
           "name": "token_program"
         }
       ],
@@ -1484,16 +1111,7 @@
     },
     {
       "name": "lending_pool_configure_bank",
-      "discriminator": [
-        121,
-        173,
-        156,
-        40,
-        93,
-        148,
-        56,
-        237
-      ],
+      "discriminator": [121, 173, 156, 40, 93, 148, 56, 237],
       "accounts": [
         {
           "name": "marginfi_group"
@@ -1520,19 +1138,8 @@
     },
     {
       "name": "lending_pool_handle_bankruptcy",
-      "docs": [
-        "Handle bad debt of a bankrupt marginfi account for a given bank."
-      ],
-      "discriminator": [
-        162,
-        11,
-        56,
-        139,
-        90,
-        128,
-        70,
-        173
-      ],
+      "docs": ["Handle bad debt of a bankrupt marginfi account for a given bank."],
+      "discriminator": [162, 11, 56, 139, 90, 128, 70, 173],
       "accounts": [
         {
           "name": "marginfi_group"
@@ -1556,23 +1163,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  108,
-                  105,
-                  113,
-                  117,
-                  105,
-                  100,
-                  105,
-                  116,
-                  121,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116
-                ]
+                "value": [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 118, 97, 117, 108, 116]
               },
               {
                 "kind": "account",
@@ -1588,23 +1179,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  105,
-                  110,
-                  115,
-                  117,
-                  114,
-                  97,
-                  110,
-                  99,
-                  101,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116
-                ]
+                "value": [105, 110, 115, 117, 114, 97, 110, 99, 101, 95, 118, 97, 117, 108, 116]
               },
               {
                 "kind": "account",
@@ -1619,28 +1194,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  105,
-                  110,
-                  115,
-                  117,
-                  114,
-                  97,
-                  110,
-                  99,
-                  101,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104
-                ]
+                "value": [105, 110, 115, 117, 114, 97, 110, 99, 101, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104]
               },
               {
                 "kind": "account",
@@ -1657,16 +1211,7 @@
     },
     {
       "name": "lending_pool_setup_emissions",
-      "discriminator": [
-        206,
-        97,
-        120,
-        172,
-        113,
-        204,
-        169,
-        70
-      ],
+      "discriminator": [206, 97, 120, 172, 113, 204, 169, 70],
       "accounts": [
         {
           "name": "marginfi_group"
@@ -1689,27 +1234,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  101,
-                  109,
-                  105,
-                  115,
-                  115,
-                  105,
-                  111,
-                  110,
-                  115,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  95,
-                  115,
-                  101,
-                  101,
-                  100
-                ]
+                "value": [101, 109, 105, 115, 115, 105, 111, 110, 115, 95, 97, 117, 116, 104, 95, 115, 101, 101, 100]
               },
               {
                 "kind": "account",
@@ -1730,34 +1255,8 @@
               {
                 "kind": "const",
                 "value": [
-                  101,
-                  109,
-                  105,
-                  115,
-                  115,
-                  105,
-                  111,
-                  110,
-                  115,
-                  95,
-                  116,
-                  111,
-                  107,
-                  101,
-                  110,
-                  95,
-                  97,
-                  99,
-                  99,
-                  111,
-                  117,
-                  110,
-                  116,
-                  95,
-                  115,
-                  101,
-                  101,
-                  100
+                  101, 109, 105, 115, 115, 105, 111, 110, 115, 95, 116, 111, 107, 101, 110, 95, 97, 99, 99, 111, 117,
+                  110, 116, 95, 115, 101, 101, 100
                 ]
               },
               {
@@ -1800,16 +1299,7 @@
     },
     {
       "name": "lending_pool_update_emissions_parameters",
-      "discriminator": [
-        55,
-        213,
-        224,
-        168,
-        153,
-        53,
-        197,
-        40
-      ],
+      "discriminator": [55, 213, 224, 168, 153, 53, 197, 40],
       "accounts": [
         {
           "name": "marginfi_group"
@@ -1834,34 +1324,8 @@
               {
                 "kind": "const",
                 "value": [
-                  101,
-                  109,
-                  105,
-                  115,
-                  115,
-                  105,
-                  111,
-                  110,
-                  115,
-                  95,
-                  116,
-                  111,
-                  107,
-                  101,
-                  110,
-                  95,
-                  97,
-                  99,
-                  99,
-                  111,
-                  117,
-                  110,
-                  116,
-                  95,
-                  115,
-                  101,
-                  101,
-                  100
+                  101, 109, 105, 115, 115, 105, 111, 110, 115, 95, 116, 111, 107, 101, 110, 95, 97, 99, 99, 111, 117,
+                  110, 116, 95, 115, 101, 101, 100
                 ]
               },
               {
@@ -1906,16 +1370,7 @@
     },
     {
       "name": "lending_pool_withdraw_fees",
-      "discriminator": [
-        92,
-        140,
-        215,
-        254,
-        170,
-        0,
-        83,
-        174
-      ],
+      "discriminator": [92, 140, 215, 254, 170, 0, 83, 174],
       "accounts": [
         {
           "name": "marginfi_group"
@@ -1934,17 +1389,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  102,
-                  101,
-                  101,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116
-                ]
+                "value": [102, 101, 101, 95, 118, 97, 117, 108, 116]
               },
               {
                 "kind": "account",
@@ -1959,22 +1404,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  102,
-                  101,
-                  101,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104
-                ]
+                "value": [102, 101, 101, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104]
               },
               {
                 "kind": "account",
@@ -2000,16 +1430,7 @@
     },
     {
       "name": "lending_pool_withdraw_insurance",
-      "discriminator": [
-        108,
-        60,
-        60,
-        246,
-        104,
-        79,
-        159,
-        243
-      ],
+      "discriminator": [108, 60, 60, 246, 104, 79, 159, 243],
       "accounts": [
         {
           "name": "marginfi_group"
@@ -2028,23 +1449,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  105,
-                  110,
-                  115,
-                  117,
-                  114,
-                  97,
-                  110,
-                  99,
-                  101,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116
-                ]
+                "value": [105, 110, 115, 117, 114, 97, 110, 99, 101, 95, 118, 97, 117, 108, 116]
               },
               {
                 "kind": "account",
@@ -2059,28 +1464,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  105,
-                  110,
-                  115,
-                  117,
-                  114,
-                  97,
-                  110,
-                  99,
-                  101,
-                  95,
-                  118,
-                  97,
-                  117,
-                  108,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104
-                ]
+                "value": [105, 110, 115, 117, 114, 97, 110, 99, 101, 95, 118, 97, 117, 108, 116, 95, 97, 117, 116, 104]
               },
               {
                 "kind": "account",
@@ -2106,16 +1490,7 @@
     },
     {
       "name": "marginfi_account_close",
-      "discriminator": [
-        186,
-        221,
-        93,
-        34,
-        50,
-        97,
-        194,
-        241
-      ],
+      "discriminator": [186, 221, 93, 34, 50, 97, 194, 241],
       "accounts": [
         {
           "name": "marginfi_account",
@@ -2135,19 +1510,8 @@
     },
     {
       "name": "marginfi_account_initialize",
-      "docs": [
-        "Initialize a marginfi account for a given group"
-      ],
-      "discriminator": [
-        43,
-        78,
-        61,
-        255,
-        148,
-        52,
-        249,
-        154
-      ],
+      "docs": ["Initialize a marginfi account for a given group"],
+      "discriminator": [43, 78, 61, 255, 148, 52, 249, 154],
       "accounts": [
         {
           "name": "marginfi_group"
@@ -2175,16 +1539,7 @@
     },
     {
       "name": "marginfi_group_configure",
-      "discriminator": [
-        62,
-        199,
-        81,
-        78,
-        33,
-        13,
-        236,
-        61
-      ],
+      "discriminator": [62, 199, 81, 78, 33, 13, 236, 61],
       "accounts": [
         {
           "name": "marginfi_group",
@@ -2208,16 +1563,7 @@
     },
     {
       "name": "marginfi_group_initialize",
-      "discriminator": [
-        255,
-        67,
-        67,
-        26,
-        94,
-        31,
-        34,
-        20
-      ],
+      "discriminator": [255, 67, 67, 26, 94, 31, 34, 20],
       "accounts": [
         {
           "name": "marginfi_group",
@@ -2230,6 +1576,17 @@
           "signer": true
         },
         {
+          "name": "fee_state",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 115, 116, 97, 116, 101]
+              }
+            ]
+          }
+        },
+        {
           "name": "system_program",
           "address": "11111111111111111111111111111111"
         }
@@ -2237,17 +1594,32 @@
       "args": []
     },
     {
-      "name": "set_account_flag",
-      "discriminator": [
-        56,
-        238,
-        18,
-        207,
-        193,
-        82,
-        138,
-        174
+      "name": "propagate_fee_state",
+      "docs": ["(Permissionless) Force any group to adopt the current FeeState settings"],
+      "discriminator": [64, 3, 166, 194, 129, 21, 101, 155],
+      "accounts": [
+        {
+          "name": "fee_state",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [102, 101, 101, 115, 116, 97, 116, 101]
+              }
+            ]
+          }
+        },
+        {
+          "name": "marginfi_group",
+          "docs": ["Any group, this ix is permisionless and can propogate the fee to any group"],
+          "writable": true
+        }
       ],
+      "args": []
+    },
+    {
+      "name": "set_account_flag",
+      "discriminator": [56, 238, 18, 207, 193, 82, 138, 174],
       "accounts": [
         {
           "name": "marginfi_group"
@@ -2258,9 +1630,7 @@
         },
         {
           "name": "admin",
-          "docs": [
-            "Admin only"
-          ],
+          "docs": ["Admin only"],
           "signer": true
         }
       ],
@@ -2273,16 +1643,7 @@
     },
     {
       "name": "set_new_account_authority",
-      "discriminator": [
-        153,
-        162,
-        50,
-        84,
-        182,
-        201,
-        74,
-        179
-      ],
+      "discriminator": [153, 162, 50, 84, 182, 201, 74, 179],
       "accounts": [
         {
           "name": "marginfi_account",
@@ -2308,16 +1669,7 @@
     },
     {
       "name": "unset_account_flag",
-      "discriminator": [
-        56,
-        81,
-        56,
-        85,
-        92,
-        49,
-        255,
-        70
-      ],
+      "discriminator": [56, 81, 56, 85, 92, 49, 255, 70],
       "accounts": [
         {
           "name": "marginfi_group"
@@ -2328,9 +1680,7 @@
         },
         {
           "name": "admin",
-          "docs": [
-            "Admin only"
-          ],
+          "docs": ["Admin only"],
           "signer": true
         }
       ],
@@ -2345,226 +1695,19 @@
   "accounts": [
     {
       "name": "Bank",
-      "discriminator": [
-        142,
-        49,
-        166,
-        242,
-        50,
-        66,
-        97,
-        188
-      ]
+      "discriminator": [142, 49, 166, 242, 50, 66, 97, 188]
+    },
+    {
+      "name": "FeeState",
+      "discriminator": [63, 224, 16, 85, 193, 36, 235, 220]
     },
     {
       "name": "MarginfiAccount",
-      "discriminator": [
-        67,
-        178,
-        130,
-        109,
-        126,
-        114,
-        28,
-        42
-      ]
+      "discriminator": [67, 178, 130, 109, 126, 114, 28, 42]
     },
     {
       "name": "MarginfiGroup",
-      "discriminator": [
-        182,
-        23,
-        173,
-        240,
-        151,
-        206,
-        182,
-        67
-      ]
-    }
-  ],
-  "events": [
-    {
-      "name": "LendingAccountBorrowEvent",
-      "discriminator": [
-        223,
-        96,
-        81,
-        10,
-        156,
-        99,
-        26,
-        59
-      ]
-    },
-    {
-      "name": "LendingAccountDepositEvent",
-      "discriminator": [
-        161,
-        54,
-        237,
-        217,
-        105,
-        248,
-        122,
-        151
-      ]
-    },
-    {
-      "name": "LendingAccountLiquidateEvent",
-      "discriminator": [
-        166,
-        160,
-        249,
-        154,
-        183,
-        39,
-        23,
-        242
-      ]
-    },
-    {
-      "name": "LendingAccountRepayEvent",
-      "discriminator": [
-        16,
-        220,
-        55,
-        111,
-        7,
-        80,
-        16,
-        25
-      ]
-    },
-    {
-      "name": "LendingAccountWithdrawEvent",
-      "discriminator": [
-        3,
-        220,
-        148,
-        243,
-        33,
-        249,
-        54,
-        88
-      ]
-    },
-    {
-      "name": "LendingPoolBankAccrueInterestEvent",
-      "discriminator": [
-        104,
-        117,
-        187,
-        156,
-        111,
-        154,
-        106,
-        186
-      ]
-    },
-    {
-      "name": "LendingPoolBankCollectFeesEvent",
-      "discriminator": [
-        101,
-        119,
-        97,
-        250,
-        169,
-        175,
-        156,
-        253
-      ]
-    },
-    {
-      "name": "LendingPoolBankConfigureEvent",
-      "discriminator": [
-        246,
-        35,
-        233,
-        110,
-        93,
-        152,
-        235,
-        40
-      ]
-    },
-    {
-      "name": "LendingPoolBankCreateEvent",
-      "discriminator": [
-        236,
-        220,
-        201,
-        63,
-        239,
-        126,
-        136,
-        249
-      ]
-    },
-    {
-      "name": "LendingPoolBankHandleBankruptcyEvent",
-      "discriminator": [
-        166,
-        77,
-        41,
-        140,
-        36,
-        94,
-        10,
-        57
-      ]
-    },
-    {
-      "name": "MarginfiAccountCreateEvent",
-      "discriminator": [
-        183,
-        5,
-        117,
-        104,
-        122,
-        199,
-        68,
-        51
-      ]
-    },
-    {
-      "name": "MarginfiAccountTransferAccountAuthorityEvent",
-      "discriminator": [
-        112,
-        61,
-        140,
-        132,
-        251,
-        92,
-        90,
-        202
-      ]
-    },
-    {
-      "name": "MarginfiGroupConfigureEvent",
-      "discriminator": [
-        241,
-        104,
-        172,
-        167,
-        41,
-        195,
-        199,
-        170
-      ]
-    },
-    {
-      "name": "MarginfiGroupCreateEvent",
-      "discriminator": [
-        233,
-        125,
-        61,
-        14,
-        98,
-        240,
-        136,
-        253
-      ]
+      "discriminator": [182, 23, 173, 240, 151, 206, 182, 67]
     }
   ],
   "errors": [
@@ -2802,6 +1945,11 @@
       "code": 6046,
       "name": "T22MintRequired",
       "msg": "Token22 Banks require mint account as first remaining account"
+    },
+    {
+      "code": 6047,
+      "name": "InvalidFeeAta",
+      "msg": "Invalid ATA for global fee account"
     }
   ],
   "types": [
@@ -2851,10 +1999,7 @@
           {
             "name": "_pad0",
             "type": {
-              "array": [
-                "u8",
-                7
-              ]
+              "array": ["u8", 7]
             }
           },
           {
@@ -2888,10 +2033,7 @@
           {
             "name": "_padding",
             "type": {
-              "array": [
-                "u64",
-                1
-              ]
+              "array": ["u64", 1]
             }
           }
         ]
@@ -2921,10 +2063,7 @@
           {
             "name": "_pad0",
             "type": {
-              "array": [
-                "u8",
-                7
-              ]
+              "array": ["u8", 7]
             }
           },
           {
@@ -2970,14 +2109,12 @@
           {
             "name": "_pad1",
             "type": {
-              "array": [
-                "u8",
-                4
-              ]
+              "array": ["u8", 4]
             }
           },
           {
             "name": "collected_insurance_fees_outstanding",
+            "docs": ["Fees collected and pending withdraw for the `insurance_vault`"],
             "type": {
               "defined": {
                 "name": "WrappedI80F48"
@@ -2999,14 +2136,12 @@
           {
             "name": "_pad2",
             "type": {
-              "array": [
-                "u8",
-                6
-              ]
+              "array": ["u8", 6]
             }
           },
           {
             "name": "collected_group_fees_outstanding",
+            "docs": ["Fees collected and pending withdraw for the `fee_vault`"],
             "type": {
               "defined": {
                 "name": "WrappedI80F48"
@@ -3074,16 +2209,24 @@
             "type": "pubkey"
           },
           {
+            "name": "collected_program_fees_outstanding",
+            "docs": [
+              "Fees collected and pending withdraw for the `FeeState.global_fee_wallet`'s cannonical ATA for `mint`"
+            ],
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
             "name": "_padding_0",
             "type": {
               "array": [
                 {
-                  "array": [
-                    "u64",
-                    2
-                  ]
+                  "array": ["u64", 2]
                 },
-                28
+                27
               ]
             }
           },
@@ -3092,10 +2235,7 @@
             "type": {
               "array": [
                 {
-                  "array": [
-                    "u64",
-                    2
-                  ]
+                  "array": ["u64", 2]
                 },
                 32
               ]
@@ -3106,9 +2246,7 @@
     },
     {
       "name": "BankConfig",
-      "docs": [
-        "TODO: Convert weights to (u64, u64) to avoid precision loss (maybe?)"
-      ],
+      "docs": ["TODO: Convert weights to (u64, u64) to avoid precision loss (maybe?)"],
       "serialization": "bytemuckunsafe",
       "repr": {
         "kind": "c"
@@ -3179,19 +2317,13 @@
           {
             "name": "oracle_keys",
             "type": {
-              "array": [
-                "pubkey",
-                5
-              ]
+              "array": ["pubkey", 5]
             }
           },
           {
             "name": "_pad0",
             "type": {
-              "array": [
-                "u8",
-                6
-              ]
+              "array": ["u8", 6]
             }
           },
           {
@@ -3209,10 +2341,7 @@
           {
             "name": "_pad1",
             "type": {
-              "array": [
-                "u8",
-                7
-              ]
+              "array": ["u8", 7]
             }
           },
           {
@@ -3231,18 +2360,13 @@
           },
           {
             "name": "oracle_max_age",
-            "docs": [
-              "Time window in seconds for the oracle price feed to be considered live."
-            ],
+            "docs": ["Time window in seconds for the oracle price feed to be considered live."],
             "type": "u16"
           },
           {
             "name": "_padding",
             "type": {
-              "array": [
-                "u8",
-                38
-              ]
+              "array": ["u8", 38]
             }
           }
         ]
@@ -3250,9 +2374,7 @@
     },
     {
       "name": "BankConfigCompact",
-      "docs": [
-        "TODO: Convert weights to (u64, u64) to avoid precision loss (maybe?)"
-      ],
+      "docs": ["TODO: Convert weights to (u64, u64) to avoid precision loss (maybe?)"],
       "repr": {
         "kind": "c"
       },
@@ -3338,10 +2460,7 @@
           {
             "name": "_pad0",
             "type": {
-              "array": [
-                "u8",
-                7
-              ]
+              "array": ["u8", 7]
             }
           },
           {
@@ -3360,9 +2479,7 @@
           },
           {
             "name": "oracle_max_age",
-            "docs": [
-              "Time window in seconds for the oracle price feed to be considered live."
-            ],
+            "docs": ["Time window in seconds for the oracle price feed to be considered live."],
             "type": "u16"
           }
         ]
@@ -3507,6 +2624,125 @@
       }
     },
     {
+      "name": "FeeState",
+      "docs": [
+        "Unique per-program. The Program Owner uses this account to administrate fees collected by the protocol"
+      ],
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "key",
+            "docs": ["The fee state's own key. A PDA derived from just `b\"feestate\"`"],
+            "type": "pubkey"
+          },
+          {
+            "name": "global_fee_admin",
+            "docs": ["Can modify fees"],
+            "type": "pubkey"
+          },
+          {
+            "name": "global_fee_wallet",
+            "docs": [
+              "The base wallet for all protocol fees. All SOL fees go to this wallet. All non-SOL fees go",
+              "to the cannonical ATA of this wallet for that asset."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "placeholder0",
+            "type": "u64"
+          },
+          {
+            "name": "bank_init_flat_sol_fee",
+            "docs": ["Flat fee assessed when a new bank is initialized, in lamports.", "* In SOL, in native decimals."],
+            "type": "u32"
+          },
+          {
+            "name": "bump_seed",
+            "type": "u8"
+          },
+          {
+            "name": "_padding0",
+            "type": {
+              "array": ["u8", 4]
+            }
+          },
+          {
+            "name": "_padding1",
+            "type": {
+              "array": ["u8", 15]
+            }
+          },
+          {
+            "name": "program_fee_fixed",
+            "docs": ["Fee collected by the program owner from all groups"],
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "program_fee_rate",
+            "docs": ["Fee collected by the program owner from all groups"],
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "_reserved0",
+            "type": {
+              "array": ["u8", 32]
+            }
+          },
+          {
+            "name": "_reserved1",
+            "type": {
+              "array": ["u8", 64]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "FeeStateCache",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "global_fee_wallet",
+            "type": "pubkey"
+          },
+          {
+            "name": "program_fee_fixed",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "program_fee_rate",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
       "name": "GroupConfig",
       "type": {
         "kind": "struct",
@@ -3573,6 +2809,7 @@
           },
           {
             "name": "insurance_fee_fixed_apr",
+            "docs": ["Goes to insurance, funds `collected_insurance_fees_outstanding`"],
             "type": {
               "defined": {
                 "name": "WrappedI80F48"
@@ -3581,6 +2818,7 @@
           },
           {
             "name": "insurance_ir_fee",
+            "docs": ["Goes to insurance, funds `collected_insurance_fees_outstanding`"],
             "type": {
               "defined": {
                 "name": "WrappedI80F48"
@@ -3589,6 +2827,7 @@
           },
           {
             "name": "protocol_fixed_fee_apr",
+            "docs": ["Earned by the group, goes to `collected_group_fees_outstanding`"],
             "type": {
               "defined": {
                 "name": "WrappedI80F48"
@@ -3597,6 +2836,7 @@
           },
           {
             "name": "protocol_ir_fee",
+            "docs": ["Earned by the group, goes to `collected_group_fees_outstanding`"],
             "type": {
               "defined": {
                 "name": "WrappedI80F48"
@@ -3604,16 +2844,27 @@
             }
           },
           {
-            "name": "_padding",
+            "name": "protocol_origination_fee",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "_padding0",
+            "type": {
+              "array": ["u8", 16]
+            }
+          },
+          {
+            "name": "_padding1",
             "type": {
               "array": [
                 {
-                  "array": [
-                    "u64",
-                    2
-                  ]
+                  "array": ["u8", 32]
                 },
-                8
+                3
               ]
             }
           }
@@ -3678,6 +2929,14 @@
           },
           {
             "name": "protocol_ir_fee",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "protocol_origination_fee",
             "type": {
               "defined": {
                 "name": "WrappedI80F48"
@@ -3761,6 +3020,16 @@
                 }
               }
             }
+          },
+          {
+            "name": "protocol_origination_fee",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "WrappedI80F48"
+                }
+              }
+            }
           }
         ]
       }
@@ -3790,10 +3059,7 @@
           {
             "name": "_padding",
             "type": {
-              "array": [
-                "u64",
-                8
-              ]
+              "array": ["u64", 8]
             }
           }
         ]
@@ -4215,10 +3481,7 @@
           {
             "name": "_padding",
             "type": {
-              "array": [
-                "u64",
-                63
-              ]
+              "array": ["u64", 63]
             }
           }
         ]
@@ -4278,16 +3541,31 @@
             "type": "pubkey"
           },
           {
+            "name": "group_flags",
+            "docs": [
+              "Bitmask for group settings flags.",
+              "* Bit 0: If set, program-level fees are enabled.",
+              "* Bits 1-63: Reserved for future use."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "fee_state_cache",
+            "docs": ["Caches information from the global `FeeState` so the FeeState can be omitted on certain ixes"],
+            "type": {
+              "defined": {
+                "name": "FeeStateCache"
+              }
+            }
+          },
+          {
             "name": "_padding_0",
             "type": {
               "array": [
                 {
-                  "array": [
-                    "u64",
-                    2
-                  ]
+                  "array": ["u64", 2]
                 },
-                32
+                27
               ]
             }
           },
@@ -4296,14 +3574,15 @@
             "type": {
               "array": [
                 {
-                  "array": [
-                    "u64",
-                    2
-                  ]
+                  "array": ["u64", 2]
                 },
                 32
               ]
             }
+          },
+          {
+            "name": "_padding_3",
+            "type": "u64"
           }
         ]
       }
@@ -4364,10 +3643,7 @@
           {
             "name": "keys",
             "type": {
-              "array": [
-                "pubkey",
-                5
-              ]
+              "array": ["pubkey", 5]
             }
           }
         ]
@@ -4429,10 +3705,7 @@
           {
             "name": "value",
             "type": {
-              "array": [
-                "u8",
-                16
-              ]
+              "array": ["u8", 16]
             }
           }
         ]

--- a/packages/marginfi-client-v2/src/models/bank.ts
+++ b/packages/marginfi-client-v2/src/models/bank.ts
@@ -105,6 +105,8 @@ interface InterestRateConfigRaw {
   insuranceIrFee: WrappedI80F48;
   protocolFixedFeeApr: WrappedI80F48;
   protocolIrFee: WrappedI80F48;
+
+  protocolOriginationFee: WrappedI80F48;
 }
 
 type OracleSetupRaw = { none: {} } | { pythLegacy: {} } | { switchboardV2: {} } | { pythPushOracle: {} };


### PR DESCRIPTION
Handles changes from https://github.com/mrgnlabs/marginfi-v2/pull/244 and https://github.com/mrgnlabs/marginfi-v2/pull/239, adding origination fees on borrow and program-level fees (paid to the program administrator) that are collected by a global fee wallet.

Changes:
- Banks have a new field: `bank.config.interest_rate_config.protocol_origination_fee` and `bank.collected_program_fees_outstanding`
- Groups have new fields: `group_flags` and `fee_state_cache`. 
- A new account called `FeeState` exists. This account is one-of-a-kind per program. 
- A new ix `init_global_fee_state` will run once after this program update, and then be removed from the program buffer in a subsequent update.
- A new FeeState admin-only ix `edit_global_fee_state` modifies program fees.
- A new FeeState admin-only ix `config_group_fee` controls if a group pays program fees or not.
- A new permissionless ix `propagate_fee_state` forces a group to adopt the current global FeeState regime.
- `add_bank` now requires the `FeeState` account and the interest rate config now has a `protocolOriginationFee` field.
- `collect_bank_fees` now requires the global fee state and fee ata, which is the canonical ATA of `FeeState.global_fee_wallet`

Launch readiness checklist:
- [ ] UI supports the changes above
- [ ] Program deployed to staging
- [ ] `init_fee_state` runs once, signed by the program multisig
- Groups created from this point on will automatically have program fees (flat sol to create pool, % of borrow fee revenue) enabled, no further action required.
- Banks created from this point on will configure their borrow origination fee on setup (`add_pool`) or via `configure_bank`
- [ ] Test fund `FeeState.global_fee_wallet` with some SOL to make sure it is a valid account that we own.
- [ ] Test create a group and pool, verify the `FeeState.global_fee_wallet` gains the flat sol fee.
- [ ] Test create a bank with a non-zero origination fee, verify the user owes X+fee after a borrow of X. Verify a portion of the fee goes to the group, and the rest to the program.
- [ ] Prepare infra to run `propagate_fee_state` for all groups that exist after any changes to fees (`edit_global_fee_state`)
- [ ] Program deployed to mainnet
- [ ] `init_fee_state` runs once for mainnet, signed by the program multisig

Less important but should do eventually:
- [ ] `propagate_fee_state` runs for any group that existed prior to this update.
- [ ] `config_group_fee` runs for any group that existed prior to this update that should enable program fees.
- [ ] `configure_bank` runs for any bank that existed prior to this update that should enable borrow origination fees.
- [ ] Create ATA's for  `FeeState.global_fee_wallet` any asset we will ultimately collect fees on, or modify how `collect_bank_fees` is called to create the ATA as needed.
- [ ] Begin update to remove `init_fee_state` from the program buffer
- [ ] `config_group_fee` turns off fees for any group created after this update that is whitelisted and should not pay them (e.g. arena groups already owned by mrgn)
- [ ] UI elements to show users how much they will pay in origination fees.