### PR TITLE
feat: added arena tx tags to all marginfi transactions on the arena

### DIFF
--- a/apps/marginfi-v2-trading/src/components/common/trade-box-v2/hooks/use-trade-simulation.ts
+++ b/apps/marginfi-v2-trading/src/components/common/trade-box-v2/hooks/use-trade-simulation.ts
@@ -10,12 +10,12 @@ import {
 } from "@mrgnlabs/marginfi-client-v2";
 import {
   ActionMessageType,
-  CalculateLoopingProps,
   DYNAMIC_SIMULATION_ERRORS,
   extractErrorString,
   TradeActionTxns,
   STATIC_SIMULATION_ERRORS,
   usePrevious,
+  CalculateTradingProps,
 } from "@mrgnlabs/mrgn-utils";
 
 import { SimulationStatus } from "~/components/action-box-v2/utils";
@@ -110,8 +110,6 @@ export function useTradeSimulation({
     if (props.txns.length > 0) {
       const simulationResult = await getSimulationResult(props);
 
-      console.log("simulationResult", simulationResult);
-
       if (simulationResult.actionMethod) {
         return { simulationResult: null, actionMessage: simulationResult.actionMethod };
       } else if (simulationResult.simulationResult) {
@@ -126,15 +124,13 @@ export function useTradeSimulation({
   };
 
   const fetchTradeTxnsAction = async (
-    props: CalculateLoopingProps
+    props: CalculateTradingProps
   ): Promise<{ actionTxns: TradeActionTxns | null; actionMessage: ActionMessageType | null }> => {
     try {
       console.log("fetching trade txns, props", props);
       const tradingResult = await generateTradeTx({
         ...props,
       });
-
-      console.log("tradingResult", tradingResult);
 
       if (tradingResult && "actionQuote" in tradingResult) {
         return { actionTxns: tradingResult, actionMessage: null };

--- a/apps/marginfi-v2-trading/src/components/common/trade-box-v2/trade-box.tsx
+++ b/apps/marginfi-v2-trading/src/components/common/trade-box-v2/trade-box.tsx
@@ -184,7 +184,16 @@ export const TradeBoxV2 = ({ activePool, side = "long" }: TradeBoxV2Props) => {
         leverage,
       }),
 
-    [amount, connected, actionTxns, tradeState, borrowBank, depositBank, leverage]
+    [
+      amount,
+      connected,
+      depositBank,
+      borrowBank,
+      actionTxns.actionQuote,
+      tradeState,
+      activePoolExtended.status,
+      leverage,
+    ]
   );
 
   const actionMethods = React.useMemo(() => {

--- a/apps/marginfi-v2-trading/src/hooks/useMarginfiClient.tsx
+++ b/apps/marginfi-v2-trading/src/hooks/useMarginfiClient.tsx
@@ -121,7 +121,7 @@ export function useMarginfiClient({
       clientOptions?.bundleSimRpcEndpoint,
       clientOptions?.processTransactionStrategy,
       lookupTables,
-      true
+      true // Add arena tag to transactions
     );
 
     return client;

--- a/apps/marginfi-v2-trading/src/hooks/useMarginfiClient.tsx
+++ b/apps/marginfi-v2-trading/src/hooks/useMarginfiClient.tsx
@@ -120,7 +120,8 @@ export function useMarginfiClient({
       bankMetadataByBankPk,
       clientOptions?.bundleSimRpcEndpoint,
       clientOptions?.processTransactionStrategy,
-      lookupTables
+      lookupTables,
+      true
     );
 
     return client;

--- a/packages/marginfi-client-v2/src/clients/client.ts
+++ b/packages/marginfi-client-v2/src/clients/client.ts
@@ -119,6 +119,7 @@ class MarginfiClient {
   public processTransactionStrategy?: ProcessTransactionStrategy;
   private preloadedBankAddresses?: PublicKey[];
   private bundleSimRpcEndpoint: string;
+  private addArenaTxTag: boolean;
 
   // --------------------------------------------------------------------------
   // Factories
@@ -139,7 +140,8 @@ class MarginfiClient {
     readonly bankMetadataMap?: BankMetadataMap,
     bundleSimRpcEndpoint?: string,
     processTransactionStrategy?: ProcessTransactionStrategy,
-    lookupTablesAddresses?: PublicKey[]
+    lookupTablesAddresses?: PublicKey[],
+    addArenaTxTag?: boolean
   ) {
     this.group = group;
     this.banks = banks;
@@ -151,6 +153,7 @@ class MarginfiClient {
     this.bundleSimRpcEndpoint = bundleSimRpcEndpoint ?? program.provider.connection.rpcEndpoint;
     this.processTransactionStrategy = processTransactionStrategy;
     this.lookupTablesAddresses = lookupTablesAddresses ?? [];
+    this.addArenaTxTag = addArenaTxTag ?? false;
   }
 
   /**
@@ -976,6 +979,7 @@ class MarginfiClient {
       programId: this.program.programId,
       bundleSimRpcEndpoint: this.bundleSimRpcEndpoint,
       dynamicStrategy: processOpts?.dynamicStrategy ?? this.processTransactionStrategy,
+      addArenaTxTag: this.addArenaTxTag,
     };
 
     const [signature] = await processTransactions({

--- a/packages/marginfi-client-v2/src/clients/client.ts
+++ b/packages/marginfi-client-v2/src/clients/client.ts
@@ -941,6 +941,7 @@ class MarginfiClient {
       programId: this.program.programId,
       bundleSimRpcEndpoint: this.bundleSimRpcEndpoint,
       dynamicStrategy: processOpts?.dynamicStrategy ?? this.processTransactionStrategy,
+      addArenaTxTag: this.addArenaTxTag,
     };
 
     console.log("processOpts", processOpts);

--- a/packages/marginfi-client-v2/src/services/transaction/transaction.service.ts
+++ b/packages/marginfi-client-v2/src/services/transaction/transaction.service.ts
@@ -53,6 +53,7 @@ export interface ProcessTransactionOpts extends ProcessTransactionsClientOpts {
   isReadOnly?: boolean;
   programId?: PublicKey;
   bundleSimRpcEndpoint?: string;
+  isArenaTxTag?: boolean;
 }
 
 export type PriorityFees = {

--- a/packages/marginfi-client-v2/src/services/transaction/transaction.service.ts
+++ b/packages/marginfi-client-v2/src/services/transaction/transaction.service.ts
@@ -53,7 +53,7 @@ export interface ProcessTransactionOpts extends ProcessTransactionsClientOpts {
   isReadOnly?: boolean;
   programId?: PublicKey;
   bundleSimRpcEndpoint?: string;
-  isArenaTxTag?: boolean;
+  addArenaTxTag?: boolean;
 }
 
 export type PriorityFees = {
@@ -247,7 +247,8 @@ export async function processTransactions({
     processOpts.bundleTipUi ?? 0,
     wallet.publicKey,
     blockhash,
-    maxCapUi
+    maxCapUi,
+    processOpts.addArenaTxTag
   );
 
   let signatures: TransactionSignature[] = [];

--- a/packages/marginfi-client-v2/src/services/transaction/transaction.service.ts
+++ b/packages/marginfi-client-v2/src/services/transaction/transaction.service.ts
@@ -12,14 +12,12 @@ import {
   addTransactionMetadata,
   microLamportsToUi,
   getComputeBudgetUnits,
-  MaxCapType,
   SKIP_SIMULATION,
 } from "@mrgnlabs/mrgn-common";
 import {
   VersionedTransaction,
   TransactionSignature,
   Connection,
-  SendTransactionError,
   ConfirmOptions,
   PublicKey,
   Commitment,

--- a/packages/mrgn-common/src/modules/transactions/transaction.types.ts
+++ b/packages/mrgn-common/src/modules/transactions/transaction.types.ts
@@ -1,4 +1,4 @@
-import { VersionedTransaction, Transaction, Signer, AddressLookupTableAccount } from "@solana/web3.js";
+import { VersionedTransaction, Transaction, Signer, AddressLookupTableAccount, PublicKey } from "@solana/web3.js";
 
 export enum TransactionType {
   // BASE LENDING ACTIONS
@@ -105,6 +105,18 @@ export const TransactionConfigMap: Record<TransactionType, TransactionConfig> = 
   [TransactionType.JUPITER_SWAP]: { label: "Swapping tokens" },
   [TransactionType.INITIALIZE_STAKED_POOL]: { label: "Initializing Staked Pool" },
   [TransactionType.ADD_STAKED_BANK]: { label: "Adding Staked Bank" },
+};
+
+export const TransactionArenaKeyMap: Partial<Record<TransactionType, PublicKey>> = {
+  [TransactionType.DEPOSIT]: new PublicKey("ArenaDeposit1111111111111111111111111111111"),
+  [TransactionType.WITHDRAW]: new PublicKey("ArenaWithdraw111111111111111111111111111111"),
+  [TransactionType.BORROW]: new PublicKey("ArenaBorrow11111111111111111111111111111111"),
+  [TransactionType.REPAY]: new PublicKey("ArenaRepay111111111111111111111111111111111"),
+  [TransactionType.REPAY_COLLAT]: new PublicKey("ArenaRepayCo11at111111111111111111111111111"),
+  [TransactionType.LONG]: new PublicKey("ArenaLong1111111111111111111111111111111111"),
+  [TransactionType.SHORT]: new PublicKey("ArenaShort111111111111111111111111111111111"),
+  [TransactionType.CLOSE_POSITION]: new PublicKey("ArenaC1ose111111111111111111111111111111111"),
+  // Add more mappings if needed
 };
 
 export type ExtendedTransaction = Transaction & {

--- a/packages/mrgn-utils/src/actions/flashloans/builders.ts
+++ b/packages/mrgn-utils/src/actions/flashloans/builders.ts
@@ -5,11 +5,13 @@ import BigNumber from "bignumber.js";
 import { MarginfiAccountWrapper, MarginfiClient, PriorityFees } from "@mrgnlabs/marginfi-client-v2";
 import { ActiveBankInfo, ExtendedBankInfo } from "@mrgnlabs/marginfi-v2-ui-state";
 import {
+  addTransactionMetadata,
   ExtendedV0Transaction,
   LUT_PROGRAM_AUTHORITY_INDEX,
   nativeToUi,
   SolanaTransaction,
   TransactionBroadcastType,
+  TransactionType,
   uiToNative,
 } from "@mrgnlabs/mrgn-common";
 
@@ -503,5 +505,14 @@ export async function closePositionBuilder({
     },
   });
 
-  return { transactions, txOverflown };
+  const updatedTransactions = transactions.map((tx) =>
+    tx.type === TransactionType.REPAY_COLLAT
+      ? addTransactionMetadata(tx, {
+          ...tx,
+          type: TransactionType.CLOSE_POSITION,
+        })
+      : tx
+  );
+
+  return { transactions: updatedTransactions, txOverflown };
 }

--- a/packages/mrgn-utils/src/actions/individualFlows.ts
+++ b/packages/mrgn-utils/src/actions/individualFlows.ts
@@ -713,20 +713,23 @@ export async function trade({
   }
   const excludedTypes: TransactionType[] = [TransactionType.JUPITER_SWAP];
 
+  console.log("tradingProps", tradingProps);
+
   if (!multiStepToast) {
     const steps = getSteps({
       actionTxns,
       excludedTypes,
       customLabels: {
-        [TransactionType.LOOP]: `${tradingProps.tradeSide === "long" ? "Longing" : "Shorting"} ${
-          tradingProps.tradeSide === "long"
-            ? tradingProps.depositBank.meta.tokenSymbol
-            : tradingProps.borrowBank.meta.tokenSymbol
-        } with ${dynamicNumeralFormatter(tradingProps.depositAmount)} USDC`,
+        [TransactionType.LONG]: `Longing ${tradingProps.depositBank.meta.tokenSymbol} with ${dynamicNumeralFormatter(
+          tradingProps.depositAmount
+        )} ${tradingProps.borrowBank.meta.tokenSymbol}`,
+        [TransactionType.SHORT]: `Shorting ${tradingProps.borrowBank.meta.tokenSymbol} with ${dynamicNumeralFormatter(
+          tradingProps.depositAmount
+        )} ${tradingProps.depositBank.meta.tokenSymbol}`,
       },
-    }); // TODO: update custom labels
+    });
 
-    multiStepToast = new MultiStepToastHandle("Trading", steps);
+    multiStepToast = new MultiStepToastHandle(tradingProps.tradeSide === "long" ? "Longing" : "Shorting", steps);
     multiStepToast.start();
   } else {
     multiStepToast.resetAndStart();

--- a/packages/mrgn-utils/src/actions/types.ts
+++ b/packages/mrgn-utils/src/actions/types.ts
@@ -99,6 +99,10 @@ export interface DepositSwapActionTxns extends ActionTxns {
   actionQuote: QuoteResponse | null;
 }
 
+export interface CalculateTradingProps extends CalculateLoopingProps {
+  tradeState: "long" | "short";
+}
+
 export interface CalculateLoopingProps
   extends Pick<LoopingProps, "marginfiAccount" | "borrowBank" | "depositBank" | "depositAmount" | "connection"> {
   targetLeverage: number;
@@ -107,7 +111,6 @@ export interface CalculateLoopingProps
   slippageMode: "DYNAMIC" | "FIXED";
   platformFeeBps: number;
   setupBankAddresses?: PublicKey[];
-  tradeState?: "long" | "short";
 }
 
 export interface CalculateRepayCollateralProps


### PR DESCRIPTION
utilizes new transaction type to determine which transaction is being proccessed and adds an account key for arena transactions

there is some extra logic to add keys for LONG, SHORT and CLOSE_POSITIONS 