### PR TITLE
fix(mfi-v2-ui): reduce only positions

### DIFF
--- a/packages/marginfi-v2-ui-state/src/lib/mrgnlend.ts
+++ b/packages/marginfi-v2-ui-state/src/lib/mrgnlend.ts
@@ -398,7 +398,7 @@ export function makeLendingPosition(
   const amounts = balance.computeQuantity(bank);
   const usdValues = balance.computeUsdValue(bank, oraclePrice, MarginRequirementType.Equity);
   const weightedUSDValues = balance.getUsdValueWithPriceBias(bank, oraclePrice, MarginRequirementType.Maintenance);
-  const isLending = usdValues.liabilities.isZero();
+  const isLending = balance.liabilityShares.isZero();
 
   const amount = isLending
     ? nativeToUi(amounts.assets.integerValue(BigNumber.ROUND_DOWN).toNumber(), bankInfo.mintDecimals)


### PR DESCRIPTION
Checks liability shares instead of usd value to determine if position is lending / borrowing. Fixes reduce only borrows, with 0 state oracles, showing as lending positions unintentionally.
