### PR TITLE
fix(mfi): looper staked-assets check & arena tag changes

### DIFF
--- a/apps/marginfi-v2-trading/src/components/common/Portfolio/PositionActionButtons.tsx
+++ b/apps/marginfi-v2-trading/src/components/common/Portfolio/PositionActionButtons.tsx
@@ -110,10 +110,9 @@ export const PositionActionButtons = ({
           depositSwapProps={{
             connected: connected,
             requestedDepositBank: depositBanks[0],
-            banks: extendedBankInfos,
             requestedSwapBank: arenaPool.status === GroupStatus.LONG ? borrowBank ?? undefined : undefined,
             showAvailableCollateral: false,
-            walletTokens: walletTokens,
+            walletTokens: null,
             captureEvent: () => {
               capture("position_add_btn_click", {
                 group: arenaPool.groupPk?.toBase58(),

--- a/apps/marginfi-v2-trading/src/components/common/trade-box-v2/hooks/use-trade-simulation.ts
+++ b/apps/marginfi-v2-trading/src/components/common/trade-box-v2/hooks/use-trade-simulation.ts
@@ -10,12 +10,12 @@ import {
 } from "@mrgnlabs/marginfi-client-v2";
 import {
   ActionMessageType,
-  CalculateLoopingProps,
   DYNAMIC_SIMULATION_ERRORS,
   extractErrorString,
   TradeActionTxns,
   STATIC_SIMULATION_ERRORS,
   usePrevious,
+  CalculateTradingProps,
 } from "@mrgnlabs/mrgn-utils";
 
 import { SimulationStatus } from "~/components/action-box-v2/utils";
@@ -110,8 +110,6 @@ export function useTradeSimulation({
     if (props.txns.length > 0) {
       const simulationResult = await getSimulationResult(props);
 
-      console.log("simulationResult", simulationResult);
-
       if (simulationResult.actionMethod) {
         return { simulationResult: null, actionMessage: simulationResult.actionMethod };
       } else if (simulationResult.simulationResult) {
@@ -126,15 +124,13 @@ export function useTradeSimulation({
   };
 
   const fetchTradeTxnsAction = async (
-    props: CalculateLoopingProps
+    props: CalculateTradingProps
   ): Promise<{ actionTxns: TradeActionTxns | null; actionMessage: ActionMessageType | null }> => {
     try {
       console.log("fetching trade txns, props", props);
       const tradingResult = await generateTradeTx({
         ...props,
       });
-
-      console.log("tradingResult", tradingResult);
 
       if (tradingResult && "actionQuote" in tradingResult) {
         return { actionTxns: tradingResult, actionMessage: null };

--- a/apps/marginfi-v2-trading/src/components/common/trade-box-v2/trade-box.tsx
+++ b/apps/marginfi-v2-trading/src/components/common/trade-box-v2/trade-box.tsx
@@ -184,7 +184,16 @@ export const TradeBoxV2 = ({ activePool, side = "long" }: TradeBoxV2Props) => {
         leverage,
       }),
 
-    [amount, connected, actionTxns, tradeState, borrowBank, depositBank, leverage]
+    [
+      amount,
+      connected,
+      depositBank,
+      borrowBank,
+      actionTxns.actionQuote,
+      tradeState,
+      activePoolExtended.status,
+      leverage,
+    ]
   );
 
   const actionMethods = React.useMemo(() => {

--- a/apps/marginfi-v2-trading/src/hooks/useMarginfiClient.tsx
+++ b/apps/marginfi-v2-trading/src/hooks/useMarginfiClient.tsx
@@ -121,7 +121,7 @@ export function useMarginfiClient({
       clientOptions?.bundleSimRpcEndpoint,
       clientOptions?.processTransactionStrategy,
       lookupTables,
-      true
+      true // Add arena tag to transactions
     );
 
     return client;

--- a/apps/marginfi-v2-trading/src/hooks/useMarginfiClient.tsx
+++ b/apps/marginfi-v2-trading/src/hooks/useMarginfiClient.tsx
@@ -120,7 +120,8 @@ export function useMarginfiClient({
       bankMetadataByBankPk,
       clientOptions?.bundleSimRpcEndpoint,
       clientOptions?.processTransactionStrategy,
-      lookupTables
+      lookupTables,
+      true
     );
 
     return client;

--- a/apps/marginfi-v2-ui/src/pages/deposit-swap.tsx
+++ b/apps/marginfi-v2-ui/src/pages/deposit-swap.tsx
@@ -17,7 +17,7 @@ export default function DepositSwapPage() {
     initialized,
     extendedBankInfosWithoutStakedAssets,
     fetchWalletTokens,
-    extendedbankInfos,
+    extendedBankInfos,
     marginfiClient,
     updateWalletTokens,
     updateWalletToken,
@@ -38,13 +38,13 @@ export default function DepositSwapPage() {
   React.useEffect(() => {
     if (
       wallet &&
-      extendedbankInfos &&
-      extendedbankInfos.length > 0 &&
+      extendedBankInfos &&
+      extendedBankInfos.length > 0 &&
       (walletTokens === null || walletTokens.length === 0)
     ) {
-      fetchWalletTokens(wallet, extendedbankInfos);
+      fetchWalletTokens(wallet, extendedBankInfos);
     }
-  }, [fetchWalletTokens, wallet, walletTokens, extendedbankInfos]);
+  }, [fetchWalletTokens, wallet, walletTokens, extendedBankInfos]);
 
   const fetchAndUpdateTokens = React.useCallback(() => {
     if (!wallet || !connection) {
@@ -79,6 +79,7 @@ export default function DepositSwapPage() {
             useProvider={true}
             depositSwapProps={{
               banks: extendedBankInfosWithoutStakedAssets,
+              allBanks: extendedBankInfos,
               connected: connected,
               requestedDepositBank: undefined,
               requestedSwapBank: undefined,

--- a/apps/marginfi-v2-ui/src/pages/looper.tsx
+++ b/apps/marginfi-v2-ui/src/pages/looper.tsx
@@ -9,9 +9,10 @@ import { Loader } from "~/components/ui/loader";
 import { useWallet } from "~/components/wallet-v2";
 
 export default function LooperPage() {
-  const [initialized, extendedBankInfosWithoutStakedAssets] = useMrgnlendStore((state) => [
+  const [initialized, extendedBankInfosWithoutStakedAssets, extendedBankInfos] = useMrgnlendStore((state) => [
     state.initialized,
     state.extendedBankInfosWithoutStakedAssets,
+    state.extendedBankInfos,
   ]);
   const { connected, walletContextState } = useWallet();
 
@@ -27,6 +28,7 @@ export default function LooperPage() {
             loopProps={{
               connected: connected,
               banks: extendedBankInfosWithoutStakedAssets,
+              allBanks: extendedBankInfos,
               walletContextState: walletContextState,
               captureEvent: (event, properties) => {
                 capture(event, properties);

--- a/apps/marginfi-v2-ui/src/utils/actionBoxUtils.ts
+++ b/apps/marginfi-v2-ui/src/utils/actionBoxUtils.ts
@@ -87,7 +87,7 @@ export function checkActionAvailable({
         if (borrowChecks.length) checks.push(...borrowChecks);
         break;
       case ActionType.Loop:
-        const loopChecks = canBeLooped(selectedBank, selectedRepayBank, repayCollatQuote);
+        const loopChecks = canBeLooped(selectedBank, selectedRepayBank, repayCollatQuote, extendedBankInfos);
         if (loopChecks.length) checks.push(...loopChecks);
         break;
       case ActionType.Repay:

--- a/packages/marginfi-client-v2/src/clients/client.ts
+++ b/packages/marginfi-client-v2/src/clients/client.ts
@@ -119,6 +119,7 @@ class MarginfiClient {
   public processTransactionStrategy?: ProcessTransactionStrategy;
   private preloadedBankAddresses?: PublicKey[];
   private bundleSimRpcEndpoint: string;
+  private addArenaTxTag: boolean;
 
   // --------------------------------------------------------------------------
   // Factories
@@ -139,7 +140,8 @@ class MarginfiClient {
     readonly bankMetadataMap?: BankMetadataMap,
     bundleSimRpcEndpoint?: string,
     processTransactionStrategy?: ProcessTransactionStrategy,
-    lookupTablesAddresses?: PublicKey[]
+    lookupTablesAddresses?: PublicKey[],
+    addArenaTxTag?: boolean
   ) {
     this.group = group;
     this.banks = banks;
@@ -151,6 +153,7 @@ class MarginfiClient {
     this.bundleSimRpcEndpoint = bundleSimRpcEndpoint ?? program.provider.connection.rpcEndpoint;
     this.processTransactionStrategy = processTransactionStrategy;
     this.lookupTablesAddresses = lookupTablesAddresses ?? [];
+    this.addArenaTxTag = addArenaTxTag ?? false;
   }
 
   /**
@@ -976,6 +979,7 @@ class MarginfiClient {
       programId: this.program.programId,
       bundleSimRpcEndpoint: this.bundleSimRpcEndpoint,
       dynamicStrategy: processOpts?.dynamicStrategy ?? this.processTransactionStrategy,
+      addArenaTxTag: this.addArenaTxTag,
     };
 
     const [signature] = await processTransactions({

--- a/packages/marginfi-client-v2/src/clients/client.ts
+++ b/packages/marginfi-client-v2/src/clients/client.ts
@@ -941,6 +941,7 @@ class MarginfiClient {
       programId: this.program.programId,
       bundleSimRpcEndpoint: this.bundleSimRpcEndpoint,
       dynamicStrategy: processOpts?.dynamicStrategy ?? this.processTransactionStrategy,
+      addArenaTxTag: this.addArenaTxTag,
     };
 
     console.log("processOpts", processOpts);

--- a/packages/marginfi-client-v2/src/services/transaction/transaction.service.ts
+++ b/packages/marginfi-client-v2/src/services/transaction/transaction.service.ts
@@ -53,6 +53,7 @@ export interface ProcessTransactionOpts extends ProcessTransactionsClientOpts {
   isReadOnly?: boolean;
   programId?: PublicKey;
   bundleSimRpcEndpoint?: string;
+  isArenaTxTag?: boolean;
 }
 
 export type PriorityFees = {

--- a/packages/marginfi-client-v2/src/services/transaction/transaction.service.ts
+++ b/packages/marginfi-client-v2/src/services/transaction/transaction.service.ts
@@ -53,7 +53,7 @@ export interface ProcessTransactionOpts extends ProcessTransactionsClientOpts {
   isReadOnly?: boolean;
   programId?: PublicKey;
   bundleSimRpcEndpoint?: string;
-  isArenaTxTag?: boolean;
+  addArenaTxTag?: boolean;
 }
 
 export type PriorityFees = {
@@ -247,7 +247,8 @@ export async function processTransactions({
     processOpts.bundleTipUi ?? 0,
     wallet.publicKey,
     blockhash,
-    maxCapUi
+    maxCapUi,
+    processOpts.addArenaTxTag
   );
 
   let signatures: TransactionSignature[] = [];

--- a/packages/marginfi-client-v2/src/services/transaction/transaction.service.ts
+++ b/packages/marginfi-client-v2/src/services/transaction/transaction.service.ts
@@ -12,14 +12,12 @@ import {
   addTransactionMetadata,
   microLamportsToUi,
   getComputeBudgetUnits,
-  MaxCapType,
   SKIP_SIMULATION,
 } from "@mrgnlabs/mrgn-common";
 import {
   VersionedTransaction,
   TransactionSignature,
   Connection,
-  SendTransactionError,
   ConfirmOptions,
   PublicKey,
   Commitment,

--- a/packages/mrgn-common/src/modules/transactions/transaction.types.ts
+++ b/packages/mrgn-common/src/modules/transactions/transaction.types.ts
@@ -1,4 +1,4 @@
-import { VersionedTransaction, Transaction, Signer, AddressLookupTableAccount } from "@solana/web3.js";
+import { VersionedTransaction, Transaction, Signer, AddressLookupTableAccount, PublicKey } from "@solana/web3.js";
 
 export enum TransactionType {
   // BASE LENDING ACTIONS
@@ -105,6 +105,18 @@ export const TransactionConfigMap: Record<TransactionType, TransactionConfig> = 
   [TransactionType.JUPITER_SWAP]: { label: "Swapping tokens" },
   [TransactionType.INITIALIZE_STAKED_POOL]: { label: "Initializing Staked Pool" },
   [TransactionType.ADD_STAKED_BANK]: { label: "Adding Staked Bank" },
+};
+
+export const TransactionArenaKeyMap: Partial<Record<TransactionType, PublicKey>> = {
+  [TransactionType.DEPOSIT]: new PublicKey("ArenaDeposit1111111111111111111111111111111"),
+  [TransactionType.WITHDRAW]: new PublicKey("ArenaWithdraw111111111111111111111111111111"),
+  [TransactionType.BORROW]: new PublicKey("ArenaBorrow11111111111111111111111111111111"),
+  [TransactionType.REPAY]: new PublicKey("ArenaRepay111111111111111111111111111111111"),
+  [TransactionType.REPAY_COLLAT]: new PublicKey("ArenaRepayCo11at111111111111111111111111111"),
+  [TransactionType.LONG]: new PublicKey("ArenaLong1111111111111111111111111111111111"),
+  [TransactionType.SHORT]: new PublicKey("ArenaShort111111111111111111111111111111111"),
+  [TransactionType.CLOSE_POSITION]: new PublicKey("ArenaC1ose111111111111111111111111111111111"),
+  // Add more mappings if needed
 };
 
 export type ExtendedTransaction = Transaction & {

--- a/packages/mrgn-ui/src/components/action-box-v2/actions/deposit-swap-box/components/action-input/action-input.tsx
+++ b/packages/mrgn-ui/src/components/action-box-v2/actions/deposit-swap-box/components/action-input/action-input.tsx
@@ -28,6 +28,7 @@ type ActionInputProps = {
   isInputDisabled?: boolean;
 
   walletTokens?: WalletToken[] | null;
+  showOnlyUserOwnedTokens?: boolean;
 
   setAmountRaw: (amount: string) => void;
   setSelectedBank: (bank: ExtendedBankInfo | WalletToken | null) => void;
@@ -51,6 +52,7 @@ export const ActionInput = ({
   setAmountRaw,
   setSelectedBank,
   walletTokens,
+  showOnlyUserOwnedTokens,
 }: ActionInputProps) => {
   const amountInputRef = React.useRef<HTMLInputElement>(null);
 
@@ -96,6 +98,7 @@ export const ActionInput = ({
             lendMode={lendMode}
             connected={connected}
             walletTokens={walletTokens}
+            showOnlyUserOwnedTokens={showOnlyUserOwnedTokens}
           />
         </div>
         <div className="flex-auto flex flex-col gap-0 items-end">

--- a/packages/mrgn-ui/src/components/action-box-v2/actions/deposit-swap-box/components/action-input/components/bank-select/bank-select.tsx
+++ b/packages/mrgn-ui/src/components/action-box-v2/actions/deposit-swap-box/components/action-input/components/bank-select/bank-select.tsx
@@ -19,6 +19,7 @@ type BankSelectProps = {
   setSelectedBank: (selectedBank: ExtendedBankInfo | WalletToken | null) => void;
 
   walletTokens?: WalletToken[] | null;
+  showOnlyUserOwnedTokens?: boolean;
 };
 
 export const BankSelect = ({
@@ -31,6 +32,7 @@ export const BankSelect = ({
   showTokenSelectionGroups,
   setSelectedBank,
   walletTokens,
+  showOnlyUserOwnedTokens,
 }: BankSelectProps) => {
   // idea check list if banks[] == 1 make it unselectable
   const [isOpen, setIsOpen] = React.useState(false);
@@ -58,6 +60,7 @@ export const BankSelect = ({
             connected={connected}
             showTokenSelectionGroups={showTokenSelectionGroups}
             walletTokens={walletTokens}
+            showOnlyUserOwnedTokens={showOnlyUserOwnedTokens}
           />
         }
       />

--- a/packages/mrgn-ui/src/components/action-box-v2/actions/deposit-swap-box/components/action-input/components/bank-select/components/bank-list/bank-list.tsx
+++ b/packages/mrgn-ui/src/components/action-box-v2/actions/deposit-swap-box/components/action-input/components/bank-select/components/bank-list/bank-list.tsx
@@ -21,6 +21,7 @@ type BankListProps = {
   onClose: () => void;
 
   walletTokens?: WalletToken[] | null;
+  showOnlyUserOwnedTokens?: boolean;
 };
 
 export const BankList = ({
@@ -34,6 +35,7 @@ export const BankList = ({
   isOpen,
   onClose,
   walletTokens,
+  showOnlyUserOwnedTokens,
 }: BankListProps) => {
   const lendingMode = React.useMemo(
     () =>
@@ -175,7 +177,7 @@ export const BankList = ({
     });
 
     return sorted as (ExtendedBankInfo | WalletToken)[];
-  }, [filteredWalletTokens, filteredBanks, nativeSolBalance]);
+  }, [filteredWalletTokens, filteredBanksUserOwns, nativeSolBalance]);
 
   return (
     <>
@@ -241,7 +243,7 @@ export const BankList = ({
         )}
 
         {/* GLOBAL & ISOLATED */}
-        {globalBanks.length > 0 && onSetSelectedBank && showTokenSelectionGroups && (
+        {!showOnlyUserOwnedTokens && globalBanks.length > 0 && onSetSelectedBank && showTokenSelectionGroups && (
           <CommandGroup heading="Global pools">
             {globalBanks.map((bank, index) => {
               return (
@@ -272,7 +274,7 @@ export const BankList = ({
             })}
           </CommandGroup>
         )}
-        {isolatedBanks.length > 0 && onSetSelectedBank && showTokenSelectionGroups && (
+        {!showOnlyUserOwnedTokens && isolatedBanks.length > 0 && onSetSelectedBank && showTokenSelectionGroups && (
           <CommandGroup heading="Isolated pools">
             {isolatedBanks.map((bank, index) => {
               return (

--- a/packages/mrgn-ui/src/components/action-box-v2/actions/deposit-swap-box/deposit-swap-box.tsx
+++ b/packages/mrgn-ui/src/components/action-box-v2/actions/deposit-swap-box/deposit-swap-box.tsx
@@ -509,7 +509,18 @@ export const DepositSwapBox = ({
           showTokenSelectionGroups={showTokenSelectionGroups}
           setAmountRaw={setAmountRaw}
           setSelectedBank={(bank) => {
-            bank && setSelectedSwapBankPk(bank.address);
+            const bankPk = bank?.address;
+            if (!bankPk) {
+              setSelectedSwapBankPk(null);
+              return;
+            }
+
+            if (selectedDepositBankPk?.equals(bankPk) && !requestedSwapBank) {
+              setSelectedSwapBankPk(bankPk);
+              setSelectedDepositBankPk(null);
+            } else {
+              setSelectedSwapBankPk(bankPk);
+            }
           }}
           walletTokens={walletTokens}
           showOnlyUserOwnedTokens={true}
@@ -554,7 +565,18 @@ export const DepositSwapBox = ({
             showTokenSelectionGroups={showTokenSelectionGroups}
             setAmountRaw={setAmountRaw}
             setSelectedBank={(bank) => {
-              bank && setSelectedDepositBankPk(bank.address);
+              const bankPk = bank?.address;
+              if (!bankPk) {
+                setSelectedDepositBankPk(null);
+                return;
+              }
+
+              if (selectedSwapBankPk?.equals(bankPk) && !requestedDepositBank) {
+                setSelectedDepositBankPk(bankPk);
+                setSelectedSwapBankPk(null);
+              } else {
+                setSelectedDepositBankPk(bankPk);
+              }
             }}
             isInputDisabled={true}
             showOnlyUserOwnedTokens={false}

--- a/packages/mrgn-ui/src/components/action-box-v2/actions/deposit-swap-box/deposit-swap-box.tsx
+++ b/packages/mrgn-ui/src/components/action-box-v2/actions/deposit-swap-box/deposit-swap-box.tsx
@@ -499,6 +499,7 @@ export const DepositSwapBox = ({
             bank && setSelectedSwapBankPk(bank.address);
           }}
           walletTokens={walletTokens}
+          showOnlyUserOwnedTokens={true}
         />
       </div>
 
@@ -543,6 +544,7 @@ export const DepositSwapBox = ({
               bank && setSelectedDepositBankPk(bank.address);
             }}
             isInputDisabled={true}
+            showOnlyUserOwnedTokens={false}
           />
         </div>
       )}

--- a/packages/mrgn-ui/src/components/action-box-v2/actions/deposit-swap-box/hooks/use-deposit-swap-simulation.hooks.ts
+++ b/packages/mrgn-ui/src/components/action-box-v2/actions/deposit-swap-box/hooks/use-deposit-swap-simulation.hooks.ts
@@ -38,7 +38,7 @@ type DepositSwapSimulationProps = {
   setActionTxns: (actionTxns: DepositSwapActionTxns) => void;
   setErrorMessage: (error: ActionMessageType | null) => void;
   setIsLoading: ({ isLoading, status }: { isLoading: boolean; status: SimulationStatus }) => void;
-  actionMessages: ActionMessageType[];
+  isDisabled: boolean;
 };
 
 export function useDepositSwapSimulation({
@@ -55,7 +55,7 @@ export function useDepositSwapSimulation({
   setActionTxns,
   setErrorMessage,
   setIsLoading,
-  actionMessages,
+  isDisabled,
 }: DepositSwapSimulationProps) {
   const prevDebouncedAmount = usePrevious(debouncedAmount);
   const prevDepositBank = usePrevious(depositBank);
@@ -134,8 +134,6 @@ export function useDepositSwapSimulation({
   const handleSimulation = React.useCallback(
     async (amount: number) => {
       try {
-        const isDisabled = actionMessages.some((message) => !message.isEnabled);
-
         if (amount === 0 || !depositBank || !selectedAccount || !marginfiClient || !jupiterOptions || isDisabled) {
           // TODO: will there be cases where the account isnt defined? In arena esp?
           setActionTxns({ transactions: [], actionQuote: null });
@@ -203,7 +201,7 @@ export function useDepositSwapSimulation({
       setIsLoading,
       setSimulationResult,
       swapBank,
-      actionMessages,
+      isDisabled,
     ]
   );
 

--- a/packages/mrgn-ui/src/components/action-box-v2/actions/deposit-swap-box/store/deposit-swap-box-store.ts
+++ b/packages/mrgn-ui/src/components/action-box-v2/actions/deposit-swap-box/store/deposit-swap-box-store.ts
@@ -135,18 +135,15 @@ const stateCreator: StateCreator<DepositSwapBoxState, [], []> = (set, get) => ({
   },
 
   setSelectedDepositBankPk(bankPk) {
-    const swapBankPk = get().selectedSwapBankPk;
     set({
       selectedDepositBankPk: bankPk,
-      selectedSwapBankPk: swapBankPk && bankPk?.toBase58() === swapBankPk.toBase58() ? null : swapBankPk, // cannot have same bank for both
     });
   },
 
   setSelectedSwapBankPk(bankPk) {
-    const depositBankPk = get().selectedDepositBankPk;
     set({
       selectedSwapBankPk: bankPk,
-      selectedDepositBankPk: depositBankPk && bankPk?.toBase58() === depositBankPk.toBase58() ? null : depositBankPk, // cannot have same bank for both
+      amountRaw: "",
     });
   },
 });

--- a/packages/mrgn-ui/src/components/action-box-v2/actions/deposit-swap-box/store/deposit-swap-box-store.ts
+++ b/packages/mrgn-ui/src/components/action-box-v2/actions/deposit-swap-box/store/deposit-swap-box-store.ts
@@ -135,11 +135,19 @@ const stateCreator: StateCreator<DepositSwapBoxState, [], []> = (set, get) => ({
   },
 
   setSelectedDepositBankPk(bankPk) {
-    set({ selectedDepositBankPk: bankPk });
+    const swapBankPk = get().selectedSwapBankPk;
+    set({
+      selectedDepositBankPk: bankPk,
+      selectedSwapBankPk: swapBankPk && bankPk?.toBase58() === swapBankPk.toBase58() ? null : swapBankPk, // cannot have same bank for both
+    });
   },
 
   setSelectedSwapBankPk(bankPk) {
-    set({ selectedSwapBankPk: bankPk });
+    const depositBankPk = get().selectedDepositBankPk;
+    set({
+      selectedSwapBankPk: bankPk,
+      selectedDepositBankPk: depositBankPk && bankPk?.toBase58() === depositBankPk.toBase58() ? null : depositBankPk, // cannot have same bank for both
+    });
   },
 });
 

--- a/packages/mrgn-ui/src/components/action-box-v2/actions/deposit-swap-box/utils/deposit-swap-action.utils.ts
+++ b/packages/mrgn-ui/src/components/action-box-v2/actions/deposit-swap-box/utils/deposit-swap-action.utils.ts
@@ -67,7 +67,8 @@ export async function generateDepositSwapTxns(
 
   if (
     props.swapBank &&
-    ("info" in props.swapBank ? props.swapBank.info.state.mint.toBase58() : props.swapBank.symbol)
+    ("info" in props.swapBank ? props.swapBank.info.state.mint.toBase58() : props.swapBank.address.toBase58()) !==
+      props.depositBank.info.state.mint.toBase58()
   ) {
     try {
       swapTx = await createSwapTx(props);
@@ -104,7 +105,12 @@ export async function generateDepositSwapTxns(
 
   let finalDepositAmount = props.amount;
 
-  if (props.swapBank && !swapTx?.quote) {
+  if (
+    props.swapBank &&
+    ("info" in props.swapBank ? props.swapBank.info.state.mint.toBase58() : props.swapBank.address.toBase58()) !==
+      props.depositBank.info.state.mint.toBase58() &&
+    !swapTx?.quote
+  ) {
     return STATIC_SIMULATION_ERRORS.CREATE_SWAP_FAILED;
   } else if (props.swapBank && swapTx?.quote) {
     finalDepositAmount = Number(

--- a/packages/mrgn-ui/src/components/action-box-v2/actions/loop-box/hooks/use-loop-simulation.hooks.ts
+++ b/packages/mrgn-ui/src/components/action-box-v2/actions/loop-box/hooks/use-loop-simulation.hooks.ts
@@ -41,6 +41,7 @@ type LoopSimulationProps = {
   setErrorMessage: (error: ActionMessageType | null) => void;
   setMaxLeverage: (maxLeverage: number) => void;
   setIsLoading: ({ isLoading, status }: { isLoading: boolean; status: SimulationStatus }) => void;
+  actionMessages: ActionMessageType[];
 };
 
 export function useLoopSimulation({
@@ -55,7 +56,7 @@ export function useLoopSimulation({
   simulationResult,
   isRefreshTxn,
   jupiterOptions,
-
+  actionMessages,
   setSimulationResult,
   setActionTxns,
   setErrorMessage,
@@ -219,7 +220,9 @@ export function useLoopSimulation({
 
   React.useEffect(() => {
     // only simulate when amount or leverage changes
-    if (prevDebouncedAmount !== debouncedAmount || prevDebouncedLeverage !== debouncedLeverage) {
+    const isDisabled = actionMessages.some((message) => !message.isEnabled);
+
+    if ((prevDebouncedAmount !== debouncedAmount || prevDebouncedLeverage !== debouncedLeverage) && !isDisabled) {
       fetchLoopingTxn(debouncedAmount, debouncedLeverage);
     }
 
@@ -227,7 +230,15 @@ export function useLoopSimulation({
     if (isRefreshTxn) {
       fetchLoopingTxn(debouncedAmount, debouncedLeverage);
     }
-  }, [prevDebouncedAmount, isRefreshTxn, debouncedAmount, debouncedLeverage, fetchLoopingTxn, prevDebouncedLeverage]);
+  }, [
+    prevDebouncedAmount,
+    isRefreshTxn,
+    debouncedAmount,
+    debouncedLeverage,
+    fetchLoopingTxn,
+    prevDebouncedLeverage,
+    actionMessages,
+  ]);
 
   React.useEffect(() => {
     // Only run simulation if we have transactions to simulate

--- a/packages/mrgn-ui/src/components/action-box-v2/actions/loop-box/loop-box.tsx
+++ b/packages/mrgn-ui/src/components/action-box-v2/actions/loop-box/loop-box.tsx
@@ -57,6 +57,7 @@ export type LoopBoxProps = {
   banks: ExtendedBankInfo[];
   requestedBank?: ExtendedBankInfo;
   accountSummaryArg?: AccountSummary;
+  allBanks: ExtendedBankInfo[];
 
   isDialog?: boolean;
 
@@ -73,6 +74,7 @@ export const LoopBox = ({
   selectedAccount,
   accountSummaryArg,
   requestedBank,
+  allBanks,
   isDialog,
   onComplete,
   captureEvent,
@@ -176,6 +178,19 @@ export const LoopBox = ({
 
   const debouncedLeverage = useAmountDebounce<number | null>(leverage, 1000);
 
+  const [additionalActionMessages, setAdditionalActionMessages] = React.useState<ActionMessageType[]>([]);
+  const [quoteActionMessage, setQuoteActionMessage] = React.useState<ActionMessageType[]>([]);
+
+  const actionMessages = React.useMemo(() => {
+    return checkLoopActionAvailable({
+      amount,
+      connected,
+      selectedBank,
+      selectedSecondaryBank,
+      banks: allBanks,
+    });
+  }, [amount, connected, selectedBank, selectedSecondaryBank, allBanks]);
+
   const { actionSummary, refreshSimulation } = useLoopSimulation({
     debouncedAmount: debouncedAmount ?? 0,
     debouncedLeverage: debouncedLeverage ?? 0,
@@ -193,9 +208,8 @@ export const LoopBox = ({
     setActionTxns,
     setErrorMessage,
     setIsLoading: setIsSimulating,
+    actionMessages: actionMessages,
   });
-
-  const [additionalActionMessages, setAdditionalActionMessages] = React.useState<ActionMessageType[]>([]);
 
   const [showSimSuccess, setShowSimSuccess] = React.useState(false);
 
@@ -223,24 +237,21 @@ export const LoopBox = ({
   }, [requestedBank, fetchActionBoxState]);
 
   React.useEffect(() => {
-    if (errorMessage && errorMessage.description) {
-      showErrorToast(errorMessage?.description);
-      setAdditionalActionMessages([errorMessage]);
+    if (errorMessage?.description) {
+      showErrorToast(errorMessage.description);
+      setAdditionalActionMessages((prevMessages) => [...prevMessages, errorMessage]);
     } else {
       setAdditionalActionMessages([]);
     }
   }, [errorMessage]);
 
-  const actionMessages = React.useMemo(() => {
-    return checkLoopActionAvailable({
-      amount,
-      connected,
-      selectedBank,
-      selectedSecondaryBank,
-      actionQuote: actionTxns.actionQuote,
-    });
-  }, [amount, connected, selectedBank, selectedSecondaryBank, actionTxns.actionQuote]);
-
+  React.useEffect(() => {
+    if (!actionTxns.actionQuote) {
+      setQuoteActionMessage([{ isEnabled: false }]);
+    } else {
+      setQuoteActionMessage([]);
+    }
+  }, [actionTxns.actionQuote]);
   /*
   Cleaing additional action messages when the bank or amount changes. This is to prevent outdated errors from being displayed.
   */
@@ -467,24 +478,30 @@ export const LoopBox = ({
           borrowLstApy={borrowLstApy}
         />
       </div>
-      {additionalActionMessages.concat(actionMessages).map(
-        (actionMessage, idx) =>
-          actionMessage.description && (
-            <div className="pb-6" key={idx}>
-              <ActionMessage
-                _actionMessage={actionMessage}
-                retry={refreshSimulation}
-                isRetrying={isSimulating.isLoading}
-              />
-            </div>
-          )
-      )}
+      {additionalActionMessages
+        .concat(actionMessages)
+        .concat(quoteActionMessage)
+        .map(
+          (actionMessage, idx) =>
+            actionMessage.description && (
+              <div className="pb-6" key={idx}>
+                <ActionMessage
+                  _actionMessage={actionMessage}
+                  retry={refreshSimulation}
+                  isRetrying={isSimulating.isLoading}
+                />
+              </div>
+            )
+        )}
 
       <div className="mb-3 space-y-2">
         <ActionButton
           isLoading={isLoading}
           isEnabled={
-            !additionalActionMessages.concat(actionMessages).filter((value) => value.isEnabled === false).length
+            !additionalActionMessages
+              .concat(actionMessages)
+              .concat(quoteActionMessage)
+              .filter((value) => value.isEnabled === false).length
           }
           connected={connected}
           handleAction={() => {

--- a/packages/mrgn-ui/src/components/action-box-v2/actions/loop-box/loop-box.tsx
+++ b/packages/mrgn-ui/src/components/action-box-v2/actions/loop-box/loop-box.tsx
@@ -57,7 +57,7 @@ export type LoopBoxProps = {
   banks: ExtendedBankInfo[];
   requestedBank?: ExtendedBankInfo;
   accountSummaryArg?: AccountSummary;
-  allBanks: ExtendedBankInfo[];
+  allBanks?: ExtendedBankInfo[];
 
   isDialog?: boolean;
 
@@ -187,7 +187,7 @@ export const LoopBox = ({
       connected,
       selectedBank,
       selectedSecondaryBank,
-      banks: allBanks,
+      banks: allBanks ?? [],
     });
   }, [amount, connected, selectedBank, selectedSecondaryBank, allBanks]);
 

--- a/packages/mrgn-utils/src/action-message.utils.ts
+++ b/packages/mrgn-utils/src/action-message.utils.ts
@@ -295,7 +295,11 @@ export function checkDepositSwapActionAvailable({
 }: CheckDepositSwapActionAvailableProps): ActionMessageType[] {
   let checks: ActionMessageType[] = [];
 
-  if (allBanks && allBanks.some((bank) => bank.isActive && bank.info.rawBank.config.assetTag === 2)) {
+  if (
+    (depositBank || swapBank) &&
+    allBanks &&
+    allBanks.some((bank) => bank.isActive && bank.info.rawBank.config.assetTag === 2)
+  ) {
     checks.push(STATIC_SIMULATION_ERRORS.STAKED_ONLY_SOL_CHECK);
     return checks;
   }

--- a/packages/mrgn-utils/src/action-message.utils.ts
+++ b/packages/mrgn-utils/src/action-message.utils.ts
@@ -10,6 +10,7 @@ import {
   DYNAMIC_SIMULATION_ERRORS,
   LstData,
   canBeDepositSwapped,
+  STATIC_SIMULATION_ERRORS,
 } from ".";
 import { ActionType, ExtendedBankInfo } from "@mrgnlabs/marginfi-v2-ui-state";
 import { MarginfiAccountWrapper } from "@mrgnlabs/marginfi-client-v2";
@@ -277,6 +278,7 @@ interface CheckDepositSwapActionAvailableProps {
   banks: ExtendedBankInfo[];
   marginfiAccount: MarginfiAccountWrapper | null;
   lendMode: ActionType;
+  allBanks?: ExtendedBankInfo[];
 }
 
 export function checkDepositSwapActionAvailable({
@@ -289,8 +291,14 @@ export function checkDepositSwapActionAvailable({
   banks,
   marginfiAccount,
   lendMode,
+  allBanks,
 }: CheckDepositSwapActionAvailableProps): ActionMessageType[] {
   let checks: ActionMessageType[] = [];
+
+  if (allBanks && allBanks.some((bank) => bank.isActive && bank.info.rawBank.config.assetTag === 2)) {
+    checks.push(STATIC_SIMULATION_ERRORS.STAKED_ONLY_SOL_CHECK);
+    return checks;
+  }
 
   if (!connected || !depositBank || !swapBank) {
     checks.push({ isEnabled: false });

--- a/packages/mrgn-utils/src/action-message.utils.ts
+++ b/packages/mrgn-utils/src/action-message.utils.ts
@@ -99,7 +99,7 @@ interface CheckLoopActionAvailableProps {
   connected: boolean;
   selectedBank: ExtendedBankInfo | null;
   selectedSecondaryBank: ExtendedBankInfo | null;
-  actionQuote: QuoteResponse | null;
+  banks: ExtendedBankInfo[];
 }
 
 export function checkLoopActionAvailable({
@@ -107,7 +107,7 @@ export function checkLoopActionAvailable({
   connected,
   selectedBank,
   selectedSecondaryBank,
-  actionQuote,
+  banks,
 }: CheckLoopActionAvailableProps): ActionMessageType[] {
   let checks: ActionMessageType[] = [];
 
@@ -119,7 +119,7 @@ export function checkLoopActionAvailable({
 
   // allert checks
   if (selectedBank) {
-    const loopChecks = canBeLooped(selectedBank, selectedSecondaryBank, actionQuote);
+    const loopChecks = canBeLooped(selectedBank, selectedSecondaryBank, undefined, banks);
     if (loopChecks.length) checks.push(...loopChecks);
   }
 

--- a/packages/mrgn-utils/src/action-message.utils.ts
+++ b/packages/mrgn-utils/src/action-message.utils.ts
@@ -99,7 +99,7 @@ interface CheckLoopActionAvailableProps {
   connected: boolean;
   selectedBank: ExtendedBankInfo | null;
   selectedSecondaryBank: ExtendedBankInfo | null;
-  banks: ExtendedBankInfo[];
+  banks?: ExtendedBankInfo[];
 }
 
 export function checkLoopActionAvailable({

--- a/packages/mrgn-utils/src/actions/flashloans/builders.ts
+++ b/packages/mrgn-utils/src/actions/flashloans/builders.ts
@@ -5,11 +5,13 @@ import BigNumber from "bignumber.js";
 import { MarginfiAccountWrapper, MarginfiClient, PriorityFees } from "@mrgnlabs/marginfi-client-v2";
 import { ActiveBankInfo, ExtendedBankInfo } from "@mrgnlabs/marginfi-v2-ui-state";
 import {
+  addTransactionMetadata,
   ExtendedV0Transaction,
   LUT_PROGRAM_AUTHORITY_INDEX,
   nativeToUi,
   SolanaTransaction,
   TransactionBroadcastType,
+  TransactionType,
   uiToNative,
 } from "@mrgnlabs/mrgn-common";
 
@@ -503,5 +505,14 @@ export async function closePositionBuilder({
     },
   });
 
-  return { transactions, txOverflown };
+  const updatedTransactions = transactions.map((tx) =>
+    tx.type === TransactionType.REPAY_COLLAT
+      ? addTransactionMetadata(tx, {
+          ...tx,
+          type: TransactionType.CLOSE_POSITION,
+        })
+      : tx
+  );
+
+  return { transactions: updatedTransactions, txOverflown };
 }

--- a/packages/mrgn-utils/src/actions/individualFlows.ts
+++ b/packages/mrgn-utils/src/actions/individualFlows.ts
@@ -713,20 +713,23 @@ export async function trade({
   }
   const excludedTypes: TransactionType[] = [TransactionType.JUPITER_SWAP];
 
+  console.log("tradingProps", tradingProps);
+
   if (!multiStepToast) {
     const steps = getSteps({
       actionTxns,
       excludedTypes,
       customLabels: {
-        [TransactionType.LOOP]: `${tradingProps.tradeSide === "long" ? "Longing" : "Shorting"} ${
-          tradingProps.tradeSide === "long"
-            ? tradingProps.depositBank.meta.tokenSymbol
-            : tradingProps.borrowBank.meta.tokenSymbol
-        } with ${dynamicNumeralFormatter(tradingProps.depositAmount)} USDC`,
+        [TransactionType.LONG]: `Longing ${tradingProps.depositBank.meta.tokenSymbol} with ${dynamicNumeralFormatter(
+          tradingProps.depositAmount
+        )} ${tradingProps.borrowBank.meta.tokenSymbol}`,
+        [TransactionType.SHORT]: `Shorting ${tradingProps.borrowBank.meta.tokenSymbol} with ${dynamicNumeralFormatter(
+          tradingProps.depositAmount
+        )} ${tradingProps.depositBank.meta.tokenSymbol}`,
       },
-    }); // TODO: update custom labels
+    });
 
-    multiStepToast = new MultiStepToastHandle("Trading", steps);
+    multiStepToast = new MultiStepToastHandle(tradingProps.tradeSide === "long" ? "Longing" : "Shorting", steps);
     multiStepToast.start();
   } else {
     multiStepToast.resetAndStart();

--- a/packages/mrgn-utils/src/actions/types.ts
+++ b/packages/mrgn-utils/src/actions/types.ts
@@ -99,6 +99,10 @@ export interface DepositSwapActionTxns extends ActionTxns {
   actionQuote: QuoteResponse | null;
 }
 
+export interface CalculateTradingProps extends CalculateLoopingProps {
+  tradeState: "long" | "short";
+}
+
 export interface CalculateLoopingProps
   extends Pick<LoopingProps, "marginfiAccount" | "borrowBank" | "depositBank" | "depositAmount" | "connection"> {
   targetLeverage: number;
@@ -107,7 +111,6 @@ export interface CalculateLoopingProps
   slippageMode: "DYNAMIC" | "FIXED";
   platformFeeBps: number;
   setupBankAddresses?: PublicKey[];
-  tradeState?: "long" | "short";
 }
 
 export interface CalculateRepayCollateralProps


### PR DESCRIPTION
Changelog: 
- Passing in stakedAssetBanks to looper box 
- Checking & restricting depending if there are active stakedAssetBanks
- Not fetching transactions when there are actionMessages
- Restrict deposit-swap when the user has staked asset banks
- Reset banks when deposit-swap are the same

Arena changelog:
- added support for arena key tags