### PR TITLE
fix(mfi-v2-ui): unwrap sol

### DIFF
--- a/packages/mrgn-ui/src/components/action-box-v2/actions/lend-box/utils/lend-actions.utils.ts
+++ b/packages/mrgn-ui/src/components/action-box-v2/actions/lend-box/utils/lend-actions.utils.ts
@@ -151,10 +151,7 @@ export async function calculateLendingTransaction(
         transactions: [depositTx],
       };
     case ActionType.Borrow:
-      const borrowTxObject = await marginfiAccount.makeBorrowTx(amount, bank.address, {
-        createAtas: true,
-        wrapAndUnwrapSol: false,
-      });
+      const borrowTxObject = await marginfiAccount.makeBorrowTx(amount, bank.address);
       return {
         transactions: borrowTxObject.transactions,
       };


### PR DESCRIPTION
Removes borrowOpts from lending actions that prevent unwrapping sol
