### PR TITLE
feat(mfi-trading): introduction of arena client

### DIFF
--- a/apps/marginfi-v2-trading/src/components/common/Pool/PoolTradeHeader.tsx
+++ b/apps/marginfi-v2-trading/src/components/common/Pool/PoolTradeHeader.tsx
@@ -32,14 +32,14 @@ import { Button } from "~/components/ui/button";
 import { useExtendedPool } from "~/hooks/useExtendedPools";
 import { ArenaPoolV2, GroupStatus } from "~/types/trade-store.types";
 import { useWrappedAccount } from "~/hooks/useWrappedAccount";
-import { useMarginfiClient } from "~/hooks/useMarginfiClient";
+import { useArenaClient } from "~/hooks/useArenaClient";
 
 export const PoolTradeHeader = ({ activePool }: { activePool: ArenaPoolV2 }) => {
   const router = useRouter();
   const { connected, wallet } = useWallet();
 
   const extendedPool = useExtendedPool(activePool);
-  const client = useMarginfiClient({ groupPk: activePool.groupPk });
+  const client = useArenaClient({ groupPk: activePool.groupPk });
   const { accountSummary, wrappedAccount } = useWrappedAccount({
     client,
     groupPk: activePool.groupPk,

--- a/apps/marginfi-v2-trading/src/components/common/Portfolio/LpActionButtons.tsx
+++ b/apps/marginfi-v2-trading/src/components/common/Portfolio/LpActionButtons.tsx
@@ -12,7 +12,7 @@ import { ActionBox, ActionBoxProvider } from "~/components/action-box-v2";
 import { Button } from "~/components/ui/button";
 import { ArenaPoolV2Extended } from "~/types/trade-store.types";
 import { useWrappedAccount } from "~/hooks/useWrappedAccount";
-import { useMarginfiClient } from "~/hooks/useMarginfiClient";
+import { useArenaClient } from "~/hooks/useArenaClient";
 
 type LpActionButtonsProps = {
   activePool: ArenaPoolV2Extended;
@@ -26,7 +26,7 @@ export const LpActionButtons = ({ size = "sm", activePool }: LpActionButtonsProp
     setDisplaySettings: state.setDisplaySettings,
   }));
   const [refreshGroup, nativeSolBalance] = useTradeStoreV2((state) => [state.refreshGroup, state.nativeSolBalance]);
-  const client = useMarginfiClient({ groupPk: activePool.groupPk });
+  const client = useArenaClient({ groupPk: activePool.groupPk });
   const { accountSummary, wrappedAccount } = useWrappedAccount({
     client,
     groupPk: activePool.groupPk,

--- a/apps/marginfi-v2-trading/src/components/common/Portfolio/PositionCard.tsx
+++ b/apps/marginfi-v2-trading/src/components/common/Portfolio/PositionCard.tsx
@@ -11,7 +11,7 @@ import { PositionActionButtons } from "~/components/common/Portfolio";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "~/components/ui/tooltip";
 
 import { ArenaPoolV2Extended, GroupStatus } from "~/types/trade-store.types";
-import { useMarginfiClient } from "~/hooks/useMarginfiClient";
+import { useArenaClient } from "~/hooks/useArenaClient";
 import { useWrappedAccount } from "~/hooks/useWrappedAccount";
 import { usePositionsData } from "~/hooks/usePositionsData";
 import { PnlBadge, PnlLabel } from "~/components/common/pnl-display";
@@ -34,7 +34,7 @@ export const PositionCard = ({ size = "lg", arenaPool }: PositionCardProps) => {
   const [showQuotePrice, setShowQuotePrice] = React.useState(false);
 
   const positionData = usePositionsData({ groupPk: arenaPool.groupPk });
-  const client = useMarginfiClient({ groupPk: arenaPool.groupPk });
+  const client = useArenaClient({ groupPk: arenaPool.groupPk });
   const { accountSummary, wrappedAccount } = useWrappedAccount({
     client,
     groupPk: arenaPool.groupPk,

--- a/apps/marginfi-v2-trading/src/components/common/Portfolio/PositionList/PositionListItem.tsx
+++ b/apps/marginfi-v2-trading/src/components/common/Portfolio/PositionList/PositionListItem.tsx
@@ -7,7 +7,7 @@ import { dynamicNumeralFormatter } from "@mrgnlabs/mrgn-common";
 
 import { ArenaPoolV2Extended, GroupStatus } from "~/types/trade-store.types";
 import { useLeveragedPositionDetails } from "~/hooks/arenaHooks";
-import { useMarginfiClient } from "~/hooks/useMarginfiClient";
+import { useArenaClient } from "~/hooks/useArenaClient";
 import { useWrappedAccount } from "~/hooks/useWrappedAccount";
 import { usePositionsData } from "~/hooks/usePositionsData";
 
@@ -23,7 +23,7 @@ interface props {
 export const PositionListItem = ({ arenaPool }: props) => {
   const router = useRouter();
   const positionData = usePositionsData({ groupPk: arenaPool.groupPk });
-  const client = useMarginfiClient({ groupPk: arenaPool.groupPk });
+  const client = useArenaClient({ groupPk: arenaPool.groupPk });
   const { accountSummary, wrappedAccount } = useWrappedAccount({
     client,
     groupPk: arenaPool.groupPk,

--- a/apps/marginfi-v2-trading/src/components/common/Portfolio/components/close-position/close-position.tsx
+++ b/apps/marginfi-v2-trading/src/components/common/Portfolio/components/close-position/close-position.tsx
@@ -14,7 +14,7 @@ import { ActiveBankInfo } from "@mrgnlabs/marginfi-v2-ui-state";
 import { Button } from "~/components/ui/button";
 import { ArenaBank, ArenaPoolPositions, ArenaPoolV2Extended } from "~/types/trade-store.types";
 import { useWrappedAccount } from "~/hooks/useWrappedAccount";
-import { useMarginfiClient } from "~/hooks/useMarginfiClient";
+import { useArenaClient } from "~/hooks/useArenaClient";
 import { useConnection } from "~/hooks/use-connection";
 import { useTradeStoreV2, useUiStore } from "~/store";
 import { useWallet } from "~/components/wallet-v2/hooks";
@@ -38,7 +38,7 @@ export const ClosePosition = ({ arenaPool, positionsByGroupPk, depositBanks, bor
   const [multiStepToast, setMultiStepToast] = React.useState<MultiStepToastHandle | null>(null);
   const [actionTxns, setActionTxns] = React.useState<ClosePositionActionTxns | null>(null);
 
-  const client = useMarginfiClient({ groupPk: arenaPool.groupPk });
+  const client = useArenaClient({ groupPk: arenaPool.groupPk });
   const { wrappedAccount } = useWrappedAccount({
     client,
     groupPk: arenaPool.groupPk,

--- a/apps/marginfi-v2-trading/src/components/common/admin/admin-pool-detail/pool-detail-card/pool-detail-card.tsx
+++ b/apps/marginfi-v2-trading/src/components/common/admin/admin-pool-detail/pool-detail-card/pool-detail-card.tsx
@@ -31,7 +31,7 @@ import { ActionBox, ActionBoxProvider } from "@mrgnlabs/mrgn-ui";
 
 import { ArenaBank, ArenaPoolV2, ArenaPoolV2Extended, GroupStatus } from "~/types/trade-store.types";
 import { useExtendedPool } from "~/hooks/useExtendedPools";
-import { useMarginfiClient } from "~/hooks/useMarginfiClient";
+import { useArenaClient } from "~/hooks/useArenaClient";
 import { useWrappedAccount } from "~/hooks/useWrappedAccount";
 import { useWallet } from "~/components/wallet-v2/hooks";
 
@@ -145,7 +145,7 @@ const YieldItem = ({
   }, [bank]);
 
   const [nativeSolBalance, refreshGroup] = useTradeStoreV2((state) => [state.nativeSolBalance, state.refreshGroup]);
-  const client = useMarginfiClient({ groupPk: pool.groupPk });
+  const client = useArenaClient({ groupPk: pool.groupPk });
   const { accountSummary, wrappedAccount } = useWrappedAccount({
     client,
     groupPk: pool.groupPk,

--- a/apps/marginfi-v2-trading/src/components/common/trade-box-v2/trade-box.tsx
+++ b/apps/marginfi-v2-trading/src/components/common/trade-box-v2/trade-box.tsx
@@ -19,7 +19,7 @@ import { Card, CardContent, CardHeader } from "~/components/ui/card";
 import { useTradeStoreV2, useUiStore } from "~/store";
 import { useWallet, useWalletStore } from "~/components/wallet-v2";
 import { useExtendedPool } from "~/hooks/useExtendedPools";
-import { useMarginfiClient } from "~/hooks/useMarginfiClient";
+import { useArenaClient } from "~/hooks/useArenaClient";
 import { useWrappedAccount } from "~/hooks/useWrappedAccount";
 import { useAmountDebounce } from "~/hooks/useAmountDebounce";
 
@@ -110,7 +110,7 @@ export const TradeBoxV2 = ({ activePool, side = "long" }: TradeBoxV2Props) => {
 
   // Hooks
   const activePoolExtended = useExtendedPool(activePool);
-  const client = useMarginfiClient({ groupPk: activePoolExtended.groupPk });
+  const client = useArenaClient({ groupPk: activePoolExtended.groupPk });
   const { accountSummary, wrappedAccount } = useWrappedAccount({
     client,
     groupPk: activePoolExtended.groupPk,

--- a/apps/marginfi-v2-trading/src/hooks/useActionBoxProps.tsx
+++ b/apps/marginfi-v2-trading/src/hooks/useActionBoxProps.tsx
@@ -2,12 +2,12 @@ import { PublicKey } from "@solana/web3.js";
 
 import { DEFAULT_ACCOUNT_SUMMARY } from "@mrgnlabs/marginfi-v2-ui-state";
 
-import { useMarginfiClient } from "~/hooks/useMarginfiClient";
+import { useArenaClient } from "~/hooks/useArenaClient";
 import { useWrappedAccount } from "~/hooks/useWrappedAccount";
 import { ArenaBank } from "~/types/trade-store.types";
 
 export function useActionBoxProps(groupPk: PublicKey, banks: ArenaBank[]) {
-  const marginfiClient = useMarginfiClient({ groupPk });
+  const marginfiClient = useArenaClient({ groupPk });
   const { wrappedAccount, accountSummary } = useWrappedAccount({ client: marginfiClient, groupPk, banks });
 
   return { marginfiClient, wrappedAccount, accountSummary: accountSummary ?? DEFAULT_ACCOUNT_SUMMARY };

--- a/apps/marginfi-v2-trading/src/hooks/useArenaClient.tsx
+++ b/apps/marginfi-v2-trading/src/hooks/useArenaClient.tsx
@@ -6,7 +6,7 @@ import {
   feedIdToString,
   getConfig,
   MARGINFI_IDL,
-  MarginfiClient,
+  ArenaClient,
   MarginfiConfig,
   MarginfiIdlType,
   MarginfiProgram,
@@ -28,7 +28,7 @@ type UseMarginfiClientProps = {
 
 const defaultConfig = getConfig();
 
-export function useMarginfiClient({
+export function useArenaClient({
   groupPk,
   clientOptions,
   clientConfig = {
@@ -105,7 +105,7 @@ export function useMarginfiClient({
       };
     });
 
-    const client = new MarginfiClient(
+    const client = new ArenaClient(
       { groupPk, ...clientConfig },
       program,
       wallet,
@@ -120,8 +120,7 @@ export function useMarginfiClient({
       bankMetadataByBankPk,
       clientOptions?.bundleSimRpcEndpoint,
       clientOptions?.processTransactionStrategy,
-      lookupTables,
-      true // Add arena tag to transactions
+      lookupTables
     );
 
     return client;

--- a/apps/marginfi-v2-trading/src/pages/api/processTransaction.ts
+++ b/apps/marginfi-v2-trading/src/pages/api/processTransaction.ts
@@ -1,0 +1,43 @@
+import cookie from "cookie";
+import { NextApiRequest, NextApiResponse } from "next";
+import { fetchAuthToken } from "~/utils";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (!process.env.MARGINFI_API_URL) {
+    return res.status(500).json({ error: "API URL is not set" });
+  }
+
+  const cookies = cookie.parse(req.headers.cookie || "");
+  let token = cookies.jwt;
+
+  // If the token is missing, fetch a new one
+  if (!token) {
+    try {
+      token = await fetchAuthToken(req);
+    } catch (error) {
+      console.error("Error fetching new JWT:", error);
+      return res.status(401).json({ error: "Unauthorized: Unable to fetch token" });
+    }
+  }
+
+  try {
+    const response = await fetch(`${process.env.MARGINFI_API_URL}/arena/process-transactions`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`API responded with status: ${response.status}`);
+    }
+
+    return res.status(200).json({ message: "Transaction processed successfully" });
+  } catch (error) {
+    console.error("Error processing transaction:", error);
+    return res.status(500).json({
+      error: "Internal server error",
+      message: process.env.NODE_ENV === "development" ? error : undefined,
+    });
+  }
+}

--- a/apps/marginfi-v2-trading/src/pages/api/processTransaction.ts
+++ b/apps/marginfi-v2-trading/src/pages/api/processTransaction.ts
@@ -24,8 +24,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const response = await fetch(`${process.env.MARGINFI_API_URL}/arena/process-transactions`, {
       method: "POST",
       headers: {
+        "Content-Type": "application/json",
         Authorization: `Bearer ${token}`,
       },
+      body: JSON.stringify({}),
     });
 
     if (!response.ok) {

--- a/packages/marginfi-client-v2/src/clients/arena-client.ts
+++ b/packages/marginfi-client-v2/src/clients/arena-client.ts
@@ -70,7 +70,7 @@ class ArenaClient extends MarginfiClient {
     txOpts?: TransactionOptions
   ): Promise<TransactionSignature[]> {
     try {
-      await fetch(`${process.env.MARGINFI_API_URL}/arena/process-transactions`, {
+      await fetch("/api/processTransaction", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/packages/marginfi-client-v2/src/clients/arena-client.ts
+++ b/packages/marginfi-client-v2/src/clients/arena-client.ts
@@ -50,6 +50,17 @@ class ArenaClient extends MarginfiClient {
     processOpts?: ProcessTransactionsClientOpts,
     txOpts?: TransactionOptions
   ): Promise<TransactionSignature> {
+    try {
+      await fetch(`${process.env.MARGINFI_API_URL}/arena/process-transactions`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+    } catch (error) {
+      console.error("Error processing transaction to the backend:", error);
+    }
+
     return super.processTransaction(transaction, { ...processOpts, addArenaTxTag: true }, txOpts);
   }
 
@@ -58,6 +69,17 @@ class ArenaClient extends MarginfiClient {
     processOpts?: ProcessTransactionsClientOpts,
     txOpts?: TransactionOptions
   ): Promise<TransactionSignature[]> {
+    try {
+      await fetch(`${process.env.MARGINFI_API_URL}/arena/process-transactions`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+    } catch (error) {
+      console.error("Error processing transaction to the backend:", error);
+    }
+
     return super.processTransactions(transactions, { ...processOpts, addArenaTxTag: true }, txOpts);
   }
 }

--- a/packages/marginfi-client-v2/src/clients/arena-client.ts
+++ b/packages/marginfi-client-v2/src/clients/arena-client.ts
@@ -1,0 +1,65 @@
+import { AddressLookupTableAccount, PublicKey, TransactionSignature } from "@solana/web3.js";
+
+import { BankMetadataMap, SolanaTransaction, TransactionOptions, Wallet } from "@mrgnlabs/mrgn-common";
+
+import { MarginfiGroup } from "../models/group";
+import { MarginfiConfig, MarginfiProgram } from "../types";
+import { PythPushFeedIdMap } from "../utils";
+import { ProcessTransactionStrategy, ProcessTransactionsClientOpts } from "../services";
+import { MarginfiClient, BankMap, OraclePriceMap, MintDataMap } from "..";
+
+class ArenaClient extends MarginfiClient {
+  constructor(
+    config: MarginfiConfig,
+    program: MarginfiProgram,
+    wallet: Wallet,
+    isReadOnly: boolean,
+    group: MarginfiGroup,
+    banks: BankMap,
+    priceInfos: OraclePriceMap,
+    mintDatas: MintDataMap,
+    feedIdMap: PythPushFeedIdMap,
+    addressLookupTables?: AddressLookupTableAccount[],
+    preloadedBankAddresses?: PublicKey[],
+    bankMetadataMap?: BankMetadataMap,
+    bundleSimRpcEndpoint?: string,
+    processTransactionStrategy?: ProcessTransactionStrategy,
+    lookupTablesAddresses?: PublicKey[]
+  ) {
+    super(
+      config,
+      program,
+      wallet,
+      isReadOnly,
+      group,
+      banks,
+      priceInfos,
+      mintDatas,
+      feedIdMap,
+      addressLookupTables,
+      preloadedBankAddresses,
+      bankMetadataMap,
+      bundleSimRpcEndpoint,
+      processTransactionStrategy,
+      lookupTablesAddresses
+    );
+  }
+
+  async processTransaction(
+    transaction: SolanaTransaction,
+    processOpts?: ProcessTransactionsClientOpts,
+    txOpts?: TransactionOptions
+  ): Promise<TransactionSignature> {
+    return super.processTransaction(transaction, { ...processOpts, addArenaTxTag: true }, txOpts);
+  }
+
+  async processTransactions(
+    transactions: SolanaTransaction[],
+    processOpts?: ProcessTransactionsClientOpts,
+    txOpts?: TransactionOptions
+  ): Promise<TransactionSignature[]> {
+    return super.processTransactions(transactions, { ...processOpts, addArenaTxTag: true }, txOpts);
+  }
+}
+
+export default ArenaClient;

--- a/packages/marginfi-client-v2/src/clients/arena-client.ts
+++ b/packages/marginfi-client-v2/src/clients/arena-client.ts
@@ -51,7 +51,7 @@ class ArenaClient extends MarginfiClient {
     txOpts?: TransactionOptions
   ): Promise<TransactionSignature> {
     try {
-      await fetch(`${process.env.MARGINFI_API_URL}/arena/process-transactions`, {
+      await fetch("/api/processTransaction", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/packages/marginfi-client-v2/src/clients/client.ts
+++ b/packages/marginfi-client-v2/src/clients/client.ts
@@ -8,8 +8,6 @@ import {
   Keypair,
   LAMPORTS_PER_SOL,
   PublicKey,
-  SendTransactionError,
-  Signer,
   Transaction,
   TransactionInstruction,
   TransactionMessage,
@@ -22,7 +20,6 @@ import instructions from "../instructions";
 import { MarginRequirementType } from "../models/account";
 import {
   addTransactionMetadata,
-  BankMetadata,
   BankMetadataMap,
   chunkedGetRawMultipleAccountInfoOrdered,
   DEFAULT_COMMITMENT,
@@ -55,13 +52,8 @@ import {
   OracleSetup,
 } from "..";
 import { MarginfiAccountWrapper } from "../models/account/wrapper";
-import {
-  ProcessTransactionError,
-  ProcessTransactionErrorType,
-  parseErrorFromLogs,
-  parseTransactionError,
-} from "../errors";
-import { findOracleKey, makePriorityFeeIx, PythPushFeedIdMap, buildFeedIdMap } from "../utils";
+import { ProcessTransactionError, ProcessTransactionErrorType, parseTransactionError } from "../errors";
+import { findOracleKey, PythPushFeedIdMap, buildFeedIdMap } from "../utils";
 import {
   ProcessTransactionOpts,
   ProcessTransactionStrategy,
@@ -119,7 +111,6 @@ class MarginfiClient {
   public processTransactionStrategy?: ProcessTransactionStrategy;
   private preloadedBankAddresses?: PublicKey[];
   private bundleSimRpcEndpoint: string;
-  private addArenaTxTag: boolean;
 
   // --------------------------------------------------------------------------
   // Factories
@@ -140,8 +131,7 @@ class MarginfiClient {
     readonly bankMetadataMap?: BankMetadataMap,
     bundleSimRpcEndpoint?: string,
     processTransactionStrategy?: ProcessTransactionStrategy,
-    lookupTablesAddresses?: PublicKey[],
-    addArenaTxTag?: boolean
+    lookupTablesAddresses?: PublicKey[]
   ) {
     this.group = group;
     this.banks = banks;
@@ -153,7 +143,6 @@ class MarginfiClient {
     this.bundleSimRpcEndpoint = bundleSimRpcEndpoint ?? program.provider.connection.rpcEndpoint;
     this.processTransactionStrategy = processTransactionStrategy;
     this.lookupTablesAddresses = lookupTablesAddresses ?? [];
-    this.addArenaTxTag = addArenaTxTag ?? false;
   }
 
   /**
@@ -941,7 +930,6 @@ class MarginfiClient {
       programId: this.program.programId,
       bundleSimRpcEndpoint: this.bundleSimRpcEndpoint,
       dynamicStrategy: processOpts?.dynamicStrategy ?? this.processTransactionStrategy,
-      addArenaTxTag: this.addArenaTxTag,
     };
 
     console.log("processOpts", processOpts);
@@ -980,7 +968,6 @@ class MarginfiClient {
       programId: this.program.programId,
       bundleSimRpcEndpoint: this.bundleSimRpcEndpoint,
       dynamicStrategy: processOpts?.dynamicStrategy ?? this.processTransactionStrategy,
-      addArenaTxTag: this.addArenaTxTag,
     };
 
     const [signature] = await processTransactions({

--- a/packages/marginfi-client-v2/src/index.ts
+++ b/packages/marginfi-client-v2/src/index.ts
@@ -1,7 +1,9 @@
 import MarginfiClient from "./clients/client";
+import ArenaClient from "./clients/arena-client";
 
 export * from "./config";
 export * from "./clients/client";
+export * from "./clients/arena-client";
 export * from "./errors";
 export * from "./instructions";
 export * from "./constants";
@@ -15,4 +17,4 @@ export * from "./idl";
 export * from "./types";
 export * from "./utils";
 export * as vendor from "./vendor";
-export { MarginfiClient };
+export { MarginfiClient, ArenaClient };

--- a/packages/marginfi-client-v2/src/services/transaction/transaction.service.ts
+++ b/packages/marginfi-client-v2/src/services/transaction/transaction.service.ts
@@ -95,6 +95,7 @@ export interface ProcessTransactionsClientOpts extends PriorityFees {
   broadcastType?: TransactionBroadcastType;
   dynamicStrategy?: ProcessTransactionStrategy;
   isSequentialTxs?: boolean;
+  addArenaTxTag?: boolean;
   callback?: (index?: number, success?: boolean, signature?: string, stepsToAdvance?: number) => void;
 }
 


### PR DESCRIPTION
This PR introduces arena client a seperate client that extends from the mrgnlend client and has some custom arena logic. This is done to prevent arena specific logic to get intertwined with mrgnlend logic.