### PR TITLE
Get Origination Fees in Bank Output

### DIFF
--- a/packages/tools/banks/get-bank.ts
+++ b/packages/tools/banks/get-bank.ts
@@ -77,6 +77,7 @@ async function main() {
   const insiranceFixedFee = wrappedI80F48toBigNumber(acc.config.interestRateConfig.insuranceFeeFixedApr);
   const protocolIrFee = wrappedI80F48toBigNumber(acc.config.interestRateConfig.protocolIrFee);
   const protocolFixedFee = wrappedI80F48toBigNumber(acc.config.interestRateConfig.protocolFixedFeeApr);
+  const protocolOriginationFee = wrappedI80F48toBigNumber(acc.config.interestRateConfig.protocolOriginationFee);
   const maxInterestRate = wrappedI80F48toBigNumber(acc.config.interestRateConfig.maxInterestRate);
   const plateauInterestRate = wrappedI80F48toBigNumber(acc.config.interestRateConfig.plateauInterestRate);
   const optimalUtilizationRate = wrappedI80F48toBigNumber(acc.config.interestRateConfig.optimalUtilizationRate);
@@ -110,6 +111,7 @@ async function main() {
     "Protocol IR Fee": protocolIrFee.toNumber(),
     "Protocol Fixed Fee": protocolFixedFee.toNumber(),
     "Max Interest Rate": maxInterestRate.toNumber(),
+    "Protocol Origination Fee": protocolOriginationFee.toNumber(),
     "Plateau Interest Rate": plateauInterestRate.toNumber(),
     "Optimal Utilization Rate": optimalUtilizationRate.toNumber(),
     "Asset Share Value": assetShareValue.toNumber(),


### PR DESCRIPTION
- Dump this to console.
- Got 0 for `pnpm banks:get --address w5P29p51KzMV4uxR6KnyLxXCt3thBNhgm2sQSyrAwMK --group 6b9vFQjfYav2tVzns2cD21xU7E4z9LDnHTv9wjCJsknf` so not sure if its working as expected.