### PR TITLE
Mock program scripts

### DIFF
--- a/packages/tools/TOOLS_README.MD
+++ b/packages/tools/TOOLS_README.MD
@@ -1,0 +1,37 @@
+# TS CLI
+
+## Requirements
+
+* Node
+* pnpm (`npm install -g pnpm@latest-10`)
+* A wallet (with SOL) at  ~/keys/wallet.json
+
+
+## Create Env File
+* Under packages/tools create a `.env` file.
+```
+PRIVATE_RPC_ENDPOINT="https://rpc.ironforge.network/mainnet?apiKey=WHATEVER"
+MARGINFI_WALLET=home/user/keys/wallet.json
+MARGINFI_ENV="production"
+```
+
+## Run the Scripts
+* `cd packages/tools`
+* `pnpm install`
+* `pnpm tools` to see list of available CLI tools
+
+# One-Off scripts
+
+## Requirements
+
+* Node
+* ts-node (`npm install -g ts-node`)
+* A wallet (with SOL) at  ~/keys/wallet.json
+* (Optional) create a .env.api and add API_URL=https://rpc.ironforge.network/mainnet?apiKey=WHATEVER
+
+## Run the Scripts
+* `cd packages/tools`
+* ts-node path_to_script
+
+## Disclaimer
+One-off scripts are exactly that: meant to be ran once. Edit them to fit your immediate needs.

--- a/packages/tools/base-encoding/bs58tobs64.ts
+++ b/packages/tools/base-encoding/bs58tobs64.ts
@@ -1,46 +1,88 @@
 import bs58 from "bs58";
-import { Transaction, VersionedMessage } from "@solana/web3.js";
+import { clusterApiUrl, Connection, Transaction, VersionedMessage, VersionedTransaction } from "@solana/web3.js";
+import { loadEnvFile } from "process";
+import { DEFAULT_API_URL } from "../scripts/utils";
 
 const b58EncodedTx =
   "eBXpPPKqnq7RJhRk9p6depQ3GMvqetNCrtBqDASzyWrwnoTRjUQCAykgfBDrN3YYToSwog7Cx8Zd2QfjHy9EG2fz6mLACJe8Es9bhEAhCb3ztd1ZsQ5395zjNQKVwZWTTvMbnm22zDt11AeSrdCiH5jWq4sz1umGCRGBJWv541RPebLY4xovT4sx9zDRrf4HuKE9v7jQnA9CKFLdjFKQz6QdNxUzwDLy4UDTcqNofRMV6Y5kE8Pw33ECC4f73WvUN9JTSAdNFJeCjZFnwSAqMMmw2P2QaPM3xq8SfgE2VNWhF7EiV8MLHpXveEFHyEMMrby3HDraRTd8Cc5yeYv77HZ2KH8eHn7RJDKCgrp9beyd2AHGYunFBcExhE3i1BbDrEUhzSvvAaACsjBw1jcCb7NJmKPiod82jwGFZr5qTm1R41Xud9ZUpX4ps6rSYyTGNJxCsLLZvkWegFvDBuZgtGy1qoa5PF2J3uGfnmsG1rzE4tFnH4G58gFjd1L4QgMdvNh1XXckjQRMGVJMuN6BXcMMGmTZ11uLQpiYq4Z5ELYucr86FKe1ZZ1mnc3Gf3JagEQpYAQWAWpWv6qeuQ7YUSiVXkA8MHbF6ReB8phyjQLfKhEzuRr9AjC9SomjJ8gBDqvLJhFAT9v1DZpPYwNkK7hJyFerNpB3sdff8mVJXSWhQy8w8gMyvbAZmNQmMortDy5wpuwUatEiruokYXBFxFndusyaFkqEsrJm9gJjPHWoXAm2UXtw2jMBFydgRuMCymjBVujpfJR24kNuyhNRYHj7zQ6X6VAijbpCAQPSjRg2TvPKGaSQXWTNPdA8ZWxh6gTy2cuK87Qx8EFo39qSn8LeBRWShYqRU5A85p4VWR2YN53A1t2zAV15N9RGa6ZuntzC8ixyFmGsQ6K1Xs3aCsTCEvaHscTTobrGhWowAAsjFSJcJQ2z1LoM624KvQ5V1tJ1LSymTcaHGcgMmd21XcFVGvV9z2wCLnZGgZ9vnS2EuaZGiwSpo2qVkp9DZocQ6vujqXtCa4k5Ge2BbYfg7VDSpQHRGegPWgZYRk17ZcRWguYG2aRiW1hVSiDgyxYTmQwSpYDRJMNJnSm5BsnHYXBWTYBL8Zbh61n6nTJtbDiMdPXoVaHUcPyfsdREoRjgBa4uKHi7vPBK3wPopbWXHaYbZjeivzjAJ1iCz4txJRzKu2xm6LtQqsFvXXEj7wyKhucuDLxbp5zbbQC7R8h5E9MMm9JcZk8WnRqQoR252xceam5CrgXzSc1xotbYN";
 
