### PR TITLE
feat(mfi-v2-ui): introduce dynamic numeral formatter 

### DIFF
--- a/apps/marginfi-v2-ui/src/components/common/Portfolio/PortfolioAssetCard.tsx
+++ b/apps/marginfi-v2-ui/src/components/common/Portfolio/PortfolioAssetCard.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import Image from "next/image";
 
 import { IconAlertTriangle } from "@tabler/icons-react";
-import { usdFormatter, numeralFormatter } from "@mrgnlabs/mrgn-common";
+import { usdFormatter, numeralFormatter, dynamicNumeralFormatter } from "@mrgnlabs/mrgn-common";
 import { ActiveBankInfo, ActionType, ExtendedBankInfo } from "@mrgnlabs/marginfi-v2-ui-state";
 import { capture } from "@mrgnlabs/mrgn-utils";
 import { ActionBox } from "@mrgnlabs/mrgn-ui";
@@ -72,7 +72,14 @@ export const PortfolioAssetCard = ({ bank, isInLendingMode, isBorrower = true }:
                 </dl>
               </div>
               <div className="font-medium text-lg mr-2">
-                {bank.position.amount < 0.01 ? "< $0.01" : numeralFormatter(bank.position.amount)}
+                {/* {bank.position.amount < 0.01
+                  ? "< $0.01"
+                  : dynamicNumeralFormatter(bank.position.amount, {
+                      tokenPrice: bank.info.oraclePrice.priceRealtime.price.toNumber(),
+                    })} */}
+                {dynamicNumeralFormatter(0.002466, {
+                  tokenPrice: 75000,
+                })}
                 {" " + bank.meta.tokenSymbol}
               </div>
             </div>

--- a/packages/mrgn-common/src/formatters.ts
+++ b/packages/mrgn-common/src/formatters.ts
@@ -28,6 +28,38 @@ const numeralFormatter = (value: number) => {
   }
 };
 
+interface dynamicNumeralFormatterOptions {
+  minDisplay?: number;
+  tokenPrice?: number;
+}
+
+export const dynamicNumeralFormatter = (value: number, options: dynamicNumeralFormatterOptions = {}) => {
+  const { minDisplay = 0.00001, tokenPrice } = options;
+
+  if (value === 0) return "0";
+
+  if (Math.abs(value) < minDisplay) {
+    return `< ${minDisplay}`;
+  }
+
+  if (Math.abs(value) >= 0.01) {
+    return numeral(value).format("0.00a");
+  }
+
+  if (tokenPrice) {
+    const minUsdDisplay = 0.01;
+    const smallestUnit = minUsdDisplay / tokenPrice;
+
+    const requiredDecimals = Math.max(2, Math.ceil(-Math.log10(smallestUnit)) + 1);
+
+    const decimalPlaces = Math.min(requiredDecimals, 8);
+
+    return value.toFixed(decimalPlaces).replace(/\.?0+$/, "");
+  }
+
+  return "0";
+};
+
 const groupedNumberFormatterDyn = new Intl.NumberFormat("en-US", {
   useGrouping: true,
   minimumFractionDigits: 0,


### PR DESCRIPTION
Introduced a new function to dynamically display the tokenAmount based on the tokenprice. If the tokenPrice is defined, we calculate the smallest display unit we want to display & format it to that. Also has optional minimumDisplay, if the amount is smaller than that amount we return '<_minimumDisplay_' 

Currently implemented only on the portfolio, can do this throughout the entire app & replace the numeralFormatter whereever possible. 