### PR TITLE
fix(mfi-ui): no unnecessary resetting of additional action messages 

### DIFF
--- a/packages/mrgn-ui/src/components/action-box-v2/actions/deposit-swap-box/deposit-swap-box.tsx
+++ b/packages/mrgn-ui/src/components/action-box-v2/actions/deposit-swap-box/deposit-swap-box.tsx
@@ -212,7 +212,7 @@ export const DepositSwapBox = ({
   );
 
   const actionMessages = React.useMemo(() => {
-    setAdditionalActionMessages([]);
+    !errorMessage && setAdditionalActionMessages([]);
     return checkDepositSwapActionAvailable({
       amount,
       connected,
@@ -225,6 +225,7 @@ export const DepositSwapBox = ({
       lendMode,
     });
   }, [
+    errorMessage,
     amount,
     connected,
     showCloseBalance,
@@ -316,7 +317,16 @@ export const DepositSwapBox = ({
         },
       });
     },
-    [captureEvent, onComplete, selectedDepositBank, selectedSwapBank, setIsActionComplete, setPreviousTxn]
+    [
+      actionTxns.actionQuote,
+      captureEvent,
+      debouncedAmount,
+      onComplete,
+      selectedDepositBank,
+      selectedSwapBank,
+      setIsActionComplete,
+      setPreviousTxn,
+    ]
   );
 
   const handleDepositSwapAction = React.useCallback(

--- a/packages/mrgn-ui/src/components/action-box-v2/actions/deposit-swap-box/deposit-swap-box.tsx
+++ b/packages/mrgn-ui/src/components/action-box-v2/actions/deposit-swap-box/deposit-swap-box.tsx
@@ -18,6 +18,7 @@ import {
   PreviousTxn,
   DepositSwapActionTxns,
   checkDepositSwapActionAvailable,
+  usePrevious,
 } from "@mrgnlabs/mrgn-utils";
 
 import { ActionButton, ActionCollateralProgressBar } from "~/components/action-box-v2/components";
@@ -212,7 +213,6 @@ export const DepositSwapBox = ({
   );
 
   const actionMessages = React.useMemo(() => {
-    !errorMessage && setAdditionalActionMessages([]);
     return checkDepositSwapActionAvailable({
       amount,
       connected,
@@ -225,7 +225,6 @@ export const DepositSwapBox = ({
       lendMode,
     });
   }, [
-    errorMessage,
     amount,
     connected,
     showCloseBalance,
@@ -238,6 +237,27 @@ export const DepositSwapBox = ({
   ]);
 
   const buttonLabel = React.useMemo(() => (showCloseBalance ? "Close" : lendMode), [showCloseBalance, lendMode]);
+
+  /*
+  Cleaing additional action messages when the bank or amount changes. This is to prevent outdated errors from being displayed.
+  */
+  const prevSelectedBank = usePrevious(selectedDepositBank);
+  const prevSwapBank = usePrevious(selectedSwapBank);
+  const prevAmount = usePrevious(amount);
+
+  React.useEffect(() => {
+    if (
+      prevSelectedBank &&
+      prevSwapBank &&
+      prevAmount &&
+      (prevSelectedBank.meta.tokenSymbol !== selectedDepositBank?.meta.tokenSymbol ||
+        prevSwapBank.meta.tokenSymbol !== selectedSwapBank?.meta.tokenSymbol ||
+        prevAmount !== amount)
+    ) {
+      setAdditionalActionMessages([]);
+      setErrorMessage(null);
+    }
+  }, [prevSelectedBank, prevSwapBank, prevAmount, selectedDepositBank, selectedSwapBank, amount, setErrorMessage]);
 
   ///////////////////////
   // Deposit-Swap Actions //

--- a/packages/mrgn-ui/src/components/action-box-v2/actions/deposit-swap-box/hooks/use-deposit-swap-simulation.hooks.ts
+++ b/packages/mrgn-ui/src/components/action-box-v2/actions/deposit-swap-box/hooks/use-deposit-swap-simulation.hooks.ts
@@ -180,6 +180,7 @@ export function useDepositSwapSimulation({
         } else if (simulationResult.simulationResult) {
           setSimulationResult(simulationResult.simulationResult);
           setActionTxns(depositSwapActionTxns.actionTxns);
+          setErrorMessage(null);
         } else {
           throw new Error("Unknown error");
         }

--- a/packages/mrgn-ui/src/components/action-box-v2/actions/lend-box/hooks/use-lend-simulation.hooks.ts
+++ b/packages/mrgn-ui/src/components/action-box-v2/actions/lend-box/hooks/use-lend-simulation.hooks.ts
@@ -112,6 +112,7 @@ export function useLendSimulation({
 
         if (lendingObject && "actionTxn" in lendingObject) {
           setActionTxns({ actionTxn: lendingObject.actionTxn, additionalTxns: lendingObject.additionalTxns });
+          setErrorMessage(null);
         } else {
           const errorMessage = lendingObject ?? STATIC_SIMULATION_ERRORS.BUILDING_LENDING_TX;
           setErrorMessage(errorMessage);

--- a/packages/mrgn-ui/src/components/action-box-v2/actions/lend-box/lend-box.tsx
+++ b/packages/mrgn-ui/src/components/action-box-v2/actions/lend-box/lend-box.tsx
@@ -21,6 +21,7 @@ import {
   MarginfiActionParams,
   MultiStepToastHandle,
   PreviousTxn,
+  usePrevious,
 } from "@mrgnlabs/mrgn-utils";
 
 import { ActionButton, ActionCollateralProgressBar } from "~/components/action-box-v2/components";
@@ -207,7 +208,6 @@ export const LendBox = ({
   );
 
   const actionMessages = React.useMemo(() => {
-    !errorMessage && setAdditionalActionMessages([]);
     return checkLendActionAvailable({
       amount,
       connected,
@@ -218,19 +218,26 @@ export const LendBox = ({
       nativeSolBalance,
       lendMode,
     });
-  }, [
-    errorMessage,
-    amount,
-    connected,
-    showCloseBalance,
-    selectedBank,
-    banks,
-    selectedAccount,
-    nativeSolBalance,
-    lendMode,
-  ]);
+  }, [amount, connected, showCloseBalance, selectedBank, banks, selectedAccount, nativeSolBalance, lendMode]);
 
   const buttonLabel = React.useMemo(() => (showCloseBalance ? "Close" : lendMode), [showCloseBalance, lendMode]);
+
+  /*
+  Cleaing additional action messages when the bank or amount changes. This is to prevent outdated errors from being displayed.
+  */
+  const prevSelectedBank = usePrevious(selectedBank);
+  const prevAmount = usePrevious(amount);
+
+  React.useEffect(() => {
+    if (
+      prevSelectedBank &&
+      prevAmount &&
+      (prevSelectedBank.meta.tokenSymbol !== selectedBank?.meta.tokenSymbol || prevAmount !== amount)
+    ) {
+      setAdditionalActionMessages([]);
+      setErrorMessage(null);
+    }
+  }, [prevSelectedBank, prevAmount, selectedBank, amount, setErrorMessage]);
 
   //////////////////////////
   // Close Balance Action //

--- a/packages/mrgn-ui/src/components/action-box-v2/actions/lend-box/lend-box.tsx
+++ b/packages/mrgn-ui/src/components/action-box-v2/actions/lend-box/lend-box.tsx
@@ -207,7 +207,7 @@ export const LendBox = ({
   );
 
   const actionMessages = React.useMemo(() => {
-    setAdditionalActionMessages([]);
+    !errorMessage && setAdditionalActionMessages([]);
     return checkLendActionAvailable({
       amount,
       connected,
@@ -218,7 +218,17 @@ export const LendBox = ({
       nativeSolBalance,
       lendMode,
     });
-  }, [amount, connected, showCloseBalance, selectedBank, banks, selectedAccount, nativeSolBalance, lendMode]);
+  }, [
+    errorMessage,
+    amount,
+    connected,
+    showCloseBalance,
+    selectedBank,
+    banks,
+    selectedAccount,
+    nativeSolBalance,
+    lendMode,
+  ]);
 
   const buttonLabel = React.useMemo(() => (showCloseBalance ? "Close" : lendMode), [showCloseBalance, lendMode]);
 

--- a/packages/mrgn-ui/src/components/action-box-v2/actions/loop-box/loop-box.tsx
+++ b/packages/mrgn-ui/src/components/action-box-v2/actions/loop-box/loop-box.tsx
@@ -21,6 +21,7 @@ import {
   showErrorToast,
   cn,
   IndividualFlowError,
+  usePrevious,
 } from "@mrgnlabs/mrgn-utils";
 
 import { useAmountDebounce } from "~/hooks/useAmountDebounce";
@@ -233,6 +234,27 @@ export const LoopBox = ({
       actionQuote: actionTxns.actionQuote,
     });
   }, [amount, connected, selectedBank, selectedSecondaryBank, actionTxns.actionQuote]);
+
+  /*
+  Cleaing additional action messages when the bank or amount changes. This is to prevent outdated errors from being displayed.
+  */
+  const prevSelectedBank = usePrevious(selectedBank);
+  const prevSecondaryBank = usePrevious(selectedSecondaryBank);
+  const prevAmount = usePrevious(amount);
+
+  React.useEffect(() => {
+    if (
+      prevSelectedBank &&
+      prevSecondaryBank &&
+      prevAmount &&
+      (prevSelectedBank.meta.tokenSymbol !== selectedBank?.meta.tokenSymbol ||
+        prevSecondaryBank.meta.tokenSymbol !== selectedSecondaryBank?.meta.tokenSymbol ||
+        prevAmount !== amount)
+    ) {
+      setAdditionalActionMessages([]);
+      setErrorMessage(null);
+    }
+  }, [prevSelectedBank, prevSecondaryBank, prevAmount, selectedBank, selectedSecondaryBank, amount, setErrorMessage]);
 
   /////////////////////
   // Looping Actions //

--- a/packages/mrgn-ui/src/components/action-box-v2/actions/repay-collat-box/repay-collat-box.tsx
+++ b/packages/mrgn-ui/src/components/action-box-v2/actions/repay-collat-box/repay-collat-box.tsx
@@ -19,6 +19,7 @@ import {
   MultiStepToastHandle,
   cn,
   IndividualFlowError,
+  usePrevious,
 } from "@mrgnlabs/mrgn-utils";
 import { IconCheck } from "@tabler/icons-react";
 
@@ -221,6 +222,27 @@ export const RepayCollatBox = ({
       actionQuote: actionTxns.actionQuote,
     });
   }, [amount, connected, selectedBank, selectedSecondaryBank, actionTxns.actionQuote]);
+
+  /*
+  Cleaing additional action messages when the bank or amount changes. This is to prevent outdated errors from being displayed.
+  */
+  const prevSelectedBank = usePrevious(selectedBank);
+  const prevSecondaryBank = usePrevious(selectedSecondaryBank);
+  const prevAmount = usePrevious(amount);
+
+  React.useEffect(() => {
+    if (
+      prevSelectedBank &&
+      prevSecondaryBank &&
+      prevAmount &&
+      (prevSelectedBank.meta.tokenSymbol !== selectedBank?.meta.tokenSymbol ||
+        prevSecondaryBank.meta.tokenSymbol !== selectedSecondaryBank?.meta.tokenSymbol ||
+        prevAmount !== amount)
+    ) {
+      setAdditionalActionMessages([]);
+      setErrorMessage(null);
+    }
+  }, [prevSelectedBank, prevSecondaryBank, prevAmount, selectedBank, selectedSecondaryBank, amount, setErrorMessage]);
 
   /////////////////////////
   // Repay Collat Action //

--- a/packages/mrgn-ui/src/components/action-box-v2/actions/stake-box/stake-box.tsx
+++ b/packages/mrgn-ui/src/components/action-box-v2/actions/stake-box/stake-box.tsx
@@ -14,6 +14,7 @@ import {
   MultiStepToastHandle,
   ActionTxns,
   IndividualFlowError,
+  usePrevious,
 } from "@mrgnlabs/mrgn-utils";
 
 import { useActionAmounts } from "~/components/action-box-v2/hooks";
@@ -183,7 +184,6 @@ export const StakeBox = ({
   }, [lstData, solPriceUsd]);
 
   const actionMessages = React.useMemo(() => {
-    setAdditionalActionMessages([]);
     return checkStakeActionAvailable({
       amount,
       connected,
@@ -192,6 +192,23 @@ export const StakeBox = ({
       lstData,
     });
   }, [amount, connected, selectedBank, actionTxns.actionQuote, lstData]);
+
+  /*
+  Cleaing additional action messages when the bank or amount changes. This is to prevent outdated errors from being displayed.
+  */
+  const prevSelectedBank = usePrevious(selectedBank);
+  const prevAmount = usePrevious(amount);
+
+  React.useEffect(() => {
+    if (
+      prevSelectedBank &&
+      prevAmount &&
+      (prevSelectedBank.meta.tokenSymbol !== selectedBank?.meta.tokenSymbol || prevAmount !== amount)
+    ) {
+      setAdditionalActionMessages([]);
+      setErrorMessage(null);
+    }
+  }, [prevSelectedBank, prevAmount, selectedBank, amount, setErrorMessage]);
 
   /////////////////////
   // Staking Actions //


### PR DESCRIPTION
Not resetting additional action messages (aka errorMessage) when refetching mrgnlend state