-const buffer = bs58.decode(b58EncodedTx);
-const base64Tx = buffer.toString("base64");
+async function main() {
+  const buffer = bs58.decode(b58EncodedTx);
+  const base64Tx = buffer.toString("base64");
 
-console.log("===========================================");
-console.log("Base64 Encoded Transaction:");
-console.log(base64Tx);
-console.log("===========================================\n");
+  console.log("===========================================");
+  console.log("Base64 Encoded Transaction:");
+  console.log(base64Tx);
+  console.log("===========================================\n");
 
-const message = VersionedMessage.deserialize(buffer);
+  let message = VersionedMessage.deserialize(buffer);
 
-const numRequiredSignatures = message.header.numRequiredSignatures;
-const keys = message.getAccountKeys().staticAccountKeys;
-const signers = keys.slice(0, numRequiredSignatures);
-// Print transaction signers
-console.log("Transaction Signers:");
-console.log("--------------------");
-signers.forEach((pubkey, index) => {
-  console.log(`Signer ${index}: ${pubkey.toBase58()}`);
-});
-console.log("");
-
-console.log("Transaction Instructions:");
-console.log("---------------------------");
-message.compiledInstructions.forEach((instruction, ixIndex) => {
-  console.log(`Instruction ${ixIndex}:`);
-  // Retrieve the program ID using the programIdIndex from the message's account keys
-  const programId = keys[instruction.programIdIndex];
-  console.log(`  Program ID: ${programId.toBase58()}`);
-  // Convert the instruction's account indices to public keys
-  console.log("  Accounts:");
-  instruction.accountKeyIndexes.forEach((accountIndex, accIndex) => {
-    console.log(`    ${accIndex}: ${keys[accountIndex].toBase58()}`);
+  const numRequiredSignatures = message.header.numRequiredSignatures;
+  const keys = message.getAccountKeys().staticAccountKeys;
+  const signers = keys.slice(0, numRequiredSignatures);
+  // Print transaction signers
+  console.log("Transaction Signers:");
+  console.log("--------------------");
+  signers.forEach((pubkey, index) => {
+    console.log(`Signer ${index}: ${pubkey.toBase58()}`);
   });
-  // 'data' is the raw instruction data (typically encoded as a hex string)
-  const dataBytes = Array.from(instruction.data).join(" ");
-  const dataHex = Buffer.from(instruction.data).toString("hex");
-  console.log(`  Data (hex): ${dataHex}`);
-  console.log(`  Data (raw): ${dataBytes}`);
+  console.log("");
+
+  console.log("Transaction Instructions:");
   console.log("---------------------------");
-});
+  message.compiledInstructions.forEach((instruction, ixIndex) => {
+    console.log(`Instruction ${ixIndex}:`);
+    const programId = keys[instruction.programIdIndex];
+    console.log(`  Program ID: ${programId.toBase58()}`);
+    // Convert the instruction's account indices to public keys
+    console.log("  Accounts:");
+    instruction.accountKeyIndexes.forEach((accountIndex, accIndex) => {
+      console.log(` [${accIndex}]: ${keys[accountIndex].toBase58()}`);
+    });
+    // const dataBytes = Array.from(instruction.data).join(" ");
+    const dataHex = Buffer.from(instruction.data).toString("hex");
+    console.log(`  Data (hex): ${dataHex}`);
+    // console.log(`  Data (raw): ${dataBytes}`);
+    console.log("---------------------------");
+  });
+
+  console.log("\n===========================================");
+  console.log("Simulating Transaction...");
+  console.log("===========================================");
+
+  loadEnvFile(".env.api");
+  const apiUrl = process.env.API_URL || DEFAULT_API_URL;
+  console.log("api: " + apiUrl);
+  const connection = new Connection(apiUrl, "confirmed");
+
+  // We have to pop out whatever blockhash we used when copying the base58 for the actual recent one
+  const { blockhash } = await connection.getLatestBlockhash();
+  message.recentBlockhash = blockhash;
+  const txn = new VersionedTransaction(message);
+
+  try {
+    const simulationResult = await connection.simulateTransaction(txn);
+    console.log("Transaction Simulation Status:");
+    console.log("-----------------------");
+
+    if (simulationResult.value.err) {
+      console.log("Transaction Failed!");
+      console.log("err: " + simulationResult.value.err.toString());
+    } else {
+      console.log("Transaction Succeeded!");
+    }
+
+    console.log("\nProgram Logs:");
+    if (simulationResult.value.logs) {
+      simulationResult.value.logs.forEach((log, index) => {
+        console.log(`[${index}]: ${log}`);
+      });
+    } else {
+      console.log("No logs available.");
+    }
+  } catch (err) {
+    console.error("Error simulating transaction:", err);
+  }
+}
+
+main().catch(console.error);

--- a/packages/tools/base-encoding/bs58tobs64.ts
+++ b/packages/tools/base-encoding/bs58tobs64.ts
@@ -1,8 +1,46 @@
 import bs58 from "bs58";
+import { Transaction, VersionedMessage } from "@solana/web3.js";
 
 const b58EncodedTx =
-  "KipD2dG8AmCSt1jaFU1RAVzRkqg2PRbqTtUvFLDQfXjCjQ1LzKkiHJ3HQYfR92QZ314qc4LSpebixfYAn5ocR5Yr93vZVh8DERdeRdKWq144E6LnLj7jwUxCMWFws1H7PPVPEzoTBULkgmRznCmF5YjVnptCq7aU8f6HmdKSndc7dLn9P2mkL77Y2tTeLnPo3qeWM9SApTBFDjA5AnPqZV7scDc6nTR7CQM5PJwFdkFHvjNYFk";
+  "eBXpPPKqnq7RJhRk9p6depQ3GMvqetNCrtBqDASzyWrwnoTRjUQCAykgfBDrN3YYToSwog7Cx8Zd2QfjHy9EG2fz6mLACJe8Es9bhEAhCb3ztd1ZsQ5395zjNQKVwZWTTvMbnm22zDt11AeSrdCiH5jWq4sz1umGCRGBJWv541RPebLY4xovT4sx9zDRrf4HuKE9v7jQnA9CKFLdjFKQz6QdNxUzwDLy4UDTcqNofRMV6Y5kE8Pw33ECC4f73WvUN9JTSAdNFJeCjZFnwSAqMMmw2P2QaPM3xq8SfgE2VNWhF7EiV8MLHpXveEFHyEMMrby3HDraRTd8Cc5yeYv77HZ2KH8eHn7RJDKCgrp9beyd2AHGYunFBcExhE3i1BbDrEUhzSvvAaACsjBw1jcCb7NJmKPiod82jwGFZr5qTm1R41Xud9ZUpX4ps6rSYyTGNJxCsLLZvkWegFvDBuZgtGy1qoa5PF2J3uGfnmsG1rzE4tFnH4G58gFjd1L4QgMdvNh1XXckjQRMGVJMuN6BXcMMGmTZ11uLQpiYq4Z5ELYucr86FKe1ZZ1mnc3Gf3JagEQpYAQWAWpWv6qeuQ7YUSiVXkA8MHbF6ReB8phyjQLfKhEzuRr9AjC9SomjJ8gBDqvLJhFAT9v1DZpPYwNkK7hJyFerNpB3sdff8mVJXSWhQy8w8gMyvbAZmNQmMortDy5wpuwUatEiruokYXBFxFndusyaFkqEsrJm9gJjPHWoXAm2UXtw2jMBFydgRuMCymjBVujpfJR24kNuyhNRYHj7zQ6X6VAijbpCAQPSjRg2TvPKGaSQXWTNPdA8ZWxh6gTy2cuK87Qx8EFo39qSn8LeBRWShYqRU5A85p4VWR2YN53A1t2zAV15N9RGa6ZuntzC8ixyFmGsQ6K1Xs3aCsTCEvaHscTTobrGhWowAAsjFSJcJQ2z1LoM624KvQ5V1tJ1LSymTcaHGcgMmd21XcFVGvV9z2wCLnZGgZ9vnS2EuaZGiwSpo2qVkp9DZocQ6vujqXtCa4k5Ge2BbYfg7VDSpQHRGegPWgZYRk17ZcRWguYG2aRiW1hVSiDgyxYTmQwSpYDRJMNJnSm5BsnHYXBWTYBL8Zbh61n6nTJtbDiMdPXoVaHUcPyfsdREoRjgBa4uKHi7vPBK3wPopbWXHaYbZjeivzjAJ1iCz4txJRzKu2xm6LtQqsFvXXEj7wyKhucuDLxbp5zbbQC7R8h5E9MMm9JcZk8WnRqQoR252xceam5CrgXzSc1xotbYN";
+
 const buffer = bs58.decode(b58EncodedTx);
 const base64Tx = buffer.toString("base64");
 
-console.log("Base64 Encoded Transaction:", base64Tx);
+console.log("===========================================");
+console.log("Base64 Encoded Transaction:");
+console.log(base64Tx);
+console.log("===========================================\n");
+
+const message = VersionedMessage.deserialize(buffer);
+
+const numRequiredSignatures = message.header.numRequiredSignatures;
+const keys = message.getAccountKeys().staticAccountKeys;
+const signers = keys.slice(0, numRequiredSignatures);
+// Print transaction signers
+console.log("Transaction Signers:");
+console.log("--------------------");
+signers.forEach((pubkey, index) => {
+  console.log(`Signer ${index}: ${pubkey.toBase58()}`);
+});
+console.log("");
+
+console.log("Transaction Instructions:");
+console.log("---------------------------");
+message.compiledInstructions.forEach((instruction, ixIndex) => {
+  console.log(`Instruction ${ixIndex}:`);
+  // Retrieve the program ID using the programIdIndex from the message's account keys
+  const programId = keys[instruction.programIdIndex];
+  console.log(`  Program ID: ${programId.toBase58()}`);
+  // Convert the instruction's account indices to public keys
+  console.log("  Accounts:");
+  instruction.accountKeyIndexes.forEach((accountIndex, accIndex) => {
+    console.log(`    ${accIndex}: ${keys[accountIndex].toBase58()}`);
+  });
+  // 'data' is the raw instruction data (typically encoded as a hex string)
+  const dataBytes = Array.from(instruction.data).join(" ");
+  const dataHex = Buffer.from(instruction.data).toString("hex");
+  console.log(`  Data (hex): ${dataHex}`);
+  console.log(`  Data (raw): ${dataBytes}`);
+  console.log("---------------------------");
+});

--- a/packages/tools/base-encoding/bs58tobs64.ts
+++ b/packages/tools/base-encoding/bs58tobs64.ts
@@ -1,0 +1,8 @@
+import bs58 from "bs58";
+
+const b58EncodedTx =
+  "KipD2dG8AmCSt1jaFU1RAVzRkqg2PRbqTtUvFLDQfXjCjQ1LzKkiHJ3HQYfR92QZ314qc4LSpebixfYAn5ocR5Yr93vZVh8DERdeRdKWq144E6LnLj7jwUxCMWFws1H7PPVPEzoTBULkgmRznCmF5YjVnptCq7aU8f6HmdKSndc7dLn9P2mkL77Y2tTeLnPo3qeWM9SApTBFDjA5AnPqZV7scDc6nTR7CQM5PJwFdkFHvjNYFk";
+const buffer = bs58.decode(b58EncodedTx);
+const base64Tx = buffer.toString("base64");
+
+console.log("Base64 Encoded Transaction:", base64Tx);

--- a/packages/tools/base-encoding/bs58tobs64.ts
+++ b/packages/tools/base-encoding/bs58tobs64.ts
@@ -1,13 +1,39 @@
 import bs58 from "bs58";
 import { clusterApiUrl, Connection, Transaction, VersionedMessage, VersionedTransaction } from "@solana/web3.js";
 import { loadEnvFile } from "process";
-import { DEFAULT_API_URL } from "../scripts/utils";
+import { DEFAULT_API_URL, loadKeypairFromFile } from "../scripts/utils";
+import { AnchorProvider, Program } from "@coral-xyz/anchor";
+import marginfiIdl from "../../marginfi-client-v2/src/idl/marginfi.json";
+import { Marginfi } from "../../marginfi-client-v2/src/idl/marginfi-types";
 
-const b58EncodedTx =
-  "eBXpPPKqnq7RJhRk9p6depQ3GMvqetNCrtBqDASzyWrwnoTRjUQCAykgfBDrN3YYToSwog7Cx8Zd2QfjHy9EG2fz6mLACJe8Es9bhEAhCb3ztd1ZsQ5395zjNQKVwZWTTvMbnm22zDt11AeSrdCiH5jWq4sz1umGCRGBJWv541RPebLY4xovT4sx9zDRrf4HuKE9v7jQnA9CKFLdjFKQz6QdNxUzwDLy4UDTcqNofRMV6Y5kE8Pw33ECC4f73WvUN9JTSAdNFJeCjZFnwSAqMMmw2P2QaPM3xq8SfgE2VNWhF7EiV8MLHpXveEFHyEMMrby3HDraRTd8Cc5yeYv77HZ2KH8eHn7RJDKCgrp9beyd2AHGYunFBcExhE3i1BbDrEUhzSvvAaACsjBw1jcCb7NJmKPiod82jwGFZr5qTm1R41Xud9ZUpX4ps6rSYyTGNJxCsLLZvkWegFvDBuZgtGy1qoa5PF2J3uGfnmsG1rzE4tFnH4G58gFjd1L4QgMdvNh1XXckjQRMGVJMuN6BXcMMGmTZ11uLQpiYq4Z5ELYucr86FKe1ZZ1mnc3Gf3JagEQpYAQWAWpWv6qeuQ7YUSiVXkA8MHbF6ReB8phyjQLfKhEzuRr9AjC9SomjJ8gBDqvLJhFAT9v1DZpPYwNkK7hJyFerNpB3sdff8mVJXSWhQy8w8gMyvbAZmNQmMortDy5wpuwUatEiruokYXBFxFndusyaFkqEsrJm9gJjPHWoXAm2UXtw2jMBFydgRuMCymjBVujpfJR24kNuyhNRYHj7zQ6X6VAijbpCAQPSjRg2TvPKGaSQXWTNPdA8ZWxh6gTy2cuK87Qx8EFo39qSn8LeBRWShYqRU5A85p4VWR2YN53A1t2zAV15N9RGa6ZuntzC8ixyFmGsQ6K1Xs3aCsTCEvaHscTTobrGhWowAAsjFSJcJQ2z1LoM624KvQ5V1tJ1LSymTcaHGcgMmd21XcFVGvV9z2wCLnZGgZ9vnS2EuaZGiwSpo2qVkp9DZocQ6vujqXtCa4k5Ge2BbYfg7VDSpQHRGegPWgZYRk17ZcRWguYG2aRiW1hVSiDgyxYTmQwSpYDRJMNJnSm5BsnHYXBWTYBL8Zbh61n6nTJtbDiMdPXoVaHUcPyfsdREoRjgBa4uKHi7vPBK3wPopbWXHaYbZjeivzjAJ1iCz4txJRzKu2xm6LtQqsFvXXEj7wyKhucuDLxbp5zbbQC7R8h5E9MMm9JcZk8WnRqQoR252xceam5CrgXzSc1xotbYN";
+type Config = {
+  PROGRAM_ID: string;
+  BS58TX: string;
+};
+
+const config: Config = {
+  PROGRAM_ID: "MFv2hWf31Z9kbCa1snEPYctwafyhdvnV7FZnsebVacA",
+  BS58TX:
+    "eBXpPPKqnq7RJhRk9p6depQ3GMvqetNCrtBqDASzyWrwnoTRjUQCAykgfBDrN3YYToSwog7Cx8Zd2QfjHy9EG2fz6mLACJe8Es9bhEAhCb3ztd1ZsQ5395zjNQKVwZWTTvMbnm22zDt11AeSrdCiH5jWq4sz1umGCRGBJWv541RPebLY4xovT4sx9zDRrf4HuKE9v7jQnA9CKFLdjFKQz6QdNxUzwDLy4UDTcqNofRMV6Y5kE8Pw33ECC4f73WvUN9JTSAdNFJeCjZFnwSAqMMmw2P2QaPM3xq8SfgE2VNWhF7EiV8MLHpXveEFHyEMMrby3HDraRTd8Cc5yeYv77HZ2KH8eHn7RJDKCgrp9beyd2AHGYunFBcExhE3i1BbDrEUhzSvvAaACsjBw1jcCb7NJmKPiod82jwGFZr5qTm1R41Xud9ZUpX4ps6rSYyTGNJxCsLLZvkWegFvDBuZgtGy1qoa5PF2J3uGfnmsG1rzE4tFnH4G58gFjd1L4QgMdvNh1XXckjQRMGVJMuN6BXcMMGmTZ11uLQpiYq4Z5ELYucr86FKe1ZZ1mnc3Gf3JagEQpYAQWAWpWv6qeuQ7YUSiVXkA8MHbF6ReB8phyjQLfKhEzuRr9AjC9SomjJ8gBDqvLJhFAT9v1DZpPYwNkK7hJyFerNpB3sdff8mVJXSWhQy8w8gMyvbAZmNQmMortDy5wpuwUatEiruokYXBFxFndusyaFkqEsrJm9gJjPHWoXAm2UXtw2jMBFydgRuMCymjBVujpfJR24kNuyhNRYHj7zQ6X6VAijbpCAQPSjRg2TvPKGaSQXWTNPdA8ZWxh6gTy2cuK87Qx8EFo39qSn8LeBRWShYqRU5A85p4VWR2YN53A1t2zAV15N9RGa6ZuntzC8ixyFmGsQ6K1Xs3aCsTCEvaHscTTobrGhWowAAsjFSJcJQ2z1LoM624KvQ5V1tJ1LSymTcaHGcgMmd21XcFVGvV9z2wCLnZGgZ9vnS2EuaZGiwSpo2qVkp9DZocQ6vujqXtCa4k5Ge2BbYfg7VDSpQHRGegPWgZYRk17ZcRWguYG2aRiW1hVSiDgyxYTmQwSpYDRJMNJnSm5BsnHYXBWTYBL8Zbh61n6nTJtbDiMdPXoVaHUcPyfsdREoRjgBa4uKHi7vPBK3wPopbWXHaYbZjeivzjAJ1iCz4txJRzKu2xm6LtQqsFvXXEj7wyKhucuDLxbp5zbbQC7R8h5E9MMm9JcZk8WnRqQoR252xceam5CrgXzSc1xotbYN",
+};
 
 async function main() {
-  const buffer = bs58.decode(b58EncodedTx);
+  loadEnvFile(".env.api");
+  const apiUrl = process.env.API_URL || DEFAULT_API_URL;
+  console.log("api: " + apiUrl);
+  marginfiIdl.address = config.PROGRAM_ID;
+  const connection = new Connection(apiUrl, "confirmed");
+  // const wallet = loadKeypairFromFile(process.env.HOME + "/keys/staging-deploy.json");
+  // const provider = new AnchorProvider(connection, wallet, {
+  //   preflightCommitment: "confirmed",
+  // });
+  // const program: Program<Marginfi> = new Program(
+  //   // @ts-ignore
+  //   marginfiIdl as Marginfi,
+  //   provider
+  // );
+
+  const buffer = bs58.decode(config.BS58TX);
   const base64Tx = buffer.toString("base64");
 
   console.log("===========================================");
@@ -43,17 +69,14 @@ async function main() {
     const dataHex = Buffer.from(instruction.data).toString("hex");
     console.log(`  Data (hex): ${dataHex}`);
     // console.log(`  Data (raw): ${dataBytes}`);
+
+    // TODO to interpret this data as args we have to manually parse the IDL. Gross.
     console.log("---------------------------");
   });
 
   console.log("\n===========================================");
   console.log("Simulating Transaction...");
   console.log("===========================================");
-
-  loadEnvFile(".env.api");
-  const apiUrl = process.env.API_URL || DEFAULT_API_URL;
-  console.log("api: " + apiUrl);
-  const connection = new Connection(apiUrl, "confirmed");
 
   // We have to pop out whatever blockhash we used when copying the base58 for the actual recent one
   const { blockhash } = await connection.getLatestBlockhash();

--- a/packages/tools/luts/create_lut.ts
+++ b/packages/tools/luts/create_lut.ts
@@ -1,0 +1,67 @@
+import {
+  AddressLookupTableProgram,
+  Connection,
+  PublicKey,
+  Transaction,
+  sendAndConfirmTransaction,
+} from "@solana/web3.js";
+import { Program, AnchorProvider, BN } from "@coral-xyz/anchor";
+
+import { DEFAULT_API_URL, loadEnvFile, loadKeypairFromFile } from "../scripts/utils";
+import { bs58 } from "@coral-xyz/anchor/dist/cjs/utils/bytes";
+
+/**
+ * If true, send the tx. If false, output the unsigned b58 tx to console.
+ */
+const sendTx = true;
+
+type Config = {
+  PLACEHOLDER: PublicKey;
+};
+
+const config: Config = {
+  PLACEHOLDER: new PublicKey("J3oBkTkDXU3TcAggJEa3YeBZE5om5yNAdTtLVNXFD47"),
+};
+
+async function main() {
+  loadEnvFile(".env.api");
+  const apiUrl = process.env.API_URL || DEFAULT_API_URL;
+  console.log("api: " + apiUrl);
+  const connection = new Connection(apiUrl, "confirmed");
+  const wallet = loadKeypairFromFile(process.env.HOME + "/keys/phantom-wallet.json");
+
+  const transaction = new Transaction();
+  const currentSlot = (await connection.getSlot()) - 1;
+
+  // Create a new lookup table. The authority and payer are set to the wallet's public key.
+  const [createLookupTableIx, lutKey] = AddressLookupTableProgram.createLookupTable({
+    authority: wallet.publicKey,
+    payer: wallet.publicKey,
+    recentSlot: currentSlot,
+  });
+  transaction.add(createLookupTableIx);
+  console.log("lut key: " + lutKey);
+
+  if (sendTx) {
+    try {
+      const signature = await sendAndConfirmTransaction(connection, transaction, [wallet]);
+      console.log("Transaction signature:", signature);
+    } catch (error) {
+      console.log("NOTE: ERROR DOES NOT MEAN IT ACTUALLY FAILED. CHECK CHAIN FIRST, DON'T WASTE RENT");
+      console.error("Transaction failed:", error);
+    }
+  } else {
+    const { blockhash } = await connection.getLatestBlockhash();
+    transaction.recentBlockhash = blockhash;
+    const serializedTransaction = transaction.serialize({
+      requireAllSignatures: false,
+      verifySignatures: true,
+    });
+    const base58Transaction = bs58.encode(serializedTransaction);
+    console.log("Base58-encoded transaction:", base58Transaction);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+});

--- a/packages/tools/luts/update_lut.ts
+++ b/packages/tools/luts/update_lut.ts
@@ -17,6 +17,8 @@ import { TOKEN_PROGRAM_ID } from "@solana/spl-token";
  */
 const sendTx = true;
 
+// TODO support deduping accross multiple LUTs and add the first non-full LUT
+
 type Config = {
   LUT: PublicKey;
   KEYS: PublicKey[];

--- a/packages/tools/luts/update_lut.ts
+++ b/packages/tools/luts/update_lut.ts
@@ -1,0 +1,102 @@
+import {
+  AddressLookupTableProgram,
+  Connection,
+  PublicKey,
+  SYSVAR_RENT_PUBKEY,
+  Transaction,
+  sendAndConfirmTransaction,
+} from "@solana/web3.js";
+
+import { DEFAULT_API_URL, loadEnvFile, loadKeypairFromFile } from "../scripts/utils";
+import { bs58 } from "@coral-xyz/anchor/dist/cjs/utils/bytes";
+import { SYSTEM_PROGRAM_ID } from "@coral-xyz/anchor/dist/cjs/native/system";
+import { TOKEN_PROGRAM_ID } from "@solana/spl-token";
+
+/**
+ * If true, send the tx. If false, output the unsigned b58 tx to console.
+ */
+const sendTx = true;
+
+type Config = {
+  LUT: PublicKey;
+  KEYS: PublicKey[];
+};
+
+const config: Config = {
+  LUT: new PublicKey("CQ8omkUwDtsszuJLo9grtXCeEyDU4QqBLRv9AjRDaUZ3"),
+  KEYS: [
+    new PublicKey("MFv2hWf31Z9kbCa1snEPYctwafyhdvnV7FZnsebVacA"),
+    new PublicKey("CYXEgwbPHu2f9cY3mcUkinzDoDcsSan7myh1uBvYRbEw"),
+    new PublicKey("4qp6Fx6tnZkY5Wropq9wUYgtFxXKwE6viZxFHg3rdAG8"),
+    new PublicKey("HoMNdUF3RDZDPKAARYK1mxcPFfUnPjLmpKYibZzAijev"),
+    new PublicKey("JAnRanMrsn5vxWmSpU5ndvtvQLAyzGJEenNzgVC1vNMC"),
+    new PublicKey("5tMcLP49P7CHKEM4KWAiSDNpEh5UFcCLsMVXi74YRg5C"),
+    SYSTEM_PROGRAM_ID,
+    SYSVAR_RENT_PUBKEY,
+    TOKEN_PROGRAM_ID,
+    new PublicKey("ezSoL6fY1PVdJcJsUpe5CM3xkfmy3zoVCABybm5WtiC"),
+  ],
+};
+
+async function main() {
+  loadEnvFile(".env.api");
+  const apiUrl = process.env.API_URL || DEFAULT_API_URL;
+  console.log("api: " + apiUrl);
+  const connection = new Connection(apiUrl, "confirmed");
+  const wallet = loadKeypairFromFile(process.env.HOME + "/keys/phantom-wallet.json");
+
+  const transaction = new Transaction();
+
+  const lutAccount = await connection.getAddressLookupTable(config.LUT);
+  if (!lutAccount.value) {
+    throw new Error("Failed to fetch the lookup table account");
+  }
+
+  // Extract the existing addresses from the lookup table
+  const existingAddresses = lutAccount.value.state.addresses;
+  const existingSet = new Set(existingAddresses.map((addr: PublicKey) => addr.toBase58()));
+
+  // Filter out keys that are already in the lookup table
+  const keysToAdd = config.KEYS.filter((key) => !existingSet.has(key.toBase58()));
+  if (keysToAdd.length === 0) {
+    console.log("No new keys to add, lookup table is already up to date, aborting.");
+    return;
+  } else {
+    console.log("Adding the following new keys, others already in the LUT");
+    for (let i = 0; i < keysToAdd.length; i++) {
+      console.log("[" + i + "] " + keysToAdd[i]);
+    }
+    console.log("");
+  }
+
+  // Create the instruction to extend the lookup table with the deduped keys
+  const extendIx = AddressLookupTableProgram.extendLookupTable({
+    authority: wallet.publicKey,
+    lookupTable: config.LUT,
+    payer: wallet.publicKey,
+    addresses: keysToAdd,
+  });
+  transaction.add(extendIx);
+
+  if (sendTx) {
+    try {
+      const signature = await sendAndConfirmTransaction(connection, transaction, [wallet]);
+      console.log("Transaction signature:", signature);
+    } catch (error) {
+      console.error("Transaction failed:", error);
+    }
+  } else {
+    const { blockhash } = await connection.getLatestBlockhash();
+    transaction.recentBlockhash = blockhash;
+    const serializedTransaction = transaction.serialize({
+      requireAllSignatures: false,
+      verifySignatures: true,
+    });
+    const base58Transaction = bs58.encode(serializedTransaction);
+    console.log("Base58-encoded transaction:", base58Transaction);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+});

--- a/packages/tools/mocks/mocks-do-nothing.ts
+++ b/packages/tools/mocks/mocks-do-nothing.ts
@@ -1,0 +1,71 @@
+// Runs once per group, before any staked banks can be init.
+import { AccountMeta, Connection, PublicKey, Transaction, sendAndConfirmTransaction } from "@solana/web3.js";
+import { Program, AnchorProvider, Wallet, BN } from "@coral-xyz/anchor";
+import { Mocks } from "./mocks";
+import mocksIdl from "./mocks.json";
+import { I80F48_ONE, loadKeypairFromFile } from "../scripts/utils";
+import {
+  bigNumberToWrappedI80F48,
+  TOKEN_PROGRAM_ID,
+  WrappedI80F48,
+  wrappedI80F48toBigNumber,
+} from "@mrgnlabs/mrgn-common";
+import { RiskTierRaw } from "@mrgnlabs/marginfi-client-v2";
+import { assertBNEqual, assertI80F48Approx, assertKeysEqual } from "../scripts/softTests";
+import { bs58 } from "@coral-xyz/anchor/dist/cjs/utils/bytes";
+
+/**
+ * If true, send the tx. If false, output the unsigned b58 tx to console.
+ */
+const sendTx = false;
+
+type Config = {
+  PROGRAM_ID: string;
+
+  /** Multisig if testing a MS */
+  PAYER: PublicKey;
+};
+
+const config: Config = {
+  PROGRAM_ID: "HfCg2Re4BnZmQ7SzUcw3fhBtf1fqWmtMY1wov59VFrYs",
+  PAYER: new PublicKey("J3oBkTkDXU3TcAggJEa3YeBZE5om5yNAdTtLVNXFD47"),
+};
+
+async function main() {
+  mocksIdl.address = config.PROGRAM_ID;
+  const connection = new Connection("https://api.mainnet-beta.solana.com", "confirmed");
+  const wallet = loadKeypairFromFile(process.env.HOME + "/keys/staging-deploy.json");
+
+  // @ts-ignore
+  const provider = new AnchorProvider(connection, wallet, {
+    preflightCommitment: "confirmed",
+  });
+
+  const program = new Program<Mocks>(mocksIdl as Mocks, provider);
+
+  const transaction = new Transaction();
+  transaction.add(await program.methods.doNothing().accounts({ payer: config.PAYER }).instruction());
+
+  if (sendTx) {
+    try {
+      const signature = await sendAndConfirmTransaction(connection, transaction, [wallet]);
+      console.log("Transaction signature:", signature);
+    } catch (error) {
+      console.error("Transaction failed:", error);
+    }
+  } else {
+    transaction.feePayer = config.PAYER; // Set the fee payer to Squads wallet
+    const { blockhash } = await connection.getLatestBlockhash();
+    transaction.recentBlockhash = blockhash;
+    const serializedTransaction = transaction.serialize({
+      requireAllSignatures: false,
+      verifySignatures: true,
+    });
+    const base58Transaction = bs58.encode(serializedTransaction);
+    console.log("Base58-encoded transaction:", base58Transaction);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+});

--- a/packages/tools/mocks/mocks-do-nothing.ts
+++ b/packages/tools/mocks/mocks-do-nothing.ts
@@ -1,17 +1,9 @@
 // Runs once per group, before any staked banks can be init.
-import { AccountMeta, Connection, PublicKey, Transaction, sendAndConfirmTransaction } from "@solana/web3.js";
-import { Program, AnchorProvider, Wallet, BN } from "@coral-xyz/anchor";
+import { Connection, PublicKey, Transaction, sendAndConfirmTransaction } from "@solana/web3.js";
+import { Program, AnchorProvider, BN } from "@coral-xyz/anchor";
 import { Mocks } from "./mocks";
 import mocksIdl from "./mocks.json";
-import { I80F48_ONE, loadKeypairFromFile } from "../scripts/utils";
-import {
-  bigNumberToWrappedI80F48,
-  TOKEN_PROGRAM_ID,
-  WrappedI80F48,
-  wrappedI80F48toBigNumber,
-} from "@mrgnlabs/mrgn-common";
-import { RiskTierRaw } from "@mrgnlabs/marginfi-client-v2";
-import { assertBNEqual, assertI80F48Approx, assertKeysEqual } from "../scripts/softTests";
+import { loadKeypairFromFile } from "../scripts/utils";
 import { bs58 } from "@coral-xyz/anchor/dist/cjs/utils/bytes";
 
 /**

--- a/packages/tools/mocks/mocks.json
+++ b/packages/tools/mocks/mocks.json
@@ -1,0 +1,308 @@
+{
+  "address": "HfCg2Re4BnZmQ7SzUcw3fhBtf1fqWmtMY1wov59VFrYs",
+  "metadata": {
+    "name": "mocks",
+    "version": "0.1.0",
+    "spec": "0.1.0",
+    "description": "External program mocks"
+  },
+  "instructions": [
+    {
+      "name": "do_nothing",
+      "docs": [
+        "Do nothing"
+      ],
+      "discriminator": [
+        112,
+        130,
+        224,
+        161,
+        71,
+        149,
+        192,
+        187
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "signer": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "init_pool_auth",
+      "docs": [
+        "Init authority for fake jupiter-like swap pools"
+      ],
+      "discriminator": [
+        48,
+        155,
+        246,
+        118,
+        211,
+        80,
+        8,
+        220
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "docs": [
+            "Pays the init fee"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "pool_auth",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "arg",
+                "path": "nonce"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "mint_a"
+        },
+        {
+          "name": "mint_b"
+        },
+        {
+          "name": "pool_a",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "mint_a"
+              },
+              {
+                "kind": "account",
+                "path": "pool_auth"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  115
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "pool_b",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "mint_b"
+              },
+              {
+                "kind": "account",
+                "path": "pool_auth"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  115
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "rent",
+          "address": "SysvarRent111111111111111111111111111111111"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "nonce",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "swap_like_jupiter",
+      "docs": [
+        "Execute an exchange of a:b like-jupiter. You set the amount a sent and b received."
+      ],
+      "discriminator": [
+        53,
+        0,
+        48,
+        18,
+        207,
+        211,
+        11,
+        240
+      ],
+      "accounts": [
+        {
+          "name": "user_authority",
+          "signer": true
+        },
+        {
+          "name": "pool_auth",
+          "docs": [
+            "PDA authority of the pools"
+          ]
+        },
+        {
+          "name": "pool_a",
+          "writable": true
+        },
+        {
+          "name": "pool_b",
+          "writable": true
+        },
+        {
+          "name": "source_a",
+          "writable": true
+        },
+        {
+          "name": "destination_b",
+          "writable": true
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        }
+      ],
+      "args": [
+        {
+          "name": "amt_a",
+          "type": "u64"
+        },
+        {
+          "name": "amt_b",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "write",
+      "docs": [
+        "Write arbitrary bytes to an arbitrary account. YOLO."
+      ],
+      "discriminator": [
+        235,
+        116,
+        91,
+        200,
+        206,
+        170,
+        144,
+        120
+      ],
+      "accounts": [
+        {
+          "name": "target",
+          "writable": true,
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "offset",
+          "type": "u64"
+        },
+        {
+          "name": "data",
+          "type": "bytes"
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "PoolAuth",
+      "discriminator": [
+        84,
+        40,
+        134,
+        46,
+        2,
+        144,
+        109,
+        184
+      ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "SomeError",
+      "msg": "This is an error."
+    }
+  ],
+  "types": [
+    {
+      "name": "PoolAuth",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "key",
+            "docs": [
+              "The account's own key"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_a",
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_b",
+            "type": "pubkey"
+          },
+          {
+            "name": "bump_seed",
+            "type": "u8"
+          },
+          {
+            "name": "nonce",
+            "type": "u16"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/tools/mocks/mocks.ts
+++ b/packages/tools/mocks/mocks.ts
@@ -1,0 +1,314 @@
+/**
+ * Program IDL in camelCase format in order to be used in JS/TS.
+ *
+ * Note that this is only a type helper and is not the actual IDL. The original
+ * IDL can be found at `target/idl/mocks.json`.
+ */
+export type Mocks = {
+  "address": "HfCg2Re4BnZmQ7SzUcw3fhBtf1fqWmtMY1wov59VFrYs",
+  "metadata": {
+    "name": "mocks",
+    "version": "0.1.0",
+    "spec": "0.1.0",
+    "description": "External program mocks"
+  },
+  "instructions": [
+    {
+      "name": "doNothing",
+      "docs": [
+        "Do nothing"
+      ],
+      "discriminator": [
+        112,
+        130,
+        224,
+        161,
+        71,
+        149,
+        192,
+        187
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "signer": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initPoolAuth",
+      "docs": [
+        "Init authority for fake jupiter-like swap pools"
+      ],
+      "discriminator": [
+        48,
+        155,
+        246,
+        118,
+        211,
+        80,
+        8,
+        220
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "docs": [
+            "Pays the init fee"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "poolAuth",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "arg",
+                "path": "nonce"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "mintA"
+        },
+        {
+          "name": "mintB"
+        },
+        {
+          "name": "poolA",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "mintA"
+              },
+              {
+                "kind": "account",
+                "path": "poolAuth"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  115
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "poolB",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "mintB"
+              },
+              {
+                "kind": "account",
+                "path": "poolAuth"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  115
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "tokenProgram",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "rent",
+          "address": "SysvarRent111111111111111111111111111111111"
+        },
+        {
+          "name": "systemProgram",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "nonce",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "swapLikeJupiter",
+      "docs": [
+        "Execute an exchange of a:b like-jupiter. You set the amount a sent and b received."
+      ],
+      "discriminator": [
+        53,
+        0,
+        48,
+        18,
+        207,
+        211,
+        11,
+        240
+      ],
+      "accounts": [
+        {
+          "name": "userAuthority",
+          "signer": true
+        },
+        {
+          "name": "poolAuth",
+          "docs": [
+            "PDA authority of the pools"
+          ]
+        },
+        {
+          "name": "poolA",
+          "writable": true
+        },
+        {
+          "name": "poolB",
+          "writable": true
+        },
+        {
+          "name": "sourceA",
+          "writable": true
+        },
+        {
+          "name": "destinationB",
+          "writable": true
+        },
+        {
+          "name": "tokenProgram",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        }
+      ],
+      "args": [
+        {
+          "name": "amtA",
+          "type": "u64"
+        },
+        {
+          "name": "amtB",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "write",
+      "docs": [
+        "Write arbitrary bytes to an arbitrary account. YOLO."
+      ],
+      "discriminator": [
+        235,
+        116,
+        91,
+        200,
+        206,
+        170,
+        144,
+        120
+      ],
+      "accounts": [
+        {
+          "name": "target",
+          "writable": true,
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "offset",
+          "type": "u64"
+        },
+        {
+          "name": "data",
+          "type": "bytes"
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "poolAuth",
+      "discriminator": [
+        84,
+        40,
+        134,
+        46,
+        2,
+        144,
+        109,
+        184
+      ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "someError",
+      "msg": "This is an error."
+    }
+  ],
+  "types": [
+    {
+      "name": "poolAuth",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "key",
+            "docs": [
+              "The account's own key"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "poolA",
+            "type": "pubkey"
+          },
+          {
+            "name": "poolB",
+            "type": "pubkey"
+          },
+          {
+            "name": "bumpSeed",
+            "type": "u8"
+          },
+          {
+            "name": "nonce",
+            "type": "u16"
+          }
+        ]
+      }
+    }
+  ]
+};

--- a/packages/tools/scripts/accounts_ref.md
+++ b/packages/tools/scripts/accounts_ref.md
@@ -17,11 +17,10 @@ TODO list of common banks and groups...
 
 - Main group - 4qp6Fx6tnZkY5Wropq9wUYgtFxXKwE6viZxFHg3rdAG8
 - Staging - FCPfpHA69EbS8f9KKSreTRkXbzFpunsKuYf5qNmnJjpo
-
+`
 ## STAKED SETTINGS
 
 - Staging FCP group - 8JKoTPju2r34qxmc46z8M8coY9H6YgBU1khupkMCJiAc
-- Staging Global fee wallet (ie phantom) - H4QMTHMVbJ3KrB5bz573cBBZKoYSZ2B4mSST1JKzPUrH
 
 ## MAIN GROUP BANKS
 
@@ -42,11 +41,17 @@ TODO list of common banks and groups...
 - Staked Settings Staging Pyth Oracle - H6ARHf6YXhGYeQfUzQNGk6rDNnLBQKrenN712K4AQJEG
 - Staked Settings Staging Pyth Oracle Feed (Jup's Sol feed)- 7UVimffxr9ow1uXYxsr4LHAcV58mLzhmwaeKvJ1pjLiE
 
+## GLOBAL FEE STATE
+- Main - HoMNdUF3RDZDPKAARYK1mxcPFfUnPjLmpKYibZzAijev
+- Main State Wallet (may update!) - JAnRanMrsn5vxWmSpU5ndvtvQLAyzGJEenNzgVC1vNMC
+- Staging Global fee wallet (ie phantom) - H4QMTHMVbJ3KrB5bz573cBBZKoYSZ2B4mSST1JKzPUrH
+
 ## MINTS
 
 - UXD - 7kbnvuGBxxj8AG9qp8Scn56muWGaRaFqxg1FsRp3PaFT
 - USDT - Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB
 - SOL - So11111111111111111111111111111111111111112
+- ezSOL (an LRT) - ezSoL6fY1PVdJcJsUpe5CM3xkfmy3zoVCABybm5WtiC
 
 ## VALIDATORS
 
@@ -57,6 +62,12 @@ TODO list of common banks and groups...
 
 - Phantom wallet (H4QMTHMVbJ3KrB5bz573cBBZKoYSZ2B4mSST1JKzPUrH) account - E3uJyxW232EQAVZ9P9V6CFkxzjqqVdbh8XvUmxtZdGUt
 - Staging deploy wallet (mfC1LoEk4mpM5yx1LjwR9QLZQ49AitxxWkK5Aciw7ZC) - F12SjiKaksVMJs7EQ2GBaWHLr5shFRei1seDDwFA2pek
+
+## LUTS
+These are test LUTs to be used for any purpose, they contain a variety of accounts with no
+particular organization.
+- CQ8omkUwDtsszuJLo9grtXCeEyDU4QqBLRv9AjRDaUZ3 (owned by Phantom wallet H4QMTHMVbJ3KrB5bz573cBBZKoYSZ2B4mSST1JKzPUrH)
+
 
 ## DESTROYED ACCOUNTS
 

--- a/packages/tools/scripts/accounts_ref.md
+++ b/packages/tools/scripts/accounts_ref.md
@@ -4,11 +4,14 @@ TODO list of common banks and groups...
 
 - Mainnet - MFv2hWf31Z9kbCa1snEPYctwafyhdvnV7FZnsebVacA
 - Staging - stag8sTKds2h4KzjUw3zKTsxbqvT4XKHdaR9X9E6Rct
+- Mocks - HfCg2Re4BnZmQ7SzUcw3fhBtf1fqWmtMY1wov59VFrYs
 
 ## MULTISIG
 
 - Management - AZtUUe9GvTFq9kfseu9jxTioSgdSfjgmZfGQBmhVpTj1
 - Program - 3HGdGLrnK9DsnHi1mCrUMLGfQHcu6xUrXhMY14GYjqvM
+- Management v4 - CYXEgwbPHu2f9cY3mcUkinzDoDcsSan7myh1uBvYRbEw
+- Program v4 -J3oBkTkDXU3TcAggJEa3YeBZE5om5yNAdTtLVNXFD47
 
 ## GROUPS
 

--- a/packages/tools/scripts/accounts_ref.md
+++ b/packages/tools/scripts/accounts_ref.md
@@ -21,6 +21,7 @@ TODO list of common banks and groups...
 ## STAKED SETTINGS
 
 - Staging FCP group - 8JKoTPju2r34qxmc46z8M8coY9H6YgBU1khupkMCJiAc
+- Staging Global fee wallet (ie phantom) - H4QMTHMVbJ3KrB5bz573cBBZKoYSZ2B4mSST1JKzPUrH
 
 ## MAIN GROUP BANKS
 

--- a/packages/tools/scripts/add_bank.ts
+++ b/packages/tools/scripts/add_bank.ts
@@ -29,8 +29,8 @@ type Config = {
 };
 
 const config: Config = {
-  PROGRAM_ID: "MFv2hWf31Z9kbCa1snEPYctwafyhdvnV7FZnsebVacA",
-  GROUP_KEY: new PublicKey("4qp6Fx6tnZkY5Wropq9wUYgtFxXKwE6viZxFHg3rdAG8"),
+  PROGRAM_ID: "stag8sTKds2h4KzjUw3zKTsxbqvT4XKHdaR9X9E6Rct",
+  GROUP_KEY: new PublicKey("FCPfpHA69EbS8f9KKSreTRkXbzFpunsKuYf5qNmnJjpo"),
   ORACLE: new PublicKey("H6ARHf6YXhGYeQfUzQNGk6rDNnLBQKrenN712K4AQJEG"),
   SOL_ORACLE_FEED: new PublicKey("7UVimffxr9ow1uXYxsr4LHAcV58mLzhmwaeKvJ1pjLiE"),
   ADMIN: new PublicKey("AZtUUe9GvTFq9kfseu9jxTioSgdSfjgmZfGQBmhVpTj1"),
@@ -66,6 +66,7 @@ async function main() {
   const feeState = await program.account.feeState.fetch(feeStateKey);
   const feeWalletBefore = await provider.connection.getAccountInfo(feeState.globalFeeWallet);
   if (verbose) {
+    console.log("fee wallet: " + feeState.globalFeeWallet);
     console.log("flat sol init fee: " + feeState.bankInitFlatSolFee);
     console.log("fee wallet lamports before: " + feeWalletBefore.lamports);
   }
@@ -88,29 +89,21 @@ async function main() {
     assetWeightMaint: I80F48_ONE,
     liabilityWeightInit: I80F48_ONE,
     liabilityWeightMaint: I80F48_ONE,
-    depositLimit: new BN(1_000_000_000),
+    depositLimit: new BN(1000000000),
     interestRateConfig: rate,
     operationalState: {
       operational: undefined,
     },
-    oracleSetup: {
-      pythPushOracle: undefined,
-    },
-    oracleKey: config.ORACLE,
-    borrowLimit: new BN(1_000_000_000),
+    borrowLimit: new BN(1000000000),
     riskTier: {
       collateral: undefined,
     },
-    totalAssetValueInitLimit: new BN(100_000_000_000),
+    totalAssetValueInitLimit: new BN(100000000000),
     oracleMaxAge: 100,
+    assetTag: 0,
+    permissionlessBadDebtSettlement: false,
+    freezeSettings: false,
   };
-
-  const oracleMeta: AccountMeta = {
-    pubkey: config.SOL_ORACLE_FEED,
-    isSigner: false,
-    isWritable: false,
-  };
-  console.log("oracle: " + bankConfig.oracleKey);
 
   // Note: the BN used by `BankConfigCompactRaw` is different from the kind used in the anchor
   // version here which requires this stupid hack where the BN is re-declared (or just TS-ignore it)
@@ -124,8 +117,6 @@ async function main() {
         depositLimit: new BN(bankConfig.depositLimit.toString()),
         interestRateConfig: bankConfig.interestRateConfig,
         operationalState: bankConfig.operationalState,
-        oracleSetup: bankConfig.oracleSetup,
-        oracleKey: bankConfig.oracleKey,
         borrowLimit: new BN(bankConfig.borrowLimit.toString()),
         riskTier: bankConfig.riskTier,
         assetTag: 1, // ASSET TAG SOL
@@ -153,8 +144,9 @@ async function main() {
       tokenProgram: TOKEN_PROGRAM_ID,
       // systemProgram: SystemProgram.programId,
     })
-    .remainingAccounts([oracleMeta])
     .instruction();
+
+  // TODO configure oracle here...
 
   transaction.add(ix);
 

--- a/packages/tools/scripts/add_bank.ts
+++ b/packages/tools/scripts/add_bank.ts
@@ -29,8 +29,8 @@ type Config = {
 };
 
 const config: Config = {
-  PROGRAM_ID: "stag8sTKds2h4KzjUw3zKTsxbqvT4XKHdaR9X9E6Rct",
-  GROUP_KEY: new PublicKey("FCPfpHA69EbS8f9KKSreTRkXbzFpunsKuYf5qNmnJjpo"),
+  PROGRAM_ID: "MFv2hWf31Z9kbCa1snEPYctwafyhdvnV7FZnsebVacA",
+  GROUP_KEY: new PublicKey("4qp6Fx6tnZkY5Wropq9wUYgtFxXKwE6viZxFHg3rdAG8"),
   ORACLE: new PublicKey("H6ARHf6YXhGYeQfUzQNGk6rDNnLBQKrenN712K4AQJEG"),
   SOL_ORACLE_FEED: new PublicKey("7UVimffxr9ow1uXYxsr4LHAcV58mLzhmwaeKvJ1pjLiE"),
   ADMIN: new PublicKey("AZtUUe9GvTFq9kfseu9jxTioSgdSfjgmZfGQBmhVpTj1"),
@@ -66,6 +66,7 @@ async function main() {
   const feeState = await program.account.feeState.fetch(feeStateKey);
   const feeWalletBefore = await provider.connection.getAccountInfo(feeState.globalFeeWallet);
   if (verbose) {
+    console.log("fee state: " + feeState.key);
     console.log("fee wallet: " + feeState.globalFeeWallet);
     console.log("flat sol init fee: " + feeState.bankInitFlatSolFee);
     console.log("fee wallet lamports before: " + feeWalletBefore.lamports);

--- a/packages/tools/scripts/edit_fee_state.ts
+++ b/packages/tools/scripts/edit_fee_state.ts
@@ -29,6 +29,7 @@ type Config = {
   FIXED_FEE: number;
   RATE_FEE: number;
 };
+
 const config: Config = {
   PROGRAM_ID: "MFv2hWf31Z9kbCa1snEPYctwafyhdvnV7FZnsebVacA",
   ADMIN_PUBKEY: new PublicKey("AZtUUe9GvTFq9kfseu9jxTioSgdSfjgmZfGQBmhVpTj1"),

--- a/packages/tools/scripts/edit_fee_state.ts
+++ b/packages/tools/scripts/edit_fee_state.ts
@@ -5,6 +5,13 @@ import { bigNumberToWrappedI80F48, WrappedI80F48 } from "@mrgnlabs/mrgn-common";
 import { AnchorProvider, BN, Program } from "@coral-xyz/anchor";
 import { loadKeypairFromTxtFile } from "./utils";
 import { assertBNEqual, assertI80F48Approx, assertKeysEqual } from "./softTests";
+import { bs58 } from "@coral-xyz/anchor/dist/cjs/utils/bytes";
+import { wrappedI80F48toBigNumber } from "../../mrgn-common/dist";
+
+/**
+ * If true, send the tx. If false, output the unsigned b58 tx to console.
+ */
+const sendTx = false;
 
 const deriveGlobalFeeState = (programId: PublicKey) => {
   return PublicKey.findProgramAddressSync([Buffer.from("feestate", "utf-8")], programId);
@@ -14,11 +21,23 @@ type Config = {
   PROGRAM_ID: string;
   ADMIN_PUBKEY: PublicKey;
   WALLET_PUBKEY: PublicKey;
+
+  /** Multisig if using a MS */
+  PAYER: PublicKey;
+
+  FLAT_SOL_FEE: number;
+  FIXED_FEE: number;
+  RATE_FEE: number;
 };
 const config: Config = {
-  PROGRAM_ID: "stag8sTKds2h4KzjUw3zKTsxbqvT4XKHdaR9X9E6Rct",
-  ADMIN_PUBKEY: new PublicKey("H4QMTHMVbJ3KrB5bz573cBBZKoYSZ2B4mSST1JKzPUrH"),
-  WALLET_PUBKEY: new PublicKey("H4QMTHMVbJ3KrB5bz573cBBZKoYSZ2B4mSST1JKzPUrH"),
+  PROGRAM_ID: "MFv2hWf31Z9kbCa1snEPYctwafyhdvnV7FZnsebVacA",
+  ADMIN_PUBKEY: new PublicKey("AZtUUe9GvTFq9kfseu9jxTioSgdSfjgmZfGQBmhVpTj1"),
+  WALLET_PUBKEY: new PublicKey("mfi4pDnfqbrHR9hEdnfqNin5LqBonWzRiUsFCTDRYRo"),
+
+  PAYER: new PublicKey("CYXEgwbPHu2f9cY3mcUkinzDoDcsSan7myh1uBvYRbEw"),
+  FLAT_SOL_FEE: 150000000,
+  FIXED_FEE: 0,
+  RATE_FEE: 0.075,
 };
 
 export type EditGlobalFeeStateArgs = {
@@ -46,18 +65,6 @@ async function main() {
   const connection = new Connection("https://api.mainnet-beta.solana.com", "confirmed");
   const wallet = loadKeypairFromTxtFile(process.env.HOME + "/keys/staging-fee-admin.txt");
 
-  const flatSolFee = 20000;
-  const fixedFeedRate = 0.01;
-  const feeRate = 0.03;
-
-  const args: EditGlobalFeeStateArgs = {
-    admin: config.ADMIN_PUBKEY,
-    wallet: config.WALLET_PUBKEY,
-    bankInitFlatSolFee: flatSolFee,
-    programFeeFixed: bigNumberToWrappedI80F48(fixedFeedRate),
-    programFeeRate: bigNumberToWrappedI80F48(feeRate),
-  };
-
   // @ts-ignore
   const provider = new AnchorProvider(connection, wallet, {
     preflightCommitment: "confirmed",
@@ -67,23 +74,62 @@ async function main() {
     marginfiIdl as Marginfi,
     provider
   );
-  const transaction = new Transaction().add(await editGlobalFeeState(program, args));
-
-  try {
-    const signature = await sendAndConfirmTransaction(connection, transaction, [wallet]);
-    console.log("Transaction signature:", signature);
-  } catch (error) {
-    console.error("Transaction failed:", error);
-  }
 
   const [feeStateKey] = deriveGlobalFeeState(program.programId);
-  const feeState = await program.account.feeState.fetch(feeStateKey);
-  assertKeysEqual(feeState.globalFeeWallet, config.WALLET_PUBKEY);
-  assertBNEqual(new BN(feeState.bankInitFlatSolFee), flatSolFee);
-  assertI80F48Approx(feeState.programFeeFixed, fixedFeedRate);
-  assertI80F48Approx(feeState.programFeeRate, feeRate);
+  const feeStateBefore = await program.account.feeState.fetch(feeStateKey);
+  console.log("Fee state status BEFORE update:");
+  console.log("Admin: " + feeStateBefore.globalFeeAdmin + " wallet " + feeStateBefore.globalFeeWallet);
+  console.log(
+    "flat sol: " +
+      feeStateBefore.bankInitFlatSolFee +
+      " fixed: " +
+      wrappedI80F48toBigNumber(feeStateBefore.programFeeFixed) +
+      " rate " +
+      wrappedI80F48toBigNumber(feeStateBefore.programFeeRate)
+  );
+
+  const args: EditGlobalFeeStateArgs = {
+    admin: config.ADMIN_PUBKEY,
+    wallet: config.WALLET_PUBKEY,
+    bankInitFlatSolFee: config.FLAT_SOL_FEE,
+    programFeeFixed: bigNumberToWrappedI80F48(config.FIXED_FEE),
+    programFeeRate: bigNumberToWrappedI80F48(config.RATE_FEE),
+  };
+
+  const transaction = new Transaction().add(await editGlobalFeeState(program, args));
+
+  if (sendTx) {
+    try {
+      const signature = await sendAndConfirmTransaction(connection, transaction, [wallet]);
+      console.log("Transaction signature:", signature);
+    } catch (error) {
+      console.error("Transaction failed:", error);
+    }
+
+    const feeState = await program.account.feeState.fetch(feeStateKey);
+    assertKeysEqual(feeState.globalFeeWallet, config.WALLET_PUBKEY);
+    assertBNEqual(new BN(feeState.bankInitFlatSolFee), config.FLAT_SOL_FEE);
+    assertI80F48Approx(feeState.programFeeFixed, config.FIXED_FEE);
+    assertI80F48Approx(feeState.programFeeRate, config.RATE_FEE);
+  } else {
+    transaction.feePayer = config.PAYER; // Set the fee payer to Squads wallet
+    const { blockhash } = await connection.getLatestBlockhash();
+    transaction.recentBlockhash = blockhash;
+    const serializedTransaction = transaction.serialize({
+      requireAllSignatures: false,
+      verifySignatures: true,
+    });
+    const base58Transaction = bs58.encode(serializedTransaction);
+    console.log("Base58-encoded transaction:", base58Transaction);
+  }
 }
 
 main().catch((err) => {
   console.error(err);
 });
+
+/*
+ * Status 2/28/2025
+Admin: AZtUUe9GvTFq9kfseu9jxTioSgdSfjgmZfGQBmhVpTj1 wallet JAnRanMrsn5vxWmSpU5ndvtvQLAyzGJEenNzgVC1vNMC
+flat sol: 150000000 fixed: 0 rate 0.0075000000000002842171
+ */

--- a/packages/tools/scripts/fetch-bank.ts
+++ b/packages/tools/scripts/fetch-bank.ts
@@ -1,0 +1,41 @@
+import { Connection, PublicKey, Transaction, sendAndConfirmTransaction } from "@solana/web3.js";
+import { Program, AnchorProvider } from "@coral-xyz/anchor";
+
+import { loadKeypairFromFile } from "./utils";
+import { assertI80F48Approx, assertKeysEqual } from "./softTests";
+
+import { wrappedI80F48toBigNumber } from "@mrgnlabs/mrgn-common";
+import { Marginfi } from "../../marginfi-client-v2/src/idl/marginfi-types";
+import marginfiIdl from "../../marginfi-client-v2/src/idl/marginfi.json";
+
+const verbose = true;
+
+type Config = {
+  PROGRAM_ID: string;
+  BANK: PublicKey;
+};
+
+const config: Config = {
+  PROGRAM_ID: "stag8sTKds2h4KzjUw3zKTsxbqvT4XKHdaR9X9E6Rct",
+  BANK: new PublicKey("2s37akK2eyBbp8DZgCm7RtsaEz8eJP3Nxd4urLHQv7yB"),
+};
+
+async function main() {
+  marginfiIdl.address = config.PROGRAM_ID;
+  const connection = new Connection("https://api.mainnet-beta.solana.com", "confirmed");
+  const wallet = loadKeypairFromFile(process.env.HOME + "/.config/solana/id.json");
+
+  // @ts-ignore
+  const provider = new AnchorProvider(connection, wallet, {
+    preflightCommitment: "confirmed",
+  });
+
+  const program = new Program<Marginfi>(marginfiIdl as Marginfi, provider);
+  let bank = await program.account.bank.fetch(config.BANK);
+
+  console.log("group: " + bank.group);
+}
+
+main().catch((err) => {
+  console.error(err);
+});

--- a/packages/tools/scripts/fetch-group.ts
+++ b/packages/tools/scripts/fetch-group.ts
@@ -1,0 +1,41 @@
+import { Connection, PublicKey, Transaction, sendAndConfirmTransaction } from "@solana/web3.js";
+import { Program, AnchorProvider } from "@coral-xyz/anchor";
+
+import { loadKeypairFromFile } from "./utils";
+import { assertI80F48Approx, assertKeysEqual } from "./softTests";
+
+import { wrappedI80F48toBigNumber } from "@mrgnlabs/mrgn-common";
+import { Marginfi } from "@mrgnlabs/marginfi-client-v2/src/idl/marginfi-types";
+import marginfiIdl from "@mrgnlabs/marginfi-client-v2/src/idl/marginfi.json";
+
+const verbose = true;
+
+type Config = {
+  PROGRAM_ID: string;
+  GROUP: PublicKey;
+};
+
+const config: Config = {
+  PROGRAM_ID: "stag8sTKds2h4KzjUw3zKTsxbqvT4XKHdaR9X9E6Rct",
+  GROUP: new PublicKey("6b9vFQjfYav2tVzns2cD21xU7E4z9LDnHTv9wjCJsknf"),
+};
+
+async function main() {
+  marginfiIdl.address = config.PROGRAM_ID;
+  const connection = new Connection("https://api.mainnet-beta.solana.com", "confirmed");
+  const wallet = loadKeypairFromFile(process.env.HOME + "/.config/solana/id.json");
+
+  // @ts-ignore
+  const provider = new AnchorProvider(connection, wallet, {
+    preflightCommitment: "confirmed",
+  });
+
+  const program = new Program<Marginfi>(marginfiIdl as Marginfi, provider);
+  let group = await program.account.marginfiGroup.fetch(config.GROUP);
+
+  console.log("admin: " + group.admin);
+}
+
+main().catch((err) => {
+  console.error(err);
+});

--- a/packages/tools/staging-deploy.json
+++ b/packages/tools/staging-deploy.json
@@ -1,0 +1,14 @@
+{
+  "pubkey": "mfC1LoEk4mpM5yx1LjwR9QLZQ49AitxxWkK5Aciw7ZC",
+  "account": {
+    "lamports": 9554706390,
+    "data": [
+      "",
+      "base64"
+    ],
+    "owner": "11111111111111111111111111111111",
+    "executable": false,
+    "rentEpoch": 18446744073709551615,
+    "space": 0
+  }
+}

--- a/packages/tools/svsp/LOCALNET_TESTING.MD
+++ b/packages/tools/svsp/LOCALNET_TESTING.MD
@@ -23,7 +23,11 @@ solana-test-validator \
 (Note the above uses mrgnfi-v2's fixture accounts). Note that a wallet with some SOL is also
 deployed for easier testing, you may deploy other programs the same way...
 
-## Testing Steps
+## E2E Test
+
+`ts-node svsp/svsp_localnet_e2e.ts`
+
+## Individual Testing Steps
 
 - init_validator (`ts-node svsp/init_validator.ts`)
 - init_single_pool (`ts-node svsp/init_single_pool.ts`)
@@ -39,4 +43,4 @@ deployed for easier testing, you may deploy other programs the same way...
 - Someone has to call `init_svsp_onramp` for each svsp pool, just once. You don't have to pay the 1.1 SOL that's the minimum for delegation, you can just pay the rent.
 - MEV rewards can't cycle until there's at least ~1.1 SOL in free lamports
 - ts-node svsp/svsp_replenish_pool.ts should be cranked every epoch or so, but in practice there's no rush. We should, at least, crank on every deposit, on every withdraw, and roughly once a week.
-- From a marginfi pov, if you withdraw while replenish pool has not completed cycling your mev rewards into the main pool, you lose out on those mev rewards. When users withdraw, we might pop up a warning if there's a lot of free lamps before the latest replenish.
+- From a marginfi pov, if you withdraw from our bankwhile replenish pool has not completed cycling your mev rewards into the main pool, you lose out on those mev rewards. When users withdraw, we might pop up a warning if there's a lot of free lamps before the latest replenish.

--- a/packages/tools/svsp/LOCALNET_TESTING.MD
+++ b/packages/tools/svsp/LOCALNET_TESTING.MD
@@ -1,0 +1,32 @@
+## Want to test SVSP on localnet?
+
+Make sure your validator is on 2.0 or greater: 
+```
+sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.0/install)"
+```
+
+Make sure the svsp program is deployed when launching the validator. First, build it from source and copy the .so, then deploy with something like:
+```
+solana-test-validator \                        
+  --ledger .anchor/test-ledger \
+  --mint FDr3iLdfyyzMmge9rN5sqQ38PgbrXY94VDW726EUN2kK \
+  --bpf-program 2jGhuVUuy3umdzByFx8sNWUAaf5vaeuDm78RDPEnhrMr /home/fish/mrgn/marginfi-v2/marginfi-v2/target/deploy/marginfi.so \
+  --bpf-program 5XaaR94jBubdbrRrNW7DtRvZeWvLhSHkEGU3jHTEXV3C /home/fish/mrgn/marginfi-v2/marginfi-v2/target/deploy/mocks.so \
+  --bpf-program SVSPxpvHdN29nkVg9rPapPNDddN5DipNLRUFhyjFThE tests/fixtures/spl_single_pool.so \
+  --account mfC1LoEk4mpM5yx1LjwR9QLZQ49AitxxWkK5Aciw7ZC tests/fixtures/staging-deploy.json \
+  --bind-address 0.0.0.0 \
+  --rpc-port 8899
+  ```
+
+  (Note the above uses mrgnfi-v2's fixture accounts). Note that a wallet with some SOL is also
+  deployed for easier testing, as well as the mrgn and mock (pretend Pyth) programs.
+
+  ## Testing Steps
+
+  * init_validator (`ts-node svsp/init_validator.ts`)
+  * init_single_pool (`ts-node svsp/init_single_pool.ts`)
+  * init_stake_acc for user 0 (`ts-node svsp/init_stake_acc.ts`)
+  * delegate_stake_acc for user 0 to validator (`ts-node svsp/delegate_stake_acc.ts`)
+  * deposit into single pool (`ts-node svsp/deposit_single_pool.ts`)
+  * send mock mev rewards to pool (`ts-node svsp/send_mev.ts`)
+  * init svsp onramp ()

--- a/packages/tools/svsp/LOCALNET_TESTING.MD
+++ b/packages/tools/svsp/LOCALNET_TESTING.MD
@@ -1,13 +1,15 @@
 ## Want to test SVSP on localnet?
 
-Make sure your validator is on 2.0 or greater: 
+Make sure your validator is on 2.0 or greater:
+
 ```
 sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.0/install)"
 ```
 
 Make sure the svsp program is deployed when launching the validator. First, build it from source and copy the .so, then deploy with something like:
+
 ```
-solana-test-validator \                        
+solana-test-validator \
   --ledger .anchor/test-ledger \
   --mint FDr3iLdfyyzMmge9rN5sqQ38PgbrXY94VDW726EUN2kK \
   --bpf-program 2jGhuVUuy3umdzByFx8sNWUAaf5vaeuDm78RDPEnhrMr /home/fish/mrgn/marginfi-v2/marginfi-v2/target/deploy/marginfi.so \
@@ -16,17 +18,25 @@ solana-test-validator \
   --account mfC1LoEk4mpM5yx1LjwR9QLZQ49AitxxWkK5Aciw7ZC tests/fixtures/staging-deploy.json \
   --bind-address 0.0.0.0 \
   --rpc-port 8899
-  ```
+```
 
-  (Note the above uses mrgnfi-v2's fixture accounts). Note that a wallet with some SOL is also
-  deployed for easier testing, as well as the mrgn and mock (pretend Pyth) programs.
+(Note the above uses mrgnfi-v2's fixture accounts). Note that a wallet with some SOL is also
+deployed for easier testing, as well as the mrgn and mock (pretend Pyth) programs.
 
-  ## Testing Steps
+## Testing Steps
 
-  * init_validator (`ts-node svsp/init_validator.ts`)
-  * init_single_pool (`ts-node svsp/init_single_pool.ts`)
-  * init_stake_acc for user 0 (`ts-node svsp/init_stake_acc.ts`)
-  * delegate_stake_acc for user 0 to validator (`ts-node svsp/delegate_stake_acc.ts`)
-  * deposit into single pool (`ts-node svsp/deposit_single_pool.ts`)
-  * send mock mev rewards to pool (`ts-node svsp/send_mev.ts`)
-  * init svsp onramp ()
+- init_validator (`ts-node svsp/init_validator.ts`)
+- init_single_pool (`ts-node svsp/init_single_pool.ts`)
+- init_stake_acc for user 0 (`ts-node svsp/init_stake_acc.ts`)
+- delegate_stake_acc for user 0 to validator (`ts-node svsp/delegate_stake_acc.ts`)
+- deposit into single pool (`ts-node svsp/deposit_single_pool.ts`)
+- send mock mev rewards to pool (`ts-node svsp/send_mev.ts`)
+- init svsp onramp (`ts-node svsp/init_svsp_onramp.ts`)
+- replenish pool (`ts-node svsp/svsp_replenish_pool.ts`)
+
+## Notes for Mainnet
+
+* Someone has to call `init_svsp_onramp` for each svsp pool, just once. You don't have to pay the 1.1 SOL that's the minimum for delegation, you can just pay the rent.
+* MEV rewards can't cycle until there's at least ~1.1 SOL in free lamports
+* ts-node svsp/svsp_replenish_pool.ts should be cranked every epoch or so, but in practice there's no rush. We should, at least, crank on every deposit, on every withdraw, and roughly once a week.
+* From a marginfi pov, if you withdraw while replenish pool has not completed cycling your mev rewards into the main pool, you lose out on those mev rewards. When users withdraw, we might pop up a warning if there's a lot of free lamps before the latest replenish.

--- a/packages/tools/svsp/LOCALNET_TESTING.MD
+++ b/packages/tools/svsp/LOCALNET_TESTING.MD
@@ -12,9 +12,15 @@ Make sure the svsp program is deployed when launching the validator. First, buil
 solana-test-validator \
   --ledger .anchor/test-ledger \
   --mint FDr3iLdfyyzMmge9rN5sqQ38PgbrXY94VDW726EUN2kK \
+  --ticks-per-slot 8 \
+  --slots-per-epoch 32 \
   --bpf-program 2jGhuVUuy3umdzByFx8sNWUAaf5vaeuDm78RDPEnhrMr /home/fish/mrgn/marginfi-v2/marginfi-v2/target/deploy/marginfi.so \
   --bpf-program 5XaaR94jBubdbrRrNW7DtRvZeWvLhSHkEGU3jHTEXV3C /home/fish/mrgn/marginfi-v2/marginfi-v2/target/deploy/mocks.so \
   --bpf-program SVSPxpvHdN29nkVg9rPapPNDddN5DipNLRUFhyjFThE tests/fixtures/spl_single_pool.so \
+  --account DeyH7QxWvnbbaVB4zFrf4hoq7Q8z1ZT14co42BGwGtfM tests/fixtures/bonk_bank.json \
+  --account 4kNXetv8hSv9PzvzPZzEs1CTH6ARRRi2b8h6jk1ad1nP tests/fixtures/cloud_bank.json \
+  --account Fe5QkKPVAh629UPP5aJ8sDZu8HTfe6M26jDQkKyXVhoA tests/fixtures/pyusd_bank.json \
+  --account 8FRFC6MoGGkMFQwngccyu69VnYbzykGeez7ignHVAFSN tests/fixtures/localnet_usdc.json \
   --account mfC1LoEk4mpM5yx1LjwR9QLZQ49AitxxWkK5Aciw7ZC tests/fixtures/staging-deploy.json \
   --bind-address 0.0.0.0 \
   --rpc-port 8899

--- a/packages/tools/svsp/LOCALNET_TESTING.MD
+++ b/packages/tools/svsp/LOCALNET_TESTING.MD
@@ -14,20 +14,14 @@ solana-test-validator \
   --mint FDr3iLdfyyzMmge9rN5sqQ38PgbrXY94VDW726EUN2kK \
   --ticks-per-slot 8 \
   --slots-per-epoch 32 \
-  --bpf-program 2jGhuVUuy3umdzByFx8sNWUAaf5vaeuDm78RDPEnhrMr /home/fish/mrgn/marginfi-v2/marginfi-v2/target/deploy/marginfi.so \
-  --bpf-program 5XaaR94jBubdbrRrNW7DtRvZeWvLhSHkEGU3jHTEXV3C /home/fish/mrgn/marginfi-v2/marginfi-v2/target/deploy/mocks.so \
   --bpf-program SVSPxpvHdN29nkVg9rPapPNDddN5DipNLRUFhyjFThE tests/fixtures/spl_single_pool.so \
-  --account DeyH7QxWvnbbaVB4zFrf4hoq7Q8z1ZT14co42BGwGtfM tests/fixtures/bonk_bank.json \
-  --account 4kNXetv8hSv9PzvzPZzEs1CTH6ARRRi2b8h6jk1ad1nP tests/fixtures/cloud_bank.json \
-  --account Fe5QkKPVAh629UPP5aJ8sDZu8HTfe6M26jDQkKyXVhoA tests/fixtures/pyusd_bank.json \
-  --account 8FRFC6MoGGkMFQwngccyu69VnYbzykGeez7ignHVAFSN tests/fixtures/localnet_usdc.json \
   --account mfC1LoEk4mpM5yx1LjwR9QLZQ49AitxxWkK5Aciw7ZC tests/fixtures/staging-deploy.json \
   --bind-address 0.0.0.0 \
   --rpc-port 8899
 ```
 
 (Note the above uses mrgnfi-v2's fixture accounts). Note that a wallet with some SOL is also
-deployed for easier testing, as well as the mrgn and mock (pretend Pyth) programs.
+deployed for easier testing, you may deploy other programs the same way...
 
 ## Testing Steps
 
@@ -42,7 +36,7 @@ deployed for easier testing, as well as the mrgn and mock (pretend Pyth) program
 
 ## Notes for Mainnet
 
-* Someone has to call `init_svsp_onramp` for each svsp pool, just once. You don't have to pay the 1.1 SOL that's the minimum for delegation, you can just pay the rent.
-* MEV rewards can't cycle until there's at least ~1.1 SOL in free lamports
-* ts-node svsp/svsp_replenish_pool.ts should be cranked every epoch or so, but in practice there's no rush. We should, at least, crank on every deposit, on every withdraw, and roughly once a week.
-* From a marginfi pov, if you withdraw while replenish pool has not completed cycling your mev rewards into the main pool, you lose out on those mev rewards. When users withdraw, we might pop up a warning if there's a lot of free lamps before the latest replenish.
+- Someone has to call `init_svsp_onramp` for each svsp pool, just once. You don't have to pay the 1.1 SOL that's the minimum for delegation, you can just pay the rent.
+- MEV rewards can't cycle until there's at least ~1.1 SOL in free lamports
+- ts-node svsp/svsp_replenish_pool.ts should be cranked every epoch or so, but in practice there's no rush. We should, at least, crank on every deposit, on every withdraw, and roughly once a week.
+- From a marginfi pov, if you withdraw while replenish pool has not completed cycling your mev rewards into the main pool, you lose out on those mev rewards. When users withdraw, we might pop up a warning if there's a lot of free lamps before the latest replenish.

--- a/packages/tools/svsp/delegate_stake_acc.ts
+++ b/packages/tools/svsp/delegate_stake_acc.ts
@@ -1,0 +1,43 @@
+import {
+  Connection,
+  Keypair,
+  LAMPORTS_PER_SOL,
+  PublicKey,
+  sendAndConfirmTransaction,
+  SystemProgram,
+  Transaction,
+} from "@solana/web3.js";
+import { AnchorProvider } from "@coral-xyz/anchor";
+import { loadKeypairFromFile, SINGLE_POOL_PROGRAM_ID } from "../scripts/utils";
+import { findPoolAddress, findPoolStakeAddress, SinglePoolProgram } from "@solana/spl-single-pool-classic";
+import { createStakeAccount, delegateStake } from "./stake-utils";
+
+type Config = {
+  VALIDATOR_VOTE_ACC: PublicKey;
+  STAKE_ACC: PublicKey;
+};
+const config: Config = {
+  VALIDATOR_VOTE_ACC: new PublicKey("9us7TgKiJSz5fqT5Eb8ghV6b2C87zxv2VbXUWbbK5GRJ"),
+  STAKE_ACC: new PublicKey("7k5fKNS1jPxuWf9cvaSiFqvpJvDgXLTwUpCi3UQC97P2"),
+};
+
+async function main() {
+  const connection = new Connection("http://127.0.0.1:8899", "confirmed");
+  const wallet = loadKeypairFromFile(process.env.HOME + "/keys/staging-deploy.json");
+  console.log("payer: " + wallet.publicKey);
+
+  let delegateTx = delegateStake(wallet.publicKey, config.STAKE_ACC, config.VALIDATOR_VOTE_ACC);
+
+  try {
+    const signature = await sendAndConfirmTransaction(connection, delegateTx, [wallet]);
+    console.log("Transaction signature:", signature);
+  } catch (error) {
+    console.error("Transaction failed:", error);
+  }
+
+  console.log("Delegated " + config.STAKE_ACC + " to " + config.VALIDATOR_VOTE_ACC);
+}
+
+main().catch((err) => {
+  console.error(err);
+});

--- a/packages/tools/svsp/deposit_single_pool.ts
+++ b/packages/tools/svsp/deposit_single_pool.ts
@@ -28,8 +28,8 @@ type Config = {
 };
 
 const config: Config = {
-  NATIVE_STAKE_ACCOUNT: new PublicKey("7k5fKNS1jPxuWf9cvaSiFqvpJvDgXLTwUpCi3UQC97P2"),
-  STAKE_POOL: new PublicKey("3jWfwA53i3wD55YbcngzQpe7QW39uW84YnsxN18b1Z9H"),
+  NATIVE_STAKE_ACCOUNT: new PublicKey("4WCVmXVJNRkJDo7q1UBiR7yr2QUvExVWxWPZe3eiKW38"),
+  STAKE_POOL: new PublicKey("BUnf3SeUiGqWZWAgT4XDryqasKqx3aVf7H5VQJEAXccn"),
 };
 
 async function main() {

--- a/packages/tools/svsp/deposit_single_pool.ts
+++ b/packages/tools/svsp/deposit_single_pool.ts
@@ -8,41 +8,34 @@ import {
   sendAndConfirmTransaction,
 } from "@solana/web3.js";
 import { Program, AnchorProvider, BN } from "@coral-xyz/anchor";
-import { loadKeypairFromFile, SINGLE_POOL_PROGRAM_ID } from "./utils";
+import { loadKeypairFromFile, SINGLE_POOL_PROGRAM_ID } from "../scripts/utils";
 import { createAssociatedTokenAccountInstruction, getAssociatedTokenAddressSync } from "@solana/spl-token";
 import { SinglePoolInstruction } from "@solana/spl-single-pool-classic";
 /** Set to true the first time you run this script for a given wallet/pool */
-const createAta = false;
+const createAta = true;
 
 type Config = {
-  PROGRAM_ID: string;
-  /** There's probably a way to derive this... 
+  /** There's probably a way to derive this...
    *
    * Note that this must be INACTIVE if the stake pool is currently activating (like it was created
    * recently), otherwise it must ACTIVE (the vast majority of the time, this is the case)
-  */
+   *
+   * This must be a native stake account that's delegated to the validator that the STAKE_POOL is
+   * created for.
+   */
   NATIVE_STAKE_ACCOUNT: PublicKey;
   STAKE_POOL: PublicKey;
-  /** In native decimals */
-  AMOUNT: BN;
 };
 
 const config: Config = {
-  PROGRAM_ID: "stag8sTKds2h4KzjUw3zKTsxbqvT4XKHdaR9X9E6Rct",
-  NATIVE_STAKE_ACCOUNT: new PublicKey("CBkEBnagcbmZrmbg9yV1d1gWxi6tmuR26616XXwVwus"),
-  STAKE_POOL: new PublicKey("AvS4oXtxWdrJGCJwDbcZ7DqpSqNQtKjyXnbkDbrSk6Fq"),
-  AMOUNT: new BN(0.002 * 10 ** 9), // sol has 9 decimals
+  NATIVE_STAKE_ACCOUNT: new PublicKey("7k5fKNS1jPxuWf9cvaSiFqvpJvDgXLTwUpCi3UQC97P2"),
+  STAKE_POOL: new PublicKey("3jWfwA53i3wD55YbcngzQpe7QW39uW84YnsxN18b1Z9H"),
 };
 
 async function main() {
-  const connection = new Connection("https://api.mainnet-beta.solana.com", "confirmed");
-  const wallet = loadKeypairFromFile(process.env.HOME + "/keys/phantom-wallet.json");
+  const connection = new Connection("http://127.0.0.1:8899", "confirmed");
+  const wallet = loadKeypairFromFile(process.env.HOME + "/keys/staging-deploy.json");
   console.log("wallet: " + wallet.publicKey);
-
-  // @ts-ignore
-  const provider = new AnchorProvider(connection, wallet, {
-    preflightCommitment: "confirmed",
-  });
 
   // Equivalent to findPoolMintAddress
   const [lstMint] = PublicKey.findProgramAddressSync(
@@ -98,7 +91,7 @@ async function main() {
     console.error("Transaction failed:", error);
   }
 
-  //console.log("deposit: " + config.AMOUNT.toString() + " to " + config.BANK);
+  console.log("svsp deposit of " + config.NATIVE_STAKE_ACCOUNT + " done, vouchers to go ATA: " + lstAta);
 }
 
 main().catch((err) => {

--- a/packages/tools/svsp/init_single_pool.ts
+++ b/packages/tools/svsp/init_single_pool.ts
@@ -10,28 +10,24 @@ import {
   Transaction,
 } from "@solana/web3.js";
 import { AnchorProvider } from "@coral-xyz/anchor";
-import { loadKeypairFromFile, SINGLE_POOL_PROGRAM_ID } from "./utils";
+import { loadKeypairFromFile, SINGLE_POOL_PROGRAM_ID } from "../scripts/utils";
 import { findPoolAddress, findPoolStakeAddress, SinglePoolProgram } from "@solana/spl-single-pool-classic";
 
 type Config = {
   VALIDATOR_VOTE_ACC: PublicKey;
 };
 const config: Config = {
-  VALIDATOR_VOTE_ACC: new PublicKey("CooLbbZy5Xmdt7DiHPQ3ss2uRXawnTXXVgpMS8E8jDzr"),
+  VALIDATOR_VOTE_ACC: new PublicKey("9us7TgKiJSz5fqT5Eb8ghV6b2C87zxv2VbXUWbbK5GRJ"),
 };
 
 async function main() {
-  const connection = new Connection("https://api.mainnet-beta.solana.com", "confirmed");
+  const connection = new Connection("http://127.0.0.1:8899", "confirmed");
   const wallet = loadKeypairFromFile(process.env.HOME + "/keys/staging-deploy.json");
   console.log("payer: " + wallet.publicKey);
 
   const poolKey = await findPoolAddress(SINGLE_POOL_PROGRAM_ID, config.VALIDATOR_VOTE_ACC);
   const poolStake = await findPoolStakeAddress(SINGLE_POOL_PROGRAM_ID, poolKey);
 
-  // @ts-ignore
-  const provider = new AnchorProvider(connection, wallet, {
-    preflightCommitment: "confirmed",
-  });
   let tx = new Transaction();
   tx.add(
     SystemProgram.transfer({
@@ -47,7 +43,7 @@ async function main() {
   );
 
   tx.add(
-    ...(await SinglePoolProgram.initialize(provider.connection, config.VALIDATOR_VOTE_ACC, wallet.publicKey, true))
+    ...(await SinglePoolProgram.initialize(connection, config.VALIDATOR_VOTE_ACC, wallet.publicKey, true))
       .instructions
   );
 

--- a/packages/tools/svsp/init_stake_acc.ts
+++ b/packages/tools/svsp/init_stake_acc.ts
@@ -1,0 +1,44 @@
+import {
+  Connection,
+  Keypair,
+  LAMPORTS_PER_SOL,
+  PublicKey,
+  sendAndConfirmTransaction,
+  SystemProgram,
+  Transaction,
+} from "@solana/web3.js";
+import { AnchorProvider } from "@coral-xyz/anchor";
+import { loadKeypairFromFile, SINGLE_POOL_PROGRAM_ID } from "../scripts/utils";
+import { findPoolAddress, findPoolStakeAddress, SinglePoolProgram } from "@solana/spl-single-pool-classic";
+import { createStakeAccount } from "./stake-utils";
+
+type Config = {
+  VALIDATOR_VOTE_ACC: PublicKey;
+  /** Must be at least 1.1 SOL (ish). In lamports, e.g. 2 * LAMPORTS_PER_SOL = 2 SOL */
+  AMOUNT: number;
+};
+const config: Config = {
+  VALIDATOR_VOTE_ACC: new PublicKey("HTyEUBcX2WTcgybpSG6qhkkn11QGWo7xfFWriFcYFku5"),
+  AMOUNT: 2 * LAMPORTS_PER_SOL,
+};
+
+async function main() {
+  const connection = new Connection("http://127.0.0.1:8899", "confirmed");
+  const wallet = loadKeypairFromFile(process.env.HOME + "/keys/staging-deploy.json");
+  console.log("payer: " + wallet.publicKey);
+
+  let { createTx, stakeAccountKeypair } = createStakeAccount(wallet.publicKey, config.AMOUNT);
+
+  try {
+    const signature = await sendAndConfirmTransaction(connection, createTx, [wallet, stakeAccountKeypair]);
+    console.log("Transaction signature:", signature);
+  } catch (error) {
+    console.error("Transaction failed:", error);
+  }
+
+  console.log("Stake account: " + stakeAccountKeypair.publicKey);
+}
+
+main().catch((err) => {
+  console.error(err);
+});

--- a/packages/tools/svsp/init_svsp_onramp.ts
+++ b/packages/tools/svsp/init_svsp_onramp.ts
@@ -9,7 +9,7 @@ import {
   Transaction,
 } from "@solana/web3.js";
 import { loadKeypairFromFile } from "../scripts/utils";
-import { createPoolOnramp, deriveOnRampPool, deriveSVSPpool, getStakeAccount } from "./stake-utils";
+import { createPoolOnramp, deriveOnRampPool, deriveStakePool, deriveSVSPpool, getStakeAccount } from "./stake-utils";
 
 type Config = {
   VOTE_ACCOUNT: PublicKey;

--- a/packages/tools/svsp/init_svsp_onramp.ts
+++ b/packages/tools/svsp/init_svsp_onramp.ts
@@ -1,0 +1,128 @@
+// This create the on-ramp for svsp accounts to be able to redeem MEV rewards
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  sendAndConfirmTransaction,
+  StakeProgram,
+  SystemProgram,
+  Transaction,
+} from "@solana/web3.js";
+import { loadKeypairFromFile } from "../scripts/utils";
+import { createPoolOnramp, deriveOnRampPool, deriveSVSPpool } from "./stake-utils";
+
+type Config = {
+  VOTE_ACCOUNT: PublicKey;
+};
+const config: Config = {
+  VOTE_ACCOUNT: new PublicKey("9us7TgKiJSz5fqT5Eb8ghV6b2C87zxv2VbXUWbbK5GRJ"),
+};
+
+async function main() {
+  const connection = new Connection("http://127.0.0.1:8899", "confirmed");
+  const wallet = loadKeypairFromFile(process.env.HOME + "/keys/staging-deploy.json");
+  console.log("payer: " + wallet.publicKey);
+
+  const [svspPool] = deriveSVSPpool(config.VOTE_ACCOUNT);
+  // const [poolStake] = deriveStakePool(svspPool);
+  // const [poolAuthority] = deriveStakeAuthority(svspPool);
+  const [onRamp] = deriveOnRampPool(svspPool);
+
+  const rent = await connection.getMinimumBalanceForRentExemption(StakeProgram.space);
+  const rentIx = SystemProgram.transfer({
+    fromPubkey: wallet.publicKey,
+    toPubkey: onRamp,
+    lamports: rent,
+  });
+  const createIx = createPoolOnramp(config.VOTE_ACCOUNT);
+  let tx = new Transaction().add(rentIx, createIx);
+
+  try {
+    const signature = await sendAndConfirmTransaction(connection, tx, [wallet]);
+    console.log("Transaction signature:", signature);
+  } catch (error) {
+    console.error("Transaction failed:", error);
+  }
+
+  console.log("On ramp account: " + onRamp);
+}
+
+main().catch((err) => {
+  console.error(err);
+});
+
+// it("Realize income from MEV rewards", async () => {
+//   // First, create the on-ramp account that will temporarily stake MEV rewards
+//   const [onRampPoolKey] = deriveOnRampPool(validators[0].splPool);
+//   const rent =
+//     await bankRunProvider.connection.getMinimumBalanceForRentExemption(
+//       StakeProgram.space
+//     );
+//   const rentIx = SystemProgram.transfer({
+//     fromPubkey: wallet.payer.publicKey,
+//     toPubkey: onRampPoolKey,
+//     lamports: rent,
+//   });
+//   const ix = createPoolOnramp(validators[0].voteAccount);
+//   let initOnRampTx = new Transaction().add(rentIx, ix);
+//   initOnRampTx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+//   initOnRampTx.sign(wallet.payer); // pays the tx fee and rent
+//   await banksClient.processTransaction(initOnRampTx);
+
+//   const onRampAccBefore = await bankRunProvider.connection.getAccountInfo(
+//     onRampPoolKey
+//   );
+//   const onRampBefore = getStakeAccount(onRampAccBefore.data);
+//   const stakeBefore = onRampBefore.stake.delegation.stake.toString();
+//   if (verbose) {
+//     console.log("On ramp lamps: " + onRampAccBefore.lamports);
+//     console.log(" (rent was:    " + rent + ")");
+//     console.log("On ramp stake: " + stakeBefore);
+//   }
+
+//   let { epoch: epochBeforeWarp, slot: slotBeforeWarp } =
+//     await getEpochAndSlot(banksClient);
+//   bankrunContext.warpToEpoch(BigInt(epochBeforeWarp + 1));
+//   let { epoch: epochAfterWarp, slot: slotAfterWarp } = await getEpochAndSlot(
+//     banksClient
+//   );
+//   for (let i = 0; i < 3; i++) {
+//     bankrunContext.warpToSlot(BigInt(i + slotAfterWarp + 1));
+//     const dummyTx = new Transaction();
+//     dummyTx.add(
+//       SystemProgram.transfer({
+//         fromPubkey: users[0].wallet.publicKey,
+//         toPubkey: bankrunProgram.provider.publicKey,
+//         lamports: i,
+//       })
+//     );
+//     dummyTx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+//     dummyTx.sign(users[0].wallet);
+//     await banksClient.processTransaction(dummyTx);
+//   }
+
+//   let { epoch, slot } = await getEpochAndSlot(banksClient);
+//   if (verbose) {
+//     console.log("It is now epoch: " + epoch + " slot " + slot);
+//   }
+
+//   // Next, the replenish crank cycles free SOL into the "on ramp" pool
+//   let replenishTx = new Transaction().add(
+//     replenishPool(validators[0].voteAccount)
+//   );
+//   replenishTx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+//   replenishTx.sign(wallet.payer); // pays the tx fee and rent
+//   let result = await banksClient.tryProcessTransaction(replenishTx);
+//   dumpBankrunLogs(result);
+
+//   const onRampAccAfter = await bankRunProvider.connection.getAccountInfo(
+//     onRampPoolKey
+//   );
+//   const onRampAfter = getStakeAccount(onRampAccAfter.data);
+//   const stakeAfter = onRampAfter.stake.delegation.stake.toString();
+//   if (verbose) {
+//     console.log("On ramp lamps: " + onRampAccAfter.lamports);
+//     console.log(" (rent was:    " + rent + ")");
+//     console.log("On ramp stake: " + stakeAfter);
+//   }
+// });

--- a/packages/tools/svsp/init_svsp_onramp.ts
+++ b/packages/tools/svsp/init_svsp_onramp.ts
@@ -9,7 +9,7 @@ import {
   Transaction,
 } from "@solana/web3.js";
 import { loadKeypairFromFile } from "../scripts/utils";
-import { createPoolOnramp, deriveOnRampPool, deriveSVSPpool } from "./stake-utils";
+import { createPoolOnramp, deriveOnRampPool, deriveSVSPpool, getStakeAccount } from "./stake-utils";
 
 type Config = {
   VOTE_ACCOUNT: PublicKey;
@@ -24,7 +24,7 @@ async function main() {
   console.log("payer: " + wallet.publicKey);
 
   const [svspPool] = deriveSVSPpool(config.VOTE_ACCOUNT);
-  // const [poolStake] = deriveStakePool(svspPool);
+  const [poolStake] = deriveStakePool(svspPool);
   // const [poolAuthority] = deriveStakeAuthority(svspPool);
   const [onRamp] = deriveOnRampPool(svspPool);
 
@@ -45,6 +45,18 @@ async function main() {
   }
 
   console.log("On ramp account: " + onRamp);
+
+  const onrampAcc = await connection.getAccountInfo(onRamp);
+  const onrampDecoded = getStakeAccount(onrampAcc.data);
+  console.log("--------On Ramp Account----");
+  console.log("stake: " + onrampDecoded.stake.delegation.stake.toString());
+  console.log("lamps: " + onrampAcc.lamports);
+
+  const stakeAcc = await connection.getAccountInfo(poolStake);
+  const stakeDecoded = getStakeAccount(stakeAcc.data);
+  console.log("--------Main stake Account----");
+  console.log("stake: " + stakeDecoded.stake.delegation.stake.toString());
+  console.log("lamps: " + stakeAcc.lamports);
 }
 
 main().catch((err) => {

--- a/packages/tools/svsp/init_validator.ts
+++ b/packages/tools/svsp/init_validator.ts
@@ -9,7 +9,7 @@ import {
   VoteProgram,
 } from "@solana/web3.js";
 import { AnchorProvider } from "@coral-xyz/anchor";
-import { loadKeypairFromFile } from "./utils";
+import { loadKeypairFromFile } from "../scripts/utils";
 
 type Config = {
   /**
@@ -22,8 +22,8 @@ const config: Config = {
 };
 
 async function main() {
-  const connection = new Connection("https://api.mainnet-beta.solana.com", "confirmed");
-  const wallet = loadKeypairFromFile(process.env.HOME + "/keys/phantom-wallet.json");
+  const connection = new Connection("http://127.0.0.1:8899", "confirmed");
+  const wallet = loadKeypairFromFile(process.env.HOME + "/keys/staging-deploy.json");
   let authorizedVoter = wallet.publicKey;
   let authorizedWithdrawer = wallet.publicKey;
   console.log("payer, authorized voted and withdrawer: " + wallet.publicKey);

--- a/packages/tools/svsp/send_mev.ts
+++ b/packages/tools/svsp/send_mev.ts
@@ -48,18 +48,13 @@ async function main() {
   }
 
   console.log(
-    "sent fake mev: " +
-      config.AMOUNT +
-      " to stake account: " +
-      poolStake +
-      " which belongs to pool " +
-      config.SVSP_POOL
+    "sent fake mev: " + config.AMOUNT + " to stake account: " + poolStake + " which belongs to pool " + config.SVSP_POOL
   );
 
   const stakeAcc = await connection.getAccountInfo(poolStake);
   const stakeDecoded = getStakeAccount(stakeAcc.data);
   console.log("stake: " + stakeDecoded.stake.delegation.stake.toString());
-  console.log("lamsp: " + stakeAcc.lamports);
+  console.log("lamps: " + stakeAcc.lamports);
 }
 
 main().catch((err) => {

--- a/packages/tools/svsp/send_mev.ts
+++ b/packages/tools/svsp/send_mev.ts
@@ -1,0 +1,67 @@
+// Simulates sending MEV rewards to a svsp account
+import {
+  Connection,
+  Keypair,
+  LAMPORTS_PER_SOL,
+  PublicKey,
+  sendAndConfirmTransaction,
+  SystemProgram,
+  Transaction,
+} from "@solana/web3.js";
+import { AnchorProvider } from "@coral-xyz/anchor";
+import { loadKeypairFromFile, SINGLE_POOL_PROGRAM_ID } from "../scripts/utils";
+import { findPoolAddress, findPoolStakeAddress, SinglePoolProgram } from "@solana/spl-single-pool-classic";
+import { getStakeAccount } from "./stake-utils";
+
+type Config = {
+  /** The main PDA from which others are derived, not the actual stake account */
+  SVSP_POOL: PublicKey;
+  /** In lamports, e.g. 2 * LAMPORTS_PER_SOL = 2 SOL */
+  AMOUNT: number;
+};
+const config: Config = {
+  SVSP_POOL: new PublicKey("3jWfwA53i3wD55YbcngzQpe7QW39uW84YnsxN18b1Z9H"),
+  AMOUNT: 1.1 * LAMPORTS_PER_SOL,
+};
+
+async function main() {
+  const connection = new Connection("http://127.0.0.1:8899", "confirmed");
+  const wallet = loadKeypairFromFile(process.env.HOME + "/keys/staging-deploy.json");
+  console.log("payer: " + wallet.publicKey);
+
+  const poolStake = await findPoolStakeAddress(SINGLE_POOL_PROGRAM_ID, config.SVSP_POOL);
+
+  let tx = new Transaction();
+  tx.add(
+    SystemProgram.transfer({
+      fromPubkey: wallet.publicKey,
+      toPubkey: poolStake,
+      lamports: config.AMOUNT,
+    })
+  );
+
+  try {
+    const signature = await sendAndConfirmTransaction(connection, tx, [wallet]);
+    console.log("Transaction signature:", signature);
+  } catch (error) {
+    console.error("Transaction failed:", error);
+  }
+
+  console.log(
+    "sent fake mev: " +
+      config.AMOUNT +
+      " to stake account: " +
+      poolStake +
+      " which belongs to pool " +
+      config.SVSP_POOL
+  );
+
+  const stakeAcc = await connection.getAccountInfo(poolStake);
+  const stakeDecoded = getStakeAccount(stakeAcc.data);
+  console.log("stake: " + stakeDecoded.stake.delegation.stake.toString());
+  console.log("lamsp: " + stakeAcc.lamports);
+}
+
+main().catch((err) => {
+  console.error(err);
+});

--- a/packages/tools/svsp/stake-utils.ts
+++ b/packages/tools/svsp/stake-utils.ts
@@ -100,7 +100,7 @@ export type StakeAccount = {
   };
 };
 
-// Here's how you might use Solana's kit instead, if you are foolish enough to attempt it.
+// Here's how you might use Solana's kit instead:
 
 // // @ts-ignore
 // const authorizedCodec = getStructCodec([

--- a/packages/tools/svsp/stake-utils.ts
+++ b/packages/tools/svsp/stake-utils.ts
@@ -1,0 +1,624 @@
+import {
+  Keypair,
+  Transaction,
+  SystemProgram,
+  StakeProgram,
+  PublicKey,
+  Connection,
+  SYSVAR_CLOCK_PUBKEY,
+  STAKE_CONFIG_ID,
+  SYSVAR_RENT_PUBKEY,
+  SYSVAR_STAKE_HISTORY_PUBKEY,
+  TransactionInstruction,
+} from "@solana/web3.js";
+import { BN } from "@coral-xyz/anchor";
+import { SINGLE_POOL_PROGRAM_ID } from "../scripts/utils";
+
+/**
+ * Create a stake account for some user
+ * @param user
+ * @param amount - in SOL (lamports), in native decimals
+ * @returns
+ */
+export const createStakeAccount = (user: PublicKey, amount: number) => {
+  const stakeAccount = Keypair.generate();
+
+  // Create a stake account and fund it with the specified amount of SOL
+  const tx = new Transaction().add(
+    SystemProgram.createAccount({
+      fromPubkey: user,
+      newAccountPubkey: stakeAccount.publicKey,
+      lamports: amount,
+      space: StakeProgram.space, // Space required for a stake account
+      programId: StakeProgram.programId,
+    }),
+    StakeProgram.initialize({
+      stakePubkey: stakeAccount.publicKey,
+      authorized: {
+        staker: user,
+        withdrawer: user,
+      },
+    })
+  );
+
+  return { createTx: tx, stakeAccountKeypair: stakeAccount };
+};
+
+/**
+ * Delegate a stake account to a validator.
+ * @param user - wallet signs
+ * @param stakeAccount
+ * @param validatorVoteAccount
+ */
+export const delegateStake = (user: PublicKey, stakeAccount: PublicKey, validatorVoteAccount: PublicKey) => {
+  return StakeProgram.delegate({
+    stakePubkey: stakeAccount,
+    authorizedPubkey: user,
+    votePubkey: validatorVoteAccount,
+  });
+};
+
+/**
+ * Delegation information for a StakeAccount
+ *
+ * Copied from https://github.com/solana-developers/solana-rpc-get-stake-activation/blob/main/web3js-1.0/src/stake.ts
+ * */
+export type Delegation = {
+  voterPubkey: PublicKey;
+  stake: bigint;
+  activationEpoch: bigint;
+  deactivationEpoch: bigint;
+};
+
+/**
+ * Parsed content of an on-chain StakeAccount
+ *
+ * Copied from https://github.com/solana-developers/solana-rpc-get-stake-activation/blob/main/web3js-1.0/src/stake.ts
+ * */
+export type StakeAccount = {
+  discriminant: bigint;
+  meta: {
+    rentExemptReserve: bigint;
+    authorized: {
+      staker: PublicKey;
+      withdrawer: PublicKey;
+    };
+    lockup: {
+      unixTimestamp: bigint;
+      epoch: bigint;
+      custodian: PublicKey;
+    };
+  };
+  stake: {
+    delegation: {
+      voterPubkey: PublicKey;
+      stake: bigint;
+      activationEpoch: bigint;
+      deactivationEpoch: bigint;
+    };
+    creditsObserved: bigint;
+  };
+};
+
+/**
+ * Decode a StakeAccount from parsed account data.
+ *
+ * Copied from https://github.com/solana-developers/solana-rpc-get-stake-activation/blob/main/web3js-1.0/src/stake.ts
+ * */
+export const getStakeAccount = function (data: Buffer): StakeAccount {
+  let offset = 0;
+
+  // Discriminant (4 bytes)
+  const discriminant = data.readBigUInt64LE(offset);
+  offset += 4;
+
+  // Meta
+  const rentExemptReserve = data.readBigUInt64LE(offset);
+  offset += 8;
+
+  // Authorized staker and withdrawer (2 public keys)
+  const staker = new PublicKey(data.subarray(offset, offset + 32));
+  offset += 32;
+  const withdrawer = new PublicKey(data.subarray(offset, offset + 32));
+  offset += 32;
+
+  // Lockup: unixTimestamp, epoch, custodian
+  const unixTimestamp = data.readBigUInt64LE(offset);
+  offset += 8;
+  const epoch = data.readBigUInt64LE(offset);
+  offset += 8;
+  const custodian = new PublicKey(data.subarray(offset, offset + 32));
+  offset += 32;
+
+  // Stake: Delegation
+  const voterPubkey = new PublicKey(data.subarray(offset, offset + 32));
+  offset += 32;
+  const stake = data.readBigUInt64LE(offset);
+  offset += 8;
+  const activationEpoch = data.readBigUInt64LE(offset);
+  offset += 8;
+  const deactivationEpoch = data.readBigUInt64LE(offset);
+  offset += 8;
+
+  // Credits observed
+  const creditsObserved = data.readBigUInt64LE(offset);
+
+  // Return the parsed StakeAccount object
+  return {
+    discriminant,
+    meta: {
+      rentExemptReserve,
+      authorized: {
+        staker,
+        withdrawer,
+      },
+      lockup: {
+        unixTimestamp,
+        epoch,
+        custodian,
+      },
+    },
+    stake: {
+      delegation: {
+        voterPubkey,
+        stake,
+        activationEpoch,
+        deactivationEpoch,
+      },
+      creditsObserved,
+    },
+  };
+};
+
+/**
+ * Parsed content of an on-chain Stake History Entry
+ *
+ * Copied from https://github.com/solana-developers/solana-rpc-get-stake-activation/blob/main/web3js-1.0/src/stake.ts
+ * */
+export type StakeHistoryEntry = {
+  epoch: bigint;
+  effective: bigint;
+  activating: bigint;
+  deactivating: bigint;
+};
+
+/**
+ * Decode a StakeHistoryEntry from parsed account data.
+ *
+ * Copied from https://github.com/solana-developers/solana-rpc-get-stake-activation/blob/main/web3js-1.0/src/stake.ts
+ * and modified to directly read from buffer
+ * */
+export const getStakeHistory = function (data: Buffer): StakeHistoryEntry[] {
+  // Note: Is just `Vec<(Epoch, StakeHistoryEntry)>` internally
+  const stakeHistory: StakeHistoryEntry[] = [];
+  const entrySize = 32; // Each entry is 32 bytes (4 x 8-byte u64 fields)
+
+  for (
+    // skip the first 8 bytes for the Vec overhead
+    let offset = 8;
+    offset + entrySize < data.length;
+    offset += entrySize
+  ) {
+    const epoch = data.readBigUInt64LE(offset); // Note `epoch` is just a u64 renamed
+    const effective = data.readBigUInt64LE(offset + 8); // u64 effective
+    const activating = data.readBigUInt64LE(offset + 16); // u64 activating
+    const deactivating = data.readBigUInt64LE(offset + 24); // u64 deactivating
+
+    // if (epoch < 10 && offset < 300) {
+    //   console.log("epoch " + epoch);
+    //   console.log("e " + effective);
+    //   console.log("a " + activating);
+    //   console.log("d " + deactivating);
+    // }
+
+    stakeHistory.push({
+      epoch,
+      effective,
+      activating,
+      deactivating,
+    });
+  }
+
+  return stakeHistory;
+};
+
+/**
+ * Representation of on-chain stake
+ *
+ * Copied from https://github.com/solana-developers/solana-rpc-get-stake-activation/blob/main/web3js-1.0/src/delegation.ts
+ */
+export interface StakeActivatingAndDeactivating {
+  effective: bigint;
+  activating: bigint;
+  deactivating: bigint;
+}
+
+/**
+ * Representation of on-chain stake excluding deactivating stake
+ *
+ * Copied from https://github.com/solana-developers/solana-rpc-get-stake-activation/blob/main/web3js-1.0/src/delegation.ts
+ */
+export interface EffectiveAndActivating {
+  effective: bigint;
+  activating: bigint;
+}
+
+/**
+ * Get stake histories for a given epoch
+ *
+ * Copied from https://github.com/solana-developers/solana-rpc-get-stake-activation/blob/main/web3js-1.0/src/delegation.ts
+ */
+function getStakeHistoryEntry(epoch: bigint, stakeHistory: StakeHistoryEntry[]): StakeHistoryEntry | null {
+  for (const entry of stakeHistory) {
+    if (entry.epoch === epoch) {
+      return entry;
+    }
+  }
+  return null;
+}
+
+const WARMUP_COOLDOWN_RATE = 0.09;
+
+/**
+ * Get on-chain status of activating stake
+ *
+ * Copied from https://github.com/solana-developers/solana-rpc-get-stake-activation/blob/main/web3js-1.0/src/delegation.ts
+ */
+export function getStakeAndActivating(
+  delegation: Delegation,
+  targetEpoch: bigint,
+  stakeHistory: StakeHistoryEntry[]
+): EffectiveAndActivating {
+  if (delegation.activationEpoch === delegation.deactivationEpoch) {
+    // activated but instantly deactivated; no stake at all regardless of target_epoch
+    return {
+      effective: BigInt(0),
+      activating: BigInt(0),
+    };
+  } else if (targetEpoch === delegation.activationEpoch) {
+    // all is activating
+    return {
+      effective: BigInt(0),
+      activating: delegation.stake,
+    };
+  } else if (targetEpoch < delegation.activationEpoch) {
+    // not yet enabled
+    return {
+      effective: BigInt(0),
+      activating: BigInt(0),
+    };
+  }
+
+  let currentEpoch = delegation.activationEpoch;
+  let entry = getStakeHistoryEntry(currentEpoch, stakeHistory);
+  if (entry !== null) {
+    // target_epoch > self.activation_epoch
+
+    // loop from my activation epoch until the target epoch summing up my entitlement
+    // current effective stake is updated using its previous epoch's cluster stake
+    let currentEffectiveStake = BigInt(0);
+    while (entry !== null) {
+      currentEpoch++;
+      const remaining = delegation.stake - currentEffectiveStake;
+      const weight = Number(remaining) / Number(entry.activating);
+      const newlyEffectiveClusterStake = Number(entry.effective) * WARMUP_COOLDOWN_RATE;
+      const newlyEffectiveStake = BigInt(Math.max(1, Math.round(weight * newlyEffectiveClusterStake)));
+
+      currentEffectiveStake += newlyEffectiveStake;
+      if (currentEffectiveStake >= delegation.stake) {
+        currentEffectiveStake = delegation.stake;
+        break;
+      }
+
+      if (currentEpoch >= targetEpoch || currentEpoch >= delegation.deactivationEpoch) {
+        break;
+      }
+      entry = getStakeHistoryEntry(currentEpoch, stakeHistory);
+    }
+    return {
+      effective: currentEffectiveStake,
+      activating: delegation.stake - currentEffectiveStake,
+    };
+  } else {
+    // no history or I've dropped out of history, so assume fully effective
+    return {
+      effective: delegation.stake,
+      activating: BigInt(0),
+    };
+  }
+}
+
+/**
+ * Get on-chain status of activating and deactivating stake
+ *
+ * Copied from https://github.com/solana-developers/solana-rpc-get-stake-activation/blob/main/web3js-1.0/src/delegation.ts
+ */
+export function getStakeActivatingAndDeactivating(
+  delegation: Delegation,
+  targetEpoch: bigint,
+  stakeHistory: StakeHistoryEntry[]
+): StakeActivatingAndDeactivating {
+  const { effective, activating } = getStakeAndActivating(delegation, targetEpoch, stakeHistory);
+
+  // then de-activate some portion if necessary
+  if (targetEpoch < delegation.deactivationEpoch) {
+    return {
+      effective,
+      activating,
+      deactivating: BigInt(0),
+    };
+  } else if (targetEpoch == delegation.deactivationEpoch) {
+    // can only deactivate what's activated
+    return {
+      effective,
+      activating: BigInt(0),
+      deactivating: effective,
+    };
+  }
+  let currentEpoch = delegation.deactivationEpoch;
+  let entry = getStakeHistoryEntry(currentEpoch, stakeHistory);
+  if (entry !== null) {
+    // target_epoch > self.activation_epoch
+    // loop from my deactivation epoch until the target epoch
+    // current effective stake is updated using its previous epoch's cluster stake
+    let currentEffectiveStake = effective;
+    while (entry !== null) {
+      currentEpoch++;
+      // if there is no deactivating stake at prev epoch, we should have been
+      // fully undelegated at this moment
+      if (entry.deactivating === BigInt(0)) {
+        break;
+      }
+
+      // I'm trying to get to zero, how much of the deactivation in stake
+      //   this account is entitled to take
+      const weight = Number(currentEffectiveStake) / Number(entry.deactivating);
+
+      // portion of newly not-effective cluster stake I'm entitled to at current epoch
+      const newlyNotEffectiveClusterStake = Number(entry.effective) * WARMUP_COOLDOWN_RATE;
+      const newlyNotEffectiveStake = BigInt(Math.max(1, Math.round(weight * newlyNotEffectiveClusterStake)));
+
+      currentEffectiveStake -= newlyNotEffectiveStake;
+      if (currentEffectiveStake <= 0) {
+        currentEffectiveStake = BigInt(0);
+        break;
+      }
+
+      if (currentEpoch >= targetEpoch) {
+        break;
+      }
+      entry = getStakeHistoryEntry(currentEpoch, stakeHistory);
+    }
+
+    // deactivating stake should equal to all of currently remaining effective stake
+    return {
+      effective: currentEffectiveStake,
+      deactivating: currentEffectiveStake,
+      activating: BigInt(0),
+    };
+  } else {
+    return {
+      effective: BigInt(0),
+      activating: BigInt(0),
+      deactivating: BigInt(0),
+    };
+  }
+}
+
+/**
+ * Representation of on-chain stake
+ *
+ * Copied from https://github.com/solana-developers/solana-rpc-get-stake-activation/blob/main/web3js-1.0/src/rpc.ts
+ */
+export interface StakeActivation {
+  status: string;
+  active: bigint;
+  inactive: bigint;
+}
+
+/**
+ * Get on-chain stake status of a stake account (activating, inactive, etc)
+ *
+ * Copied from https://github.com/solana-developers/solana-rpc-get-stake-activation/blob/main/web3js-1.0/src/rpc.ts
+ */
+export async function getStakeActivation(
+  connection: Connection,
+  stakeAddress: PublicKey,
+  epoch: number | undefined = undefined // Added to bypass connection.getEpochInfo() when using a bankrun provider.
+): Promise<StakeActivation> {
+  const SYSVAR_STAKE_HISTORY_ADDRESS = new PublicKey("SysvarStakeHistory1111111111111111111111111");
+  const epochInfoPromise = epoch !== undefined ? Promise.resolve({ epoch }) : connection.getEpochInfo();
+  const [epochInfo, { stakeAccount, stakeAccountLamports }, stakeHistory] = await Promise.all([
+    epochInfoPromise,
+    (async () => {
+      const stakeAccountInfo = await connection.getAccountInfo(stakeAddress);
+      if (stakeAccountInfo === null) {
+        throw new Error("Account not found");
+      }
+      const stakeAccount = getStakeAccount(stakeAccountInfo.data);
+      const stakeAccountLamports = stakeAccountInfo.lamports;
+      return { stakeAccount, stakeAccountLamports };
+    })(),
+    (async () => {
+      const stakeHistoryInfo = await connection.getAccountInfo(SYSVAR_STAKE_HISTORY_ADDRESS);
+      if (stakeHistoryInfo === null) {
+        throw new Error("StakeHistory not found");
+      }
+      return getStakeHistory(stakeHistoryInfo.data);
+    })(),
+  ]);
+
+  const targetEpoch = epoch ? epoch : epochInfo.epoch;
+  const { effective, activating, deactivating } = getStakeActivatingAndDeactivating(
+    stakeAccount.stake.delegation,
+    BigInt(targetEpoch),
+    stakeHistory
+  );
+
+  let status;
+  if (deactivating > 0) {
+    status = "deactivating";
+  } else if (activating > 0) {
+    status = "activating";
+  } else if (effective > 0) {
+    status = "active";
+  } else {
+    status = "inactive";
+  }
+  const inactive = BigInt(stakeAccountLamports) - effective - stakeAccount.meta.rentExemptReserve;
+
+  return {
+    status,
+    active: effective,
+    inactive,
+  };
+}
+
+export const getEpochAndSlot = async (connection: Connection) => {
+  let clock = await connection.getAccountInfo(SYSVAR_CLOCK_PUBKEY);
+
+  // Slot is bytes 0-8
+  let slot = new BN(clock.data.subarray(0, 8), 10, "le").toNumber();
+
+  // Epoch is bytes 16-24
+  let epoch = new BN(clock.data.subarray(16, 24), 10, "le").toNumber();
+
+  return { epoch, slot };
+};
+
+/**
+ * SVSP stake pool that stores MEV rewards teporarily before they are merged into the main pool
+ * @param stakePool 
+ * @returns 
+ */
+export const deriveOnRampPool = (stakePool: PublicKey) => {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from("onramp"), stakePool.toBuffer()],
+    SINGLE_POOL_PROGRAM_ID
+  );
+};
+
+/**
+ * Copy of SVSP `findPoolStakeAddress`
+ * @param stakePool 
+ * @returns 
+ */
+export const deriveStakePool = (stakePool: PublicKey) => {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from("stake"), stakePool.toBuffer()],
+    SINGLE_POOL_PROGRAM_ID
+  );
+};
+
+/**
+ * Copy of SVSP `findPoolStakeAuthorityAddress`
+ * @param stakePool 
+ * @returns 
+ */
+export const deriveStakeAuthority = (stakePool: PublicKey) => {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from("stake_authority"), stakePool.toBuffer()],
+    SINGLE_POOL_PROGRAM_ID
+  );
+};
+
+/**
+ * Copy of SVSP `findPoolAddress`
+ * @param stakePool 
+ * @returns 
+ */
+export const deriveSVSPpool = (voteAccount: PublicKey) => {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from("pool"), voteAccount.toBuffer()],
+    SINGLE_POOL_PROGRAM_ID
+  );
+};
+
+/**
+ * Spl Single Pool's CreateOnRamp instruction.
+ *
+ * Accounts (in order):
+ *
+ * * 0. `[]` Pool account
+ * * 1. `[w]` Pool onramp account
+ * * 2. `[]` Pool stake authority
+ * * 3. `[]` Rent sysvar
+ * * 4. `[]` System program
+ * * 5. `[]` Stake program
+ *
+ * @param voteAccount - Validator's vote account
+ *
+ * @returns A TransactionInstruction
+ */
+export function createPoolOnramp(
+  voteAccount: PublicKey
+): TransactionInstruction {
+  const [poolAccount] = deriveSVSPpool(voteAccount);
+  const [onRampAccount] = deriveOnRampPool(poolAccount);
+  const [poolStakeAuthority] = deriveStakeAuthority(poolAccount);
+
+  const keys = [
+    { pubkey: poolAccount, isSigner: false, isWritable: false },
+    { pubkey: onRampAccount, isSigner: false, isWritable: true },
+    { pubkey: poolStakeAuthority, isSigner: false, isWritable: false },
+    { pubkey: SYSVAR_RENT_PUBKEY, isSigner: false, isWritable: false },
+    { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    { pubkey: StakeProgram.programId, isSigner: false, isWritable: false },
+  ];
+
+  // TODO don't hard code the instruction index? (or why not, it's not gna change is it?)
+  const data = Buffer.from(Uint8Array.of(6));
+
+  return new TransactionInstruction({
+    keys,
+    programId: SINGLE_POOL_PROGRAM_ID,
+    data,
+  });
+}
+
+/**
+ * Spl Single Pool's CreateOnRamp instruction.
+ *
+ * Accounts (in order):
+ *
+ * * 0. `[]` Validator vote account
+ * * 1. `[]` Pool account
+ * * 2. `[w]` Pool stake account
+ * * 3. `[w]` Pool onramp account
+ * * 4. `[]` Pool stake authority
+ * * 5. `[]` Clock sysvar
+ * * 6. `[]` Stake history sysvar
+ * * 7. `[]` Stake config sysvar
+ * * 8. `[]` Stake program
+ *
+ * @param voteAccount - Validator's vote account
+ *
+ * @returns A TransactionInstruction
+ */
+export function replenishPool(voteAccount: PublicKey): TransactionInstruction {
+  const [poolAccount] = deriveSVSPpool(voteAccount);
+  const [stakePool] = deriveStakePool(poolAccount);
+  const [onRampPool] = deriveOnRampPool(poolAccount);
+  const [authority] = deriveStakeAuthority(poolAccount);
+
+  const keys = [
+    { pubkey: voteAccount, isSigner: false, isWritable: false },
+    { pubkey: poolAccount, isSigner: false, isWritable: false },
+    { pubkey: stakePool, isSigner: false, isWritable: true },
+    { pubkey: onRampPool, isSigner: false, isWritable: true },
+    { pubkey: authority, isSigner: false, isWritable: false },
+    { pubkey: SYSVAR_CLOCK_PUBKEY, isSigner: false, isWritable: false },
+    { pubkey: SYSVAR_STAKE_HISTORY_PUBKEY, isSigner: false, isWritable: false },
+    { pubkey: STAKE_CONFIG_ID, isSigner: false, isWritable: false },
+    { pubkey: StakeProgram.programId, isSigner: false, isWritable: false },
+  ];
+
+  // TODO don't hard code the instruction index? (or why not, it's not gna change is it?)
+  const data = Buffer.from(Uint8Array.of(1));
+
+  return new TransactionInstruction({
+    keys,
+    programId: SINGLE_POOL_PROGRAM_ID,
+    data,
+  });
+}

--- a/packages/tools/svsp/stake-utils.ts
+++ b/packages/tools/svsp/stake-utils.ts
@@ -76,7 +76,7 @@ export type Delegation = {
  * Copied from https://github.com/solana-developers/solana-rpc-get-stake-activation/blob/main/web3js-1.0/src/stake.ts
  * */
 export type StakeAccount = {
-  discriminant: bigint;
+  discriminant: number;
   meta: {
     rentExemptReserve: bigint;
     authorized: {
@@ -100,6 +100,52 @@ export type StakeAccount = {
   };
 };
 
+// Here's how you might use Solana's kit instead, if you are foolish enough to attempt it.
+
+// // @ts-ignore
+// const authorizedCodec = getStructCodec([
+//   ['staker', fixCodecSize(getBytesCodec(), 32)],
+//   ['withdrawer', fixCodecSize(getBytesCodec(), 32)],
+// ]);
+// // @ts-ignore
+// const lockupCodec = getStructCodec([
+//   ['unixTimestamp', getU64Codec()],
+//   ['epoch', getU64Codec()],
+//   ['custodian', fixCodecSize(getBytesCodec(), 32)],
+// ]);
+// // @ts-ignore
+// const metaCodec = getStructCodec([
+//   ['rentExemptReserve', getU64Codec()],
+//   ['authorized', authorizedCodec],
+//   ['lockup', lockupCodec],
+// ]);
+// // @ts-ignore
+// const delegationCodec = getStructCodec([
+//   ['voterPubkey', fixCodecSize(getBytesCodec(), 32)],
+//   ['stake', getU64Codec()],
+//   ['activationEpoch', getU64Codec()],
+//   ['deactivationEpoch', getU64Codec()],
+//   ['unused', getU64Codec()],
+// ]);
+// // @ts-ignore
+// const stakeCodec = getStructCodec([
+//   ['delegation', delegationCodec],
+//   ['creditsObserved', getU64Codec()],
+// ]);
+// // @ts-ignore
+// export const stakeAccountCodec = getStructCodec([
+//   ['discriminant', getU32Codec()],
+//   ['meta', metaCodec],
+//   ['stake', stakeCodec],
+// ]);
+
+// export const getStakeAccountReal = async (address: Address) => {
+//   const rpc = createSolanaRpc(testnet('http://127.0.0.1:8899'));
+//   const stakeAccountEncoded = await fetchEncodedAccount(rpc, address);
+//   const stakeAccountReal = decodeAccount(stakeAccountEncoded, stakeAccountCodec);
+//   return stakeAccountReal;
+// }
+
 /**
  * Decode a StakeAccount from parsed account data.
  *
@@ -109,7 +155,7 @@ export const getStakeAccount = function (data: Buffer): StakeAccount {
   let offset = 0;
 
   // Discriminant (4 bytes)
-  const discriminant = data.readBigUInt64LE(offset);
+  const discriminant = data.readUInt32LE(offset);
   offset += 4;
 
   // Meta

--- a/packages/tools/svsp/svsp_localnet_e2e.ts
+++ b/packages/tools/svsp/svsp_localnet_e2e.ts
@@ -1,0 +1,345 @@
+// Note: state a validator in a local terminal first. Make sure --ticks-per-slot 8 --slots-per-epoch
+// 32 \ so epochs elapse very quickly
+import {
+  Connection,
+  Keypair,
+  LAMPORTS_PER_SOL,
+  PublicKey,
+  sendAndConfirmTransaction,
+  StakeAuthorizationLayout,
+  StakeProgram,
+  SystemProgram,
+  Transaction,
+  TransactionInstruction,
+  VoteInit,
+  VoteProgram,
+} from "@solana/web3.js";
+import { AnchorProvider } from "@coral-xyz/anchor";
+import { loadKeypairFromFile } from "../scripts/utils";
+import {
+  createPoolOnramp,
+  createStakeAccount,
+  delegateStake,
+  deriveOnRampPool,
+  deriveStakeAuthority,
+  deriveStakeMint,
+  deriveStakePool,
+  deriveSVSPpool,
+  getEpochAndSlot,
+  getStakeAccount,
+  replenishPool,
+  waitUntil,
+} from "./stake-utils";
+import { SinglePoolInstruction, SinglePoolProgram } from "@solana/spl-single-pool-classic";
+import { getAssociatedTokenAddressSync } from "@solana/spl-token";
+import { createAssociatedTokenAccountInstruction } from "@solana/spl-token";
+
+const toStake = 2 * LAMPORTS_PER_SOL;
+const toMockMev = 2 * LAMPORTS_PER_SOL;
+
+async function main() {
+  const wallet = loadKeypairFromFile(process.env.HOME + "/keys/staging-deploy.json");
+  console.log("payer: " + wallet.publicKey);
+
+  const voteAccount = await initValidator(wallet);
+  await initSinglePool(wallet, voteAccount);
+  const stakeAcc = await initUserStakeAcc(wallet, toStake);
+  await delegateUserStake(wallet, voteAccount, stakeAcc);
+
+  console.log("Waiting a while...");
+  await waitUntil(Date.now() / 1000 + 3);
+
+  await depositIntoSinglePool(wallet, voteAccount, stakeAcc);
+  await sendMockMev(wallet, voteAccount);
+  await initSvspOnRamp(wallet, voteAccount);
+  await svspReplenishPool(wallet, voteAccount);
+
+  console.log("Waiting a while...");
+  await waitUntil(Date.now() / 1000 + 3);
+
+  await svspReplenishPool(wallet, voteAccount);
+
+  console.log("Waiting a while...");
+  await waitUntil(Date.now() / 1000 + 3);
+
+  await svspReplenishPool(wallet, voteAccount);
+}
+
+export async function svspReplenishPool(wallet: Keypair, voteAccount: PublicKey) {
+  const connection = new Connection("http://127.0.0.1:8899", "finalized");
+  const [svspPool] = deriveSVSPpool(voteAccount);
+  const [poolStake] = deriveStakePool(svspPool);
+  const [onRamp] = deriveOnRampPool(svspPool);
+
+  const replenishIx = replenishPool(voteAccount);
+  let tx = new Transaction().add(replenishIx);
+
+  try {
+    const signature = await sendAndConfirmTransaction(connection, tx, [wallet]);
+    // console.log("Transaction signature:", signature);
+  } catch (error) {
+    console.error("Transaction failed:", error);
+  }
+
+  console.log();
+  console.log("-----REPLENISHED SVSP----");
+  const { epoch, slot } = await getEpochAndSlot(connection);
+  console.log("It's epoch: " + epoch + " slot " + slot);
+  console.log();
+
+  const onrampAcc = await connection.getAccountInfo(onRamp);
+  const onrampDecoded = getStakeAccount(onrampAcc.data);
+  console.log("--------On Ramp Account----");
+  console.log("stake: " + onrampDecoded.stake.delegation.stake.toString());
+  console.log("lamps: " + onrampAcc.lamports);
+  console.log();
+
+  const stakeAcc = await connection.getAccountInfo(poolStake);
+  const stakeDecoded = getStakeAccount(stakeAcc.data);
+  console.log("--------Main stake Account----");
+  console.log("stake: " + stakeDecoded.stake.delegation.stake.toString());
+  console.log("lamps: " + stakeAcc.lamports);
+  console.log("");
+}
+
+export async function initSvspOnRamp(wallet: Keypair, voteAccount: PublicKey) {
+  const connection = new Connection("http://127.0.0.1:8899", "finalized");
+  const [svspPool] = deriveSVSPpool(voteAccount);
+  const [poolStake] = deriveStakePool(svspPool);
+  // const [poolAuthority] = deriveStakeAuthority(svspPool);
+  const [onRamp] = deriveOnRampPool(svspPool);
+
+  const rent = await connection.getMinimumBalanceForRentExemption(StakeProgram.space);
+  const rentIx = SystemProgram.transfer({
+    fromPubkey: wallet.publicKey,
+    toPubkey: onRamp,
+    lamports: rent,
+  });
+  const createIx = createPoolOnramp(voteAccount);
+  let tx = new Transaction().add(rentIx, createIx);
+
+  try {
+    const signature = await sendAndConfirmTransaction(connection, tx, [wallet]);
+    // console.log("Transaction signature:", signature);
+  } catch (error) {
+    console.error("Transaction failed:", error);
+  }
+
+  console.log("-----INIT ON RAMP----");
+  console.log("On ramp account: " + onRamp);
+
+  const onrampAcc = await connection.getAccountInfo(onRamp);
+  const onrampDecoded = getStakeAccount(onrampAcc.data);
+  console.log("--------On Ramp Account----");
+  console.log("stake: " + onrampDecoded.stake.delegation.stake.toString());
+  console.log("lamps: " + onrampAcc.lamports);
+  console.log("");
+
+  const stakeAcc = await connection.getAccountInfo(poolStake);
+  const stakeDecoded = getStakeAccount(stakeAcc.data);
+  console.log("--------Main stake Account----");
+  console.log("stake: " + stakeDecoded.stake.delegation.stake.toString());
+  console.log("lamps: " + stakeAcc.lamports);
+  console.log("");
+}
+
+export async function sendMockMev(wallet: Keypair, voteAccount: PublicKey) {
+  const connection = new Connection("http://127.0.0.1:8899", "finalized");
+  const [poolKey] = deriveSVSPpool(voteAccount);
+  const [poolStake] = deriveStakePool(poolKey);
+  const [onRamp] = deriveOnRampPool(poolKey);
+
+  let tx = new Transaction();
+  tx.add(
+    SystemProgram.transfer({
+      fromPubkey: wallet.publicKey,
+      toPubkey: poolStake,
+      lamports: toMockMev,
+    })
+  );
+
+  try {
+    const signature = await sendAndConfirmTransaction(connection, tx, [wallet]);
+    // console.log("Transaction signature:", signature);
+  } catch (error) {
+    console.error("Transaction failed:", error);
+  }
+
+  console.log("sent fake mev: " + toMockMev + " to stake account: " + poolStake + " which belongs to pool " + poolKey);
+
+  const onrampAcc = await connection.getAccountInfo(onRamp);
+  if (onrampAcc) {
+    const onrampDecoded = getStakeAccount(onrampAcc.data);
+    console.log("--------On Ramp Account----");
+    console.log("stake: " + onrampDecoded.stake.delegation.stake.toString());
+    console.log("lamps: " + onrampAcc.lamports);
+    console.log("");
+  } else {
+    console.log("On Ramp does not yet exist!");
+    console.log("");
+  }
+
+  const stakeAcc = await connection.getAccountInfo(poolStake);
+  const stakeDecoded = getStakeAccount(stakeAcc.data);
+  console.log("--------Main stake Account----");
+  console.log("stake: " + stakeDecoded.stake.delegation.stake.toString());
+  console.log("lamps: " + stakeAcc.lamports);
+  console.log("");
+}
+
+export async function depositIntoSinglePool(wallet: Keypair, voteAccount: PublicKey, userStakeAccount: PublicKey) {
+  const connection = new Connection("http://127.0.0.1:8899", "finalized");
+  const [poolKey] = deriveSVSPpool(voteAccount);
+  const [poolStake] = deriveStakePool(poolKey);
+  const [lstMint] = deriveStakeMint(poolKey);
+  const [auth] = deriveStakeAuthority(poolKey);
+  const lstAta = getAssociatedTokenAddressSync(lstMint, wallet.publicKey);
+  console.log("poolKey: " + poolKey);
+  console.log("poolStake: " + poolStake);
+  console.log("lstMint: " + lstMint);
+  console.log("auth: " + auth);
+
+  const ixes: TransactionInstruction[] = [];
+  ixes.push(createAssociatedTokenAccountInstruction(wallet.publicKey, lstAta, wallet.publicKey, lstMint));
+
+  const authorizeStakerIxes = StakeProgram.authorize({
+    stakePubkey: userStakeAccount,
+    authorizedPubkey: wallet.publicKey,
+    newAuthorizedPubkey: auth,
+    stakeAuthorizationType: StakeAuthorizationLayout.Staker,
+  }).instructions;
+
+  ixes.push(...authorizeStakerIxes);
+
+  const authorizeWithdrawIxes = StakeProgram.authorize({
+    stakePubkey: userStakeAccount,
+    authorizedPubkey: wallet.publicKey,
+    newAuthorizedPubkey: auth,
+    stakeAuthorizationType: StakeAuthorizationLayout.Withdrawer,
+  }).instructions;
+
+  ixes.push(...authorizeWithdrawIxes);
+
+  const depositIx = await SinglePoolInstruction.depositStake(poolKey, userStakeAccount, lstAta, wallet.publicKey);
+
+  ixes.push(depositIx);
+
+  const transaction = new Transaction();
+  transaction.add(...ixes);
+
+  try {
+    const signature = await sendAndConfirmTransaction(connection, transaction, [wallet]);
+    // console.log("Transaction signature:", signature);
+  } catch (error) {
+    console.error("Transaction failed:", error);
+  }
+
+  console.log("svsp deposit of " + userStakeAccount + " done, vouchers to go ATA: " + lstAta);
+  console.log("");
+}
+
+export async function delegateUserStake(wallet: Keypair, voteAccount: PublicKey, stakeAccount: PublicKey) {
+  const connection = new Connection("http://127.0.0.1:8899", "confirmed");
+  let delegateTx = delegateStake(wallet.publicKey, stakeAccount, voteAccount);
+
+  try {
+    const signature = await sendAndConfirmTransaction(connection, delegateTx, [wallet]);
+    // console.log("Transaction signature:", signature);
+  } catch (error) {
+    console.error("Transaction failed:", error);
+  }
+
+  console.log("Delegated " + stakeAccount + " to " + voteAccount);
+  console.log("");
+}
+
+export async function initUserStakeAcc(wallet: Keypair, amt: number) {
+  const connection = new Connection("http://127.0.0.1:8899", "confirmed");
+  let { createTx, stakeAccountKeypair } = createStakeAccount(wallet.publicKey, amt);
+
+  try {
+    const signature = await sendAndConfirmTransaction(connection, createTx, [wallet, stakeAccountKeypair]);
+    // console.log("Transaction signature:", signature);
+  } catch (error) {
+    console.error("Transaction failed:", error);
+  }
+
+  console.log("Stake account: " + stakeAccountKeypair.publicKey);
+  console.log("");
+
+  return stakeAccountKeypair.publicKey;
+}
+
+export async function initSinglePool(wallet: Keypair, voteAccount: PublicKey) {
+  const connection = new Connection("http://127.0.0.1:8899", "confirmed");
+  const [poolKey] = deriveSVSPpool(voteAccount);
+  const [poolStake] = deriveStakePool(poolKey);
+
+  let tx = new Transaction();
+  tx.add(
+    SystemProgram.transfer({
+      fromPubkey: wallet.publicKey,
+      toPubkey: poolStake,
+      lamports: LAMPORTS_PER_SOL * 1.1,
+    })
+  );
+
+  tx.add(...(await SinglePoolProgram.initialize(connection, voteAccount, wallet.publicKey, true)).instructions);
+
+  try {
+    const signature = await sendAndConfirmTransaction(connection, tx, [wallet]);
+    // console.log("Transaction signature:", signature);
+  } catch (error) {
+    console.error("Transaction failed:", error);
+  }
+
+  console.log("svsp pool:  " + poolKey);
+  console.log("stake acc:  " + poolStake);
+  console.log("");
+}
+
+export async function initValidator(wallet: Keypair) {
+  const connection = new Connection("http://127.0.0.1:8899", "confirmed");
+  let authorizedVoter = wallet.publicKey;
+  let authorizedWithdrawer = wallet.publicKey;
+  console.log("payer, authorized voted and withdrawer: " + wallet.publicKey);
+
+  const voteAccountKeypair = Keypair.generate();
+  const node = Keypair.generate();
+
+  // @ts-ignore
+  const provider = new AnchorProvider(connection, wallet, {
+    preflightCommitment: "confirmed",
+  });
+  const tx = new Transaction().add(
+    // Create the vote account
+    SystemProgram.createAccount({
+      fromPubkey: authorizedVoter,
+      newAccountPubkey: voteAccountKeypair.publicKey,
+      lamports: await provider.connection.getMinimumBalanceForRentExemption(VoteProgram.space),
+      space: VoteProgram.space,
+      programId: VoteProgram.programId,
+    }),
+    // Initialize the vote account
+    VoteProgram.initializeAccount({
+      votePubkey: voteAccountKeypair.publicKey,
+      nodePubkey: node.publicKey,
+      voteInit: new VoteInit(node.publicKey, authorizedVoter, authorizedWithdrawer, 0),
+    })
+  );
+
+  try {
+    const signature = await sendAndConfirmTransaction(connection, tx, [wallet, voteAccountKeypair, node]);
+    // console.log("Transaction signature:", signature);
+  } catch (error) {
+    console.error("Transaction failed:", error);
+  }
+
+  console.log("vote account: " + voteAccountKeypair.publicKey);
+
+  return voteAccountKeypair.publicKey;
+}
+
+main().catch((err) => {
+  console.error(err);
+});

--- a/packages/tools/svsp/svsp_localnet_e2e.ts
+++ b/packages/tools/svsp/svsp_localnet_e2e.ts
@@ -91,13 +91,19 @@ export async function svspReplenishPool(wallet: Keypair, voteAccount: PublicKey)
   const onrampDecoded = getStakeAccount(onrampAcc.data);
   console.log("--------On Ramp Account----");
   console.log("stake: " + onrampDecoded.stake.delegation.stake.toString());
+  /**
+   * Note: The "stake" field is INVALID if the discriminator is not 2 (Stake in the StakeStatev2 enum)
+   */
+  const discrimOnRamp = onrampDecoded.discriminant;
+  console.log("discrim: " + discrimOnRamp + " stake is valid: " + (discrimOnRamp == 2));
   console.log("lamps: " + onrampAcc.lamports);
   console.log();
 
   const stakeAcc = await connection.getAccountInfo(poolStake);
   const stakeDecoded = getStakeAccount(stakeAcc.data);
-  console.log("--------Main stake Account----");
   console.log("stake: " + stakeDecoded.stake.delegation.stake.toString());
+  const discrimStake = stakeDecoded.discriminant;
+  console.log("discrim: " + discrimStake + " stake is valid: " + (discrimStake == 2));
   console.log("lamps: " + stakeAcc.lamports);
   console.log("");
 }

--- a/packages/tools/svsp/svsp_replenish_pool.ts
+++ b/packages/tools/svsp/svsp_replenish_pool.ts
@@ -1,0 +1,69 @@
+// This create the on-ramp for svsp accounts to be able to redeem MEV rewards
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  sendAndConfirmTransaction,
+  StakeProgram,
+  SystemProgram,
+  Transaction,
+} from "@solana/web3.js";
+import { loadKeypairFromFile } from "../scripts/utils";
+import {
+  createPoolOnramp,
+  deriveOnRampPool,
+  deriveStakePool,
+  deriveSVSPpool,
+  getEpochAndSlot,
+  getStakeAccount,
+  replenishPool,
+} from "./stake-utils";
+
+type Config = {
+  VOTE_ACCOUNT: PublicKey;
+};
+const config: Config = {
+  VOTE_ACCOUNT: new PublicKey("9us7TgKiJSz5fqT5Eb8ghV6b2C87zxv2VbXUWbbK5GRJ"),
+};
+
+async function main() {
+  const connection = new Connection("http://127.0.0.1:8899", "confirmed");
+  const wallet = loadKeypairFromFile(process.env.HOME + "/keys/staging-deploy.json");
+  console.log("payer: " + wallet.publicKey);
+
+  const [svspPool] = deriveSVSPpool(config.VOTE_ACCOUNT);
+  const [poolStake] = deriveStakePool(svspPool);
+  // const [poolAuthority] = deriveStakeAuthority(svspPool);
+  const [onRamp] = deriveOnRampPool(svspPool);
+
+  const replenishIx = replenishPool(config.VOTE_ACCOUNT);
+  let tx = new Transaction().add(replenishIx);
+
+  try {
+    const signature = await sendAndConfirmTransaction(connection, tx, [wallet]);
+    console.log("Transaction signature:", signature);
+  } catch (error) {
+    console.error("Transaction failed:", error);
+  }
+
+  const { epoch, slot } = await getEpochAndSlot(connection);
+  console.log("It's epoch: " + epoch + " slot " + slot);
+  console.log();
+
+  const onrampAcc = await connection.getAccountInfo(onRamp);
+  const onrampDecoded = getStakeAccount(onrampAcc.data);
+  console.log("--------On Ramp Account----");
+  console.log("stake: " + onrampDecoded.stake.delegation.stake.toString());
+  console.log("lamps: " + onrampAcc.lamports);
+  console.log();
+
+  const stakeAcc = await connection.getAccountInfo(poolStake);
+  const stakeDecoded = getStakeAccount(stakeAcc.data);
+  console.log("--------Main stake Account----");
+  console.log("stake: " + stakeDecoded.stake.delegation.stake.toString());
+  console.log("lamps: " + stakeAcc.lamports);
+}
+
+main().catch((err) => {
+  console.error(err);
+});

--- a/packages/tools/svsp/svsp_replenish_pool.ts
+++ b/packages/tools/svsp/svsp_replenish_pool.ts
@@ -46,6 +46,7 @@ async function main() {
     console.error("Transaction failed:", error);
   }
 
+  console.log();
   const { epoch, slot } = await getEpochAndSlot(connection);
   console.log("It's epoch: " + epoch + " slot " + slot);
   console.log();


### PR DESCRIPTION
*  Deploys the mock program to mainnet, adds some scripts to interact with the mock program
* The mock program can do nothing (fully supported!) or pretend to be a jup-like swap pool for testing flashloans and etc
* Fixes some issues with add_banks script following removal of oracles from this ix.
* Adds a script for dumping base58 from squads to examine the instruction info and simulate