### PR TITLE
chore: QA changes on deposit-swap

### DIFF
--- a/packages/mrgn-ui/src/components/action-box-v2/actions/deposit-swap-box/hooks/use-deposit-swap-simulation.hooks.ts
+++ b/packages/mrgn-ui/src/components/action-box-v2/actions/deposit-swap-box/hooks/use-deposit-swap-simulation.hooks.ts
@@ -38,6 +38,7 @@ type DepositSwapSimulationProps = {
   setActionTxns: (actionTxns: DepositSwapActionTxns) => void;
   setErrorMessage: (error: ActionMessageType | null) => void;
   setIsLoading: ({ isLoading, status }: { isLoading: boolean; status: SimulationStatus }) => void;
+  actionMessages: ActionMessageType[];
 };
 
 export function useDepositSwapSimulation({
@@ -54,6 +55,7 @@ export function useDepositSwapSimulation({
   setActionTxns,
   setErrorMessage,
   setIsLoading,
+  actionMessages,
 }: DepositSwapSimulationProps) {
   const prevDebouncedAmount = usePrevious(debouncedAmount);
   const prevDepositBank = usePrevious(depositBank);
@@ -132,7 +134,9 @@ export function useDepositSwapSimulation({
   const handleSimulation = React.useCallback(
     async (amount: number) => {
       try {
-        if (amount === 0 || !depositBank || !selectedAccount || !marginfiClient || !jupiterOptions) {
+        const isDisabled = actionMessages.some((message) => !message.isEnabled);
+
+        if (amount === 0 || !depositBank || !selectedAccount || !marginfiClient || !jupiterOptions || isDisabled) {
           // TODO: will there be cases where the account isnt defined? In arena esp?
           setActionTxns({ actionTxn: null, additionalTxns: [], actionQuote: null });
           return;
@@ -202,6 +206,7 @@ export function useDepositSwapSimulation({
       setIsLoading,
       setSimulationResult,
       swapBank,
+      actionMessages,
     ]
   );
 

--- a/packages/mrgn-utils/src/action-message.utils.ts
+++ b/packages/mrgn-utils/src/action-message.utils.ts
@@ -9,6 +9,7 @@ import {
   canBeLooped,
   DYNAMIC_SIMULATION_ERRORS,
   LstData,
+  canBeDepositSwapped,
 } from ".";
 import { ActionType, ExtendedBankInfo } from "@mrgnlabs/marginfi-v2-ui-state";
 import { MarginfiAccountWrapper } from "@mrgnlabs/marginfi-client-v2";
@@ -289,22 +290,19 @@ export function checkDepositSwapActionAvailable({
 }: CheckDepositSwapActionAvailableProps): ActionMessageType[] {
   let checks: ActionMessageType[] = [];
 
-  const requiredCheck = getRequiredCheck(connected, depositBank);
-  if (requiredCheck) return [requiredCheck];
+  if (!connected || !depositBank || !swapBank) {
+    checks.push({ isEnabled: false });
+    return checks;
+  }
 
   const generalChecks = getGeneralChecks(amount ?? 0, showCloseBalance);
   if (generalChecks) checks.push(...generalChecks);
 
   // alert checks
   if (depositBank) {
-    const depositChecks = canBeLent(depositBank, nativeSolBalance);
+    const depositChecks = canBeDepositSwapped(depositBank, swapBank, nativeSolBalance);
     if (depositChecks.length) checks.push(...depositChecks);
   }
-
-  if (!swapBank) {
-    checks.push({ isEnabled: false });
-  }
-
   if (checks.length === 0)
     checks.push({
       isEnabled: true,


### PR DESCRIPTION
- Tailored canDepositSwap check: this was the issue that i mentioned during our chat. Updated the canDepositSwap to not look for the balance of the bank we were depositing into but to check the swapBank
- Not simulating when there are actionMessages that disable: unnecessarily running a simulation when there were actionMessages that prevent that simulation. Found this one using a whale wallet. He was borrowing sol, I tried to deposit-swap into sol, got an actionMessage but it still simulated the action
- Update filter of second inputField: I wasnt correctly filtering out the origin token, but that's updated now & we are filtering correctly 