### PR TITLE
feat: allow user to pass feePayer when creating margingiAccountIx

### DIFF
--- a/packages/marginfi-client-v2/src/clients/client.ts
+++ b/packages/marginfi-client-v2/src/clients/client.ts
@@ -685,7 +685,7 @@ class MarginfiClient {
    *
    * @returns transaction instruction
    */
-  async makeCreateMarginfiAccountIx(marginfiAccountPk: PublicKey): Promise<InstructionsWrapper> {
+  async makeCreateMarginfiAccountIx(marginfiAccountPk: PublicKey, feePayer: PublicKey): Promise<InstructionsWrapper> {
     const dbg = require("debug")("mfi:client");
 
     dbg("Generating marginfi account ix for %s", marginfiAccountPk);
@@ -694,7 +694,7 @@ class MarginfiClient {
       marginfiGroup: this.groupAddress,
       marginfiAccount: marginfiAccountPk,
       authority: this.provider.wallet.publicKey,
-      feePayer: this.provider.wallet.publicKey,
+      feePayer: feePayer ?? this.provider.wallet.publicKey,
     });
 
     const ixs = [initMarginfiAccountIx];


### PR DESCRIPTION
in some cases a protocol might want to sponser opening accounts for his users, so the fee payer at this case will not be the same as the authority of the account

This pull request updates the `makeCreateMarginfiAccountIx` method in the `MarginfiClient` class to allow specifying a custom `feePayer` when creating a marginfi account instruction. This provides more flexibility in transaction construction.

**Enhancement to account creation instruction:**

* The `makeCreateMarginfiAccountIx` method in `client.ts` now accepts an explicit `feePayer` parameter, enabling callers to specify a different fee payer instead of always using the provider wallet's public key. [[1]](diffhunk://#diff-4352b3e6d08d3225bf463bc962044d0ac79acd22e3f558772744fa281f73b7fbL688-R688) [[2]](diffhunk://#diff-4352b3e6d08d3225bf463bc962044d0ac79acd22e3f558772744fa281f73b7fbL697-R697)