### PR TITLE
feat: update marginfi IDL to 0.1.8 (supports on-chain program mrgn-0.1.8-rc3)

### DIFF
--- a/packages/marginfi-client-v2/src/idl/index.ts
+++ b/packages/marginfi-client-v2/src/idl/index.ts
@@ -1,5 +1,6 @@
 import { Marginfi as MarginfiIdlTypeV0_1_7 } from "./marginfi-types_0.1.7";
 import MARGINFI_IDL_V0_1_7_JSON from "./marginfi_0.1.7.json";
+import MARGINFI_IDL_V0_1_8_JSON from "./marginfi_0.1.8.json";
 
-export const MARGINFI_IDL = MARGINFI_IDL_V0_1_7_JSON as MarginfiIdlType;
+export const MARGINFI_IDL = MARGINFI_IDL_V0_1_8_JSON as unknown as MarginfiIdlType;
 export type MarginfiIdlType = MarginfiIdlTypeV0_1_7;

--- a/packages/marginfi-client-v2/src/idl/marginfi_0.1.8.json
+++ b/packages/marginfi-client-v2/src/idl/marginfi_0.1.8.json
@@ -1,0 +1,17802 @@
+{
+  "accounts": [
+    {
+      "discriminator": [
+        142,
+        49,
+        166,
+        242,
+        50,
+        66,
+        97,
+        188
+      ],
+      "name": "Bank"
+    },
+    {
+      "discriminator": [
+        49,
+        207,
+        31,
+        34,
+        67,
+        225,
+        169,
+        186
+      ],
+      "name": "BankMetadata"
+    },
+    {
+      "discriminator": [
+        6,
+        100,
+        107,
+        60,
+        164,
+        226,
+        56,
+        97
+      ],
+      "name": "ExecuteOrderRecord"
+    },
+    {
+      "discriminator": [
+        63,
+        224,
+        16,
+        85,
+        193,
+        36,
+        235,
+        220
+      ],
+      "name": "FeeState"
+    },
+    {
+      "discriminator": [
+        135,
+        199,
+        82,
+        16,
+        249,
+        131,
+        182,
+        241
+      ],
+      "name": "Lending"
+    },
+    {
+      "discriminator": [
+        95,
+        116,
+        23,
+        132,
+        89,
+        210,
+        245,
+        162
+      ],
+      "name": "LiquidationRecord"
+    },
+    {
+      "discriminator": [
+        67,
+        178,
+        130,
+        109,
+        126,
+        114,
+        28,
+        42
+      ],
+      "name": "MarginfiAccount"
+    },
+    {
+      "discriminator": [
+        182,
+        23,
+        173,
+        240,
+        151,
+        206,
+        182,
+        67
+      ],
+      "name": "MarginfiGroup"
+    },
+    {
+      "discriminator": [
+        168,
+        206,
+        141,
+        106,
+        88,
+        76,
+        172,
+        167
+      ],
+      "name": "MinimalObligation"
+    },
+    {
+      "discriminator": [
+        43,
+        242,
+        204,
+        202,
+        26,
+        247,
+        59,
+        127
+      ],
+      "name": "MinimalReserve"
+    },
+    {
+      "discriminator": [
+        100,
+        177,
+        8,
+        107,
+        168,
+        65,
+        65,
+        39
+      ],
+      "name": "MinimalSpotMarket"
+    },
+    {
+      "discriminator": [
+        159,
+        117,
+        95,
+        227,
+        239,
+        151,
+        58,
+        236
+      ],
+      "name": "MinimalUser"
+    },
+    {
+      "discriminator": [
+        134,
+        173,
+        223,
+        185,
+        77,
+        86,
+        28,
+        51
+      ],
+      "name": "Order"
+    },
+    {
+      "discriminator": [
+        1
+      ],
+      "name": "SolendMinimalReserve"
+    },
+    {
+      "discriminator": [
+        157,
+        140,
+        6,
+        77,
+        89,
+        173,
+        173,
+        125
+      ],
+      "name": "StakedSettings"
+    }
+  ],
+  "address": "",
+  "errors": [
+    {
+      "code": 6000,
+      "msg": "Internal Marginfi logic error",
+      "name": "InternalLogicError"
+    },
+    {
+      "code": 6001,
+      "msg": "Invalid bank index",
+      "name": "BankNotFound"
+    },
+    {
+      "code": 6002,
+      "msg": "Lending account balance not found",
+      "name": "LendingAccountBalanceNotFound"
+    },
+    {
+      "code": 6003,
+      "msg": "Bank deposit capacity exceeded",
+      "name": "BankAssetCapacityExceeded"
+    },
+    {
+      "code": 6004,
+      "msg": "Invalid transfer",
+      "name": "InvalidTransfer"
+    },
+    {
+      "code": 6005,
+      "msg": "Missing Oracle, Bank, LST mint, or Sol Pool",
+      "name": "MissingPythOrBankAccount"
+    },
+    {
+      "code": 6006,
+      "msg": "Missing Pyth account",
+      "name": "MissingPythAccount"
+    },
+    {
+      "code": 6007,
+      "msg": "Missing Bank account",
+      "name": "MissingBankAccount"
+    },
+    {
+      "code": 6008,
+      "msg": "Invalid Bank account",
+      "name": "InvalidBankAccount"
+    },
+    {
+      "code": 6009,
+      "msg": "RiskEngine rejected due to either bad health or stale oracles",
+      "name": "RiskEngineInitRejected"
+    },
+    {
+      "code": 6010,
+      "msg": "Lending account balance slots are full",
+      "name": "LendingAccountBalanceSlotsFull"
+    },
+    {
+      "code": 6011,
+      "msg": "Bank already exists",
+      "name": "BankAlreadyExists"
+    },
+    {
+      "code": 6012,
+      "msg": "Amount to liquidate must be positive",
+      "name": "ZeroLiquidationAmount"
+    },
+    {
+      "code": 6013,
+      "msg": "Account is not bankrupt",
+      "name": "AccountNotBankrupt"
+    },
+    {
+      "code": 6014,
+      "msg": "Account balance is not bad debt",
+      "name": "BalanceNotBadDebt"
+    },
+    {
+      "code": 6015,
+      "msg": "Invalid group config",
+      "name": "InvalidConfig"
+    },
+    {
+      "code": 6016,
+      "msg": "Bank paused",
+      "name": "BankPaused"
+    },
+    {
+      "code": 6017,
+      "msg": "Bank is ReduceOnly mode",
+      "name": "BankReduceOnly"
+    },
+    {
+      "code": 6018,
+      "msg": "Bank is missing",
+      "name": "BankAccountNotFound"
+    },
+    {
+      "code": 6019,
+      "msg": "Operation is deposit-only",
+      "name": "OperationDepositOnly"
+    },
+    {
+      "code": 6020,
+      "msg": "Operation is withdraw-only",
+      "name": "OperationWithdrawOnly"
+    },
+    {
+      "code": 6021,
+      "msg": "Operation is borrow-only",
+      "name": "OperationBorrowOnly"
+    },
+    {
+      "code": 6022,
+      "msg": "Operation is repay-only",
+      "name": "OperationRepayOnly"
+    },
+    {
+      "code": 6023,
+      "msg": "No asset found",
+      "name": "NoAssetFound"
+    },
+    {
+      "code": 6024,
+      "msg": "No liability found",
+      "name": "NoLiabilityFound"
+    },
+    {
+      "code": 6025,
+      "msg": "Invalid oracle setup",
+      "name": "InvalidOracleSetup"
+    },
+    {
+      "code": 6026,
+      "msg": "Invalid bank utilization ratio",
+      "name": "IllegalUtilizationRatio"
+    },
+    {
+      "code": 6027,
+      "msg": "Bank borrow cap exceeded",
+      "name": "BankLiabilityCapacityExceeded"
+    },
+    {
+      "code": 6028,
+      "msg": "Invalid Price",
+      "name": "InvalidPrice"
+    },
+    {
+      "code": 6029,
+      "msg": "Account can have only one liability when account is under isolated risk",
+      "name": "IsolatedAccountIllegalState"
+    },
+    {
+      "code": 6030,
+      "msg": "Emissions already setup",
+      "name": "EmissionsAlreadySetup"
+    },
+    {
+      "code": 6031,
+      "msg": "Oracle is not set",
+      "name": "OracleNotSetup"
+    },
+    {
+      "code": 6032,
+      "msg": "Invalid switchboard decimal conversion",
+      "name": "InvalidSwitchboardDecimalConversion"
+    },
+    {
+      "code": 6033,
+      "msg": "Cannot close balance because of outstanding emissions",
+      "name": "CannotCloseOutstandingEmissions"
+    },
+    {
+      "code": 6034,
+      "msg": "Update emissions error",
+      "name": "EmissionsUpdateError"
+    },
+    {
+      "code": 6035,
+      "msg": "Account disabled",
+      "name": "AccountDisabled"
+    },
+    {
+      "code": 6036,
+      "msg": "Account can't temporarily open 3 balances, please close a balance first",
+      "name": "AccountTempActiveBalanceLimitExceeded"
+    },
+    {
+      "code": 6037,
+      "msg": "Illegal action during flashloan",
+      "name": "AccountInFlashloan"
+    },
+    {
+      "code": 6038,
+      "msg": "Illegal flashloan",
+      "name": "IllegalFlashloan"
+    },
+    {
+      "code": 6039,
+      "msg": "Illegal flag",
+      "name": "IllegalFlag"
+    },
+    {
+      "code": 6040,
+      "msg": "Illegal balance state",
+      "name": "IllegalBalanceState"
+    },
+    {
+      "code": 6041,
+      "msg": "Illegal account authority transfer",
+      "name": "IllegalAccountAuthorityTransfer"
+    },
+    {
+      "code": 6042,
+      "msg": "Unauthorized",
+      "name": "Unauthorized"
+    },
+    {
+      "code": 6043,
+      "msg": "Invalid account authority",
+      "name": "IllegalAction"
+    },
+    {
+      "code": 6044,
+      "msg": "Token22 Banks require mint account as first remaining account",
+      "name": "T22MintRequired"
+    },
+    {
+      "code": 6045,
+      "msg": "Invalid ATA for global fee account",
+      "name": "InvalidFeeAta"
+    },
+    {
+      "code": 6046,
+      "msg": "Use add pool permissionless instead",
+      "name": "AddedStakedPoolManually"
+    },
+    {
+      "code": 6047,
+      "msg": "Staked SOL accounts can only deposit staked assets and borrow SOL",
+      "name": "AssetTagMismatch"
+    },
+    {
+      "code": 6048,
+      "msg": "Stake pool validation failed: check the stake pool, mint, or sol pool",
+      "name": "StakePoolValidationFailed"
+    },
+    {
+      "code": 6049,
+      "msg": "Switchboard oracle: stale price",
+      "name": "SwitchboardStalePrice"
+    },
+    {
+      "code": 6050,
+      "msg": "Pyth Push oracle: stale price",
+      "name": "PythPushStalePrice"
+    },
+    {
+      "code": 6051,
+      "msg": "Oracle error: wrong number of accounts",
+      "name": "WrongNumberOfOracleAccounts"
+    },
+    {
+      "code": 6052,
+      "msg": "Oracle error: wrong account keys",
+      "name": "WrongOracleAccountKeys"
+    },
+    {
+      "code": 6053,
+      "msg": "Vacated2",
+      "name": "Vacated2"
+    },
+    {
+      "code": 6054,
+      "msg": "Vacated3",
+      "name": "Vacated3"
+    },
+    {
+      "code": 6055,
+      "msg": "Oracle max confidence exceeded: try again later",
+      "name": "OracleMaxConfidenceExceeded"
+    },
+    {
+      "code": 6056,
+      "msg": "Pyth Push oracle: insufficient verification level",
+      "name": "PythPushInsufficientVerificationLevel"
+    },
+    {
+      "code": 6057,
+      "msg": "Zero asset price",
+      "name": "ZeroAssetPrice"
+    },
+    {
+      "code": 6058,
+      "msg": "Zero liability price",
+      "name": "ZeroLiabilityPrice"
+    },
+    {
+      "code": 6059,
+      "msg": "Switchboard oracle: wrong account owner",
+      "name": "SwitchboardWrongAccountOwner"
+    },
+    {
+      "code": 6060,
+      "msg": "Pyth Push oracle: invalid account",
+      "name": "PythPushInvalidAccount"
+    },
+    {
+      "code": 6061,
+      "msg": "Switchboard oracle: invalid account",
+      "name": "SwitchboardInvalidAccount"
+    },
+    {
+      "code": 6062,
+      "msg": "Math error",
+      "name": "MathError"
+    },
+    {
+      "code": 6063,
+      "msg": "Invalid emissions destination account",
+      "name": "InvalidEmissionsDestinationAccount"
+    },
+    {
+      "code": 6064,
+      "msg": "Asset and liability bank cannot be the same",
+      "name": "SameAssetAndLiabilityBanks"
+    },
+    {
+      "code": 6065,
+      "msg": "Trying to withdraw more assets than available",
+      "name": "OverliquidationAttempt"
+    },
+    {
+      "code": 6066,
+      "msg": "Liability bank has no liabilities",
+      "name": "NoLiabilitiesInLiabilityBank"
+    },
+    {
+      "code": 6067,
+      "msg": "Liability bank has assets",
+      "name": "AssetsInLiabilityBank"
+    },
+    {
+      "code": 6068,
+      "msg": "Account is healthy and cannot be liquidated",
+      "name": "HealthyAccount"
+    },
+    {
+      "code": 6069,
+      "msg": "Liability payoff too severe, exhausted liability",
+      "name": "ExhaustedLiability"
+    },
+    {
+      "code": 6070,
+      "msg": "Liability payoff too severe, liability balance has assets",
+      "name": "TooSeverePayoff"
+    },
+    {
+      "code": 6071,
+      "msg": "Liquidation too severe, account above maintenance requirement",
+      "name": "TooSevereLiquidation"
+    },
+    {
+      "code": 6072,
+      "msg": "Liquidation would worsen account health",
+      "name": "WorseHealthPostLiquidation"
+    },
+    {
+      "code": 6073,
+      "msg": "Exceeded the maximum allowed integration positions",
+      "name": "IntegrationPositionLimitExceeded"
+    },
+    {
+      "code": 6074,
+      "msg": "Maximum initial leverage exceeded",
+      "name": "MaxInitLeverageExceeded"
+    },
+    {
+      "code": 6075,
+      "msg": "The Emode config was invalid",
+      "name": "BadEmodeConfig"
+    },
+    {
+      "code": 6076,
+      "msg": "TWAP window size does not match expected duration",
+      "name": "PythPushInvalidWindowSize"
+    },
+    {
+      "code": 6077,
+      "msg": "Invalid fees destination account",
+      "name": "InvalidFeesDestinationAccount"
+    },
+    {
+      "code": 6078,
+      "msg": "Banks cannot close when they have open positions or emissions outstanding",
+      "name": "BankCannotClose"
+    },
+    {
+      "code": 6079,
+      "msg": "Account already migrated",
+      "name": "AccountAlreadyMigrated"
+    },
+    {
+      "code": 6080,
+      "msg": "Protocol is paused",
+      "name": "ProtocolPaused"
+    },
+    {
+      "code": 6081,
+      "msg": "Metadata is too long",
+      "name": "MetadataTooLong"
+    },
+    {
+      "code": 6082,
+      "msg": "Pause limit exceeded",
+      "name": "PauseLimitExceeded"
+    },
+    {
+      "code": 6083,
+      "msg": "Protocol is not paused",
+      "name": "ProtocolNotPaused"
+    },
+    {
+      "code": 6084,
+      "msg": "Bank killed by bankruptcy: bank shutdown and value of all holdings is zero",
+      "name": "BankKilledByBankruptcy"
+    },
+    {
+      "code": 6085,
+      "msg": "Liquidation state issue. Check start before end, end last, and both unique",
+      "name": "UnexpectedLiquidationState"
+    },
+    {
+      "code": 6086,
+      "msg": "Liquidation start must be first instruction (other than compute program ixes)",
+      "name": "StartNotFirst"
+    },
+    {
+      "code": 6087,
+      "msg": "Only one liquidation event allowed per tx",
+      "name": "StartRepeats"
+    },
+    {
+      "code": 6088,
+      "msg": "The end instruction must be the last ix in the tx",
+      "name": "EndNotLast"
+    },
+    {
+      "code": 6089,
+      "msg": "Tried to call an instruction that is forbidden during liquidation",
+      "name": "ForbiddenIx"
+    },
+    {
+      "code": 6090,
+      "msg": "Seized too much of the asset relative to liability repaid",
+      "name": "LiquidationPremiumTooHigh"
+    },
+    {
+      "code": 6091,
+      "msg": "Start and end liquidation and flashloan must be top-level instructions",
+      "name": "NotAllowedInCPI"
+    },
+    {
+      "code": 6092,
+      "msg": "Stake pool supply is zero: cannot compute price",
+      "name": "ZeroSupplyInStakePool"
+    },
+    {
+      "code": 6093,
+      "msg": "Invalid group: account constraint violated",
+      "name": "InvalidGroup"
+    },
+    {
+      "code": 6094,
+      "msg": "Invalid liquidity vault: account constraint violated",
+      "name": "InvalidLiquidityVault"
+    },
+    {
+      "code": 6095,
+      "msg": "Invalid liquidation record: account constraint violated",
+      "name": "InvalidLiquidationRecord"
+    },
+    {
+      "code": 6096,
+      "msg": "Invalid liquidation receiver: account constraint violated",
+      "name": "InvalidLiquidationReceiver"
+    },
+    {
+      "code": 6097,
+      "msg": "Invalid emissions mint: account constraint violated",
+      "name": "InvalidEmissionsMint"
+    },
+    {
+      "code": 6098,
+      "msg": "Invalid mint: account constraint violated",
+      "name": "InvalidMint"
+    },
+    {
+      "code": 6099,
+      "msg": "Invalid fee wallet: account constraint violated",
+      "name": "InvalidFeeWallet"
+    },
+    {
+      "code": 6100,
+      "msg": "Fixed oracle price must be zero or greater",
+      "name": "FixedOraclePriceNegative"
+    },
+    {
+      "code": 6101,
+      "msg": "Daily withdrawal limit exceeded: try again later",
+      "name": "DailyWithdrawalLimitExceeded"
+    },
+    {
+      "code": 6102,
+      "msg": "Cannot set daily withdrawal limit to zero",
+      "name": "ZeroWithdrawalLimit"
+    },
+    {
+      "code": 6103,
+      "msg": "Account is frozen by the group admin",
+      "name": "AccountFrozen"
+    },
+    {
+      "code": 6104,
+      "msg": "Cannot reference duplicate balances",
+      "name": "DuplicateBalance"
+    },
+    {
+      "code": 6105,
+      "msg": "Invalid amount of balances referenced",
+      "name": "InvalidBalanceCount"
+    },
+    {
+      "code": 6106,
+      "msg": "Liquidator not allowed to close order",
+      "name": "LiquidatorOrderCloseNotAllowed"
+    },
+    {
+      "code": 6107,
+      "msg": "Order trigger is yet to be met",
+      "name": "OrderTriggerNotMet"
+    },
+    {
+      "code": 6108,
+      "msg": "Order execution state issue. Check the necessary invariants i.e not in flashloan or disabled e.t.c",
+      "name": "UnexpectedOrderExecutionState"
+    },
+    {
+      "code": 6109,
+      "msg": "Order liability not closed",
+      "name": "OrderLiabilityNotClosed"
+    },
+    {
+      "code": 6110,
+      "msg": "Invalid asset or liabilities count",
+      "name": "InvalidAssetOrLiabilitiesCount"
+    },
+    {
+      "code": 6111,
+      "msg": "Account health can only worsen if account is healthy",
+      "name": "WorseHealthPostExecution"
+    },
+    {
+      "code": 6112,
+      "msg": "TP must be > 0, SL must be > 0 and TP > SL if both are set",
+      "name": "InvalidOrderTakeProfitOrStopLoss"
+    },
+    {
+      "code": 6113,
+      "msg": "Max slippage must be less than 100%",
+      "name": "InvalidSlippage"
+    },
+    {
+      "code": 6114,
+      "msg": "Executor withdrew too much: slippage or max fee constraint violated",
+      "name": "OrderExecutionOverWithdrawal"
+    },
+    {
+      "code": 6115,
+      "msg": "Bank hourly rate limit exceeded: try again later",
+      "name": "BankHourlyRateLimitExceeded"
+    },
+    {
+      "code": 6116,
+      "msg": "Bank daily rate limit exceeded: try again later",
+      "name": "BankDailyRateLimitExceeded"
+    },
+    {
+      "code": 6117,
+      "msg": "Group hourly rate limit exceeded: try again later",
+      "name": "GroupHourlyRateLimitExceeded"
+    },
+    {
+      "code": 6118,
+      "msg": "Group daily rate limit exceeded: try again later",
+      "name": "GroupDailyRateLimitExceeded"
+    },
+    {
+      "code": 6119,
+      "msg": "Invalid rate limit price: pass oracle or pre-crank cache",
+      "name": "InvalidRateLimitPrice"
+    },
+    {
+      "code": 6120,
+      "msg": "Group rate limiter admin update must include inflow and/or outflow",
+      "name": "GroupRateLimiterUpdateEmpty"
+    },
+    {
+      "code": 6121,
+      "msg": "Group rate limiter admin update slot range is invalid",
+      "name": "GroupRateLimiterUpdateInvalidSlotRange"
+    },
+    {
+      "code": 6122,
+      "msg": "Group rate limiter admin update cannot reference future slots",
+      "name": "GroupRateLimiterUpdateFutureSlot"
+    },
+    {
+      "code": 6123,
+      "msg": "Group rate limiter admin update is too stale",
+      "name": "GroupRateLimiterUpdateStale"
+    },
+    {
+      "code": 6124,
+      "msg": "Group rate limiter admin update slot progression is out of order",
+      "name": "GroupRateLimiterUpdateOutOfOrderSlot"
+    },
+    {
+      "code": 6125,
+      "msg": "Group rate limiter admin update sequence is out of order",
+      "name": "GroupRateLimiterUpdateOutOfOrderSeq"
+    },
+    {
+      "code": 6126,
+      "msg": "Deleverage withdrawal admin update must include outflow",
+      "name": "DeleverageWithdrawalUpdateEmpty"
+    },
+    {
+      "code": 6127,
+      "msg": "Deleverage withdrawal admin update slot range is invalid",
+      "name": "DeleverageWithdrawalUpdateInvalidSlotRange"
+    },
+    {
+      "code": 6128,
+      "msg": "Deleverage withdrawal admin update cannot reference future slots",
+      "name": "DeleverageWithdrawalUpdateFutureSlot"
+    },
+    {
+      "code": 6129,
+      "msg": "Deleverage withdrawal admin update is too stale",
+      "name": "DeleverageWithdrawalUpdateStale"
+    },
+    {
+      "code": 6130,
+      "msg": "Deleverage withdrawal admin update slot progression is out of order",
+      "name": "DeleverageWithdrawalUpdateOutOfOrderSlot"
+    },
+    {
+      "code": 6131,
+      "msg": "Deleverage withdrawal admin update sequence is out of order",
+      "name": "DeleverageWithdrawalUpdateOutOfOrderSeq"
+    },
+    {
+      "code": 6200,
+      "msg": "Wrong asset tag for standard instructions, expected DEFAULT, SOL, or STAKED asset tag",
+      "name": "WrongAssetTagForStandardInstructions"
+    },
+    {
+      "code": 6201,
+      "msg": "Wrong asset tag for Kamino instructions, expected KAMINO asset tag",
+      "name": "WrongAssetTagForKaminoInstructions"
+    },
+    {
+      "code": 6202,
+      "msg": "Cannot create a kamino bank with this instruction, use add_bank_kamino",
+      "name": "CantAddPool"
+    },
+    {
+      "code": 6203,
+      "msg": "Kamino reserve mint address doesn't match the bank mint address",
+      "name": "KaminoReserveMintAddressMismatch"
+    },
+    {
+      "code": 6204,
+      "msg": "Deposit failed: obligation deposit amount increase did not match the expected increase, left - actual, right - expected",
+      "name": "KaminoDepositFailed"
+    },
+    {
+      "code": 6205,
+      "msg": "Withdraw failed: token vault increase did not match the expected increase, left - actual, right - expected",
+      "name": "KaminoWithdrawFailed"
+    },
+    {
+      "code": 6206,
+      "msg": "Kamino Reserve data is stale - run refresh_reserve on kamino program first",
+      "name": "ReserveStale"
+    },
+    {
+      "code": 6207,
+      "msg": "Kamino obligation must have exactly one active deposit, at index 0",
+      "name": "InvalidObligationDepositCount"
+    },
+    {
+      "code": 6208,
+      "msg": "Kamino obligation deposit doesn't match the expected reserve",
+      "name": "ObligationDepositReserveMismatch"
+    },
+    {
+      "code": 6209,
+      "msg": "Failed to meet minimum deposit amount requirement for init obligation",
+      "name": "ObligationInitDepositInsufficient"
+    },
+    {
+      "code": 6210,
+      "msg": "Kamino reserve validation failed",
+      "name": "KaminoReserveValidationFailed"
+    },
+    {
+      "code": 6211,
+      "msg": "Invalid oracle setup: only KaminoPythPush and KaminoSwitchboardPull are supported",
+      "name": "KaminoInvalidOracleSetup"
+    },
+    {
+      "code": 6212,
+      "msg": "Maximum Maintenance leverage exceeded",
+      "name": "MaxMaintLeverageExceeded"
+    },
+    {
+      "code": 6213,
+      "msg": "Invalid Kamino reserve: account constraint violated",
+      "name": "InvalidKaminoReserve"
+    },
+    {
+      "code": 6214,
+      "msg": "Invalid Kamino obligation: account constraint violated",
+      "name": "InvalidKaminoObligation"
+    },
+    {
+      "code": 6300,
+      "msg": "Invalid oracle setup: only DriftPythPull and DriftSwitchboardPull are supported",
+      "name": "DriftInvalidOracleSetup"
+    },
+    {
+      "code": 6301,
+      "msg": "Drift spot market mint does not match bank mint",
+      "name": "DriftSpotMarketMintMismatch"
+    },
+    {
+      "code": 6302,
+      "msg": "Wrong bank asset tag for Drift operation",
+      "name": "WrongBankAssetTagForDriftOperation"
+    },
+    {
+      "code": 6303,
+      "msg": "Cannot use standard operations on Drift assets",
+      "name": "CantUseStandardOperationsOnDriftAssets"
+    },
+    {
+      "code": 6304,
+      "msg": "Drift spot market validation failed",
+      "name": "DriftSpotMarketValidationFailed"
+    },
+    {
+      "code": 6305,
+      "msg": "Drift user has invalid spot positions (only first position can have balance)",
+      "name": "DriftInvalidSpotPositions"
+    },
+    {
+      "code": 6306,
+      "msg": "Drift spot position market does not match bank's configured market",
+      "name": "DriftSpotPositionMarketMismatch"
+    },
+    {
+      "code": 6307,
+      "msg": "Drift position has invalid balance type (must be deposit)",
+      "name": "DriftInvalidPositionType"
+    },
+    {
+      "code": 6308,
+      "msg": "Drift scaled balance change does not match expected amount",
+      "name": "DriftScaledBalanceMismatch"
+    },
+    {
+      "code": 6309,
+      "msg": "Drift withdrawal failed - token amount mismatch",
+      "name": "DriftWithdrawFailed"
+    },
+    {
+      "code": 6310,
+      "msg": "Drift user initial deposit insufficient (minimum 10 units required)",
+      "name": "DriftUserInitDepositInsufficient"
+    },
+    {
+      "code": 6311,
+      "msg": "Invalid drift account",
+      "name": "InvalidDriftAccount"
+    },
+    {
+      "code": 6312,
+      "msg": "Drift authority mismatch",
+      "name": "DriftAuthorityMismatch"
+    },
+    {
+      "code": 6313,
+      "msg": "Invalid harvest position index - must be between 2 and 7",
+      "name": "DriftInvalidHarvestPositionIndex"
+    },
+    {
+      "code": 6314,
+      "msg": "Drift position is empty",
+      "name": "DriftPositionEmpty"
+    },
+    {
+      "code": 6315,
+      "msg": "Drift position has invalid balance type",
+      "name": "DriftInvalidBalanceType"
+    },
+    {
+      "code": 6316,
+      "msg": "No admin deposits found in Drift positions 2-7 for this market",
+      "name": "DriftNoAdminDeposit"
+    },
+    {
+      "code": 6317,
+      "msg": "Cannot harvest from the same market as the bank's main drift spot market",
+      "name": "DriftHarvestSameMarket"
+    },
+    {
+      "code": 6318,
+      "msg": "Drift account bricked: too many active deposits from admin operations",
+      "name": "DriftBrickedAccount"
+    },
+    {
+      "code": 6319,
+      "msg": "Drift reward oracle required when 2+ active deposits exist",
+      "name": "DriftMissingRewardOracle"
+    },
+    {
+      "code": 6320,
+      "msg": "Drift reward spot market required when 2+ active deposits exist",
+      "name": "DriftMissingRewardSpotMarket"
+    },
+    {
+      "code": 6321,
+      "msg": "Drift account has admin deposits that require reward accounts to be provided",
+      "name": "DriftMissingRewardAccounts"
+    },
+    {
+      "code": 6322,
+      "msg": "Drift spot market is stale, interest needs to be updated",
+      "name": "DriftSpotMarketStale"
+    },
+    {
+      "code": 6323,
+      "msg": "Invalid Drift spot market: account constraint violated",
+      "name": "InvalidDriftSpotMarket"
+    },
+    {
+      "code": 6324,
+      "msg": "Invalid Drift user: account constraint violated",
+      "name": "InvalidDriftUser"
+    },
+    {
+      "code": 6325,
+      "msg": "Invalid Drift user stats: account constraint violated",
+      "name": "InvalidDriftUserStats"
+    },
+    {
+      "code": 6326,
+      "msg": "Drift cannot support tokens with more than 19 decimals",
+      "name": "DriftUnsupportedTokenDecimals"
+    },
+    {
+      "code": 6400,
+      "msg": "Invalid oracle setup: only SolendPythPull and SolendSwitchboardPull are supported",
+      "name": "SolendInvalidOracleSetup"
+    },
+    {
+      "code": 6401,
+      "msg": "Solend reserve validation failed",
+      "name": "SolendReserveValidationFailed"
+    },
+    {
+      "code": 6402,
+      "msg": "Solend obligation owner mismatch",
+      "name": "SolendObligationOwnerMismatch"
+    },
+    {
+      "code": 6403,
+      "msg": "Wrong bank asset tag for Solend operation",
+      "name": "WrongBankAssetTagForSolendOperation"
+    },
+    {
+      "code": 6404,
+      "msg": "Cannot use standard operations on Solend assets",
+      "name": "CantUseStandardOperationsOnSolendAssets"
+    },
+    {
+      "code": 6405,
+      "msg": "Solend reserve mismatch",
+      "name": "SolendReserveMismatch"
+    },
+    {
+      "code": 6406,
+      "msg": "Solend reserve mint mismatch",
+      "name": "SolendReserveMintMismatch"
+    },
+    {
+      "code": 6407,
+      "msg": "Solend obligation has invalid deposits (only first position can have balance)",
+      "name": "SolendInvalidDepositPositions"
+    },
+    {
+      "code": 6408,
+      "msg": "Solend deposit position reserve does not match bank's configured reserve",
+      "name": "SolendDepositPositionReserveMismatch"
+    },
+    {
+      "code": 6409,
+      "msg": "Solend cToken balance change does not match expected amount",
+      "name": "SolendCTokenBalanceMismatch"
+    },
+    {
+      "code": 6410,
+      "msg": "Solend withdrawal failed - token amount mismatch",
+      "name": "SolendWithdrawFailed"
+    },
+    {
+      "code": 6411,
+      "msg": "Solend reserve is stale",
+      "name": "SolendReserveStale"
+    },
+    {
+      "code": 6412,
+      "msg": "Solend deposit failed - collateral amount mismatch",
+      "name": "SolendDepositFailed"
+    },
+    {
+      "code": 6413,
+      "msg": "Invalid Solend account owner",
+      "name": "InvalidSolendAccount"
+    },
+    {
+      "code": 6414,
+      "msg": "Invalid Solend account version",
+      "name": "InvalidSolendAccountVersion"
+    },
+    {
+      "code": 6415,
+      "msg": "Invalid Solend reserve: account constraint violated",
+      "name": "InvalidSolendReserve"
+    },
+    {
+      "code": 6416,
+      "msg": "Invalid Solend obligation: account constraint violated",
+      "name": "InvalidSolendObligation"
+    },
+    {
+      "code": 6500,
+      "msg": "Invalid oracle setup: only JuplendPythPull and JuplendSwitchboardPull are supported",
+      "name": "JuplendInvalidOracleSetup"
+    },
+    {
+      "code": 6501,
+      "msg": "Juplend lending state validation failed",
+      "name": "JuplendLendingValidationFailed"
+    },
+    {
+      "code": 6502,
+      "msg": "Wrong bank asset tag for Juplend operation",
+      "name": "WrongBankAssetTagForJuplendOperation"
+    },
+    {
+      "code": 6503,
+      "msg": "Cannot use standard operations on Juplend assets",
+      "name": "CantUseStandardOperationsOnJuplendAssets"
+    },
+    {
+      "code": 6504,
+      "msg": "Juplend lending state is stale",
+      "name": "JuplendLendingStale"
+    },
+    {
+      "code": 6505,
+      "msg": "Invalid Juplend lending: account constraint violated",
+      "name": "InvalidJuplendLending"
+    },
+    {
+      "code": 6506,
+      "msg": "Juplend lending mint mismatch",
+      "name": "JuplendLendingMintMismatch"
+    },
+    {
+      "code": 6507,
+      "msg": "Juplend bank is already activated",
+      "name": "JuplendBankAlreadyActivated"
+    },
+    {
+      "code": 6508,
+      "msg": "Invalid Juplend fToken vault",
+      "name": "InvalidJuplendFTokenVault"
+    },
+    {
+      "code": 6509,
+      "msg": "Juplend deposit failed",
+      "name": "JuplendDepositFailed"
+    },
+    {
+      "code": 6510,
+      "msg": "Juplend withdraw failed",
+      "name": "JuplendWithdrawFailed"
+    },
+    {
+      "code": 6511,
+      "msg": "Juplend init position deposit insufficient",
+      "name": "JuplendInitPositionDepositInsufficient"
+    },
+    {
+      "code": 6512,
+      "msg": "Invalid Juplend withdraw intermediary ATA",
+      "name": "InvalidJuplendWithdrawIntermediaryAta"
+    }
+  ],
+  "events": [
+    {
+      "discriminator": [
+        161,
+        8,
+        108,
+        204,
+        209,
+        198,
+        12,
+        30
+      ],
+      "name": "DeleverageEvent"
+    },
+    {
+      "discriminator": [
+        109,
+        90,
+        139,
+        200,
+        10,
+        204,
+        84,
+        176
+      ],
+      "name": "DeleverageWithdrawFlowEvent"
+    },
+    {
+      "discriminator": [
+        29,
+        58,
+        155,
+        191,
+        75,
+        220,
+        145,
+        206
+      ],
+      "name": "EditStakedSettingsEvent"
+    },
+    {
+      "discriminator": [
+        183,
+        159,
+        218,
+        110,
+        61,
+        220,
+        65,
+        1
+      ],
+      "name": "HealthPulseEvent"
+    },
+    {
+      "discriminator": [
+        46,
+        152,
+        11,
+        174,
+        92,
+        157,
+        77,
+        64
+      ],
+      "name": "KeeperCloseOrderEvent"
+    },
+    {
+      "discriminator": [
+        223,
+        96,
+        81,
+        10,
+        156,
+        99,
+        26,
+        59
+      ],
+      "name": "LendingAccountBorrowEvent"
+    },
+    {
+      "discriminator": [
+        161,
+        54,
+        237,
+        217,
+        105,
+        248,
+        122,
+        151
+      ],
+      "name": "LendingAccountDepositEvent"
+    },
+    {
+      "discriminator": [
+        166,
+        160,
+        249,
+        154,
+        183,
+        39,
+        23,
+        242
+      ],
+      "name": "LendingAccountLiquidateEvent"
+    },
+    {
+      "discriminator": [
+        16,
+        220,
+        55,
+        111,
+        7,
+        80,
+        16,
+        25
+      ],
+      "name": "LendingAccountRepayEvent"
+    },
+    {
+      "discriminator": [
+        3,
+        220,
+        148,
+        243,
+        33,
+        249,
+        54,
+        88
+      ],
+      "name": "LendingAccountWithdrawEvent"
+    },
+    {
+      "discriminator": [
+        104,
+        117,
+        187,
+        156,
+        111,
+        154,
+        106,
+        186
+      ],
+      "name": "LendingPoolBankAccrueInterestEvent"
+    },
+    {
+      "discriminator": [
+        101,
+        119,
+        97,
+        250,
+        169,
+        175,
+        156,
+        253
+      ],
+      "name": "LendingPoolBankCollectFeesEvent"
+    },
+    {
+      "discriminator": [
+        246,
+        35,
+        233,
+        110,
+        93,
+        152,
+        235,
+        40
+      ],
+      "name": "LendingPoolBankConfigureEvent"
+    },
+    {
+      "discriminator": [
+        24,
+        10,
+        55,
+        18,
+        49,
+        150,
+        157,
+        179
+      ],
+      "name": "LendingPoolBankConfigureFrozenEvent"
+    },
+    {
+      "discriminator": [
+        119,
+        140,
+        110,
+        253,
+        150,
+        64,
+        210,
+        62
+      ],
+      "name": "LendingPoolBankConfigureOracleEvent"
+    },
+    {
+      "discriminator": [
+        236,
+        220,
+        201,
+        63,
+        239,
+        126,
+        136,
+        249
+      ],
+      "name": "LendingPoolBankCreateEvent"
+    },
+    {
+      "discriminator": [
+        166,
+        77,
+        41,
+        140,
+        36,
+        94,
+        10,
+        57
+      ],
+      "name": "LendingPoolBankHandleBankruptcyEvent"
+    },
+    {
+      "discriminator": [
+        65,
+        72,
+        8,
+        85,
+        229,
+        20,
+        90,
+        26
+      ],
+      "name": "LendingPoolBankSetFixedOraclePriceEvent"
+    },
+    {
+      "discriminator": [
+        40,
+        131,
+        224,
+        220,
+        151,
+        83,
+        24,
+        230
+      ],
+      "name": "LiquidationReceiverEvent"
+    },
+    {
+      "discriminator": [
+        158,
+        34,
+        122,
+        98,
+        23,
+        146,
+        229,
+        212
+      ],
+      "name": "MarginfiAccountCloseOrderEvent"
+    },
+    {
+      "discriminator": [
+        183,
+        5,
+        117,
+        104,
+        122,
+        199,
+        68,
+        51
+      ],
+      "name": "MarginfiAccountCreateEvent"
+    },
+    {
+      "discriminator": [
+        219,
+        219,
+        57,
+        178,
+        75,
+        86,
+        146,
+        122
+      ],
+      "name": "MarginfiAccountFreezeEvent"
+    },
+    {
+      "discriminator": [
+        1,
+        105,
+        79,
+        28,
+        142,
+        242,
+        99,
+        145
+      ],
+      "name": "MarginfiAccountPlaceOrderEvent"
+    },
+    {
+      "discriminator": [
+        59,
+        105,
+        171,
+        110,
+        223,
+        136,
+        80,
+        89
+      ],
+      "name": "MarginfiAccountTransferToNewAccount"
+    },
+    {
+      "discriminator": [
+        241,
+        104,
+        172,
+        167,
+        41,
+        195,
+        199,
+        170
+      ],
+      "name": "MarginfiGroupConfigureEvent"
+    },
+    {
+      "discriminator": [
+        233,
+        125,
+        61,
+        14,
+        98,
+        240,
+        136,
+        253
+      ],
+      "name": "MarginfiGroupCreateEvent"
+    },
+    {
+      "discriminator": [
+        229,
+        5,
+        73,
+        200,
+        0,
+        107,
+        105,
+        109
+      ],
+      "name": "RateLimitFlowEvent"
+    },
+    {
+      "discriminator": [
+        193,
+        230,
+        93,
+        128,
+        117,
+        87,
+        96,
+        21
+      ],
+      "name": "SetKeeperCloseFlagsEvent"
+    }
+  ],
+  "instructions": [
+    {
+      "accounts": [
+        {
+          "name": "marginfi_group",
+          "writable": true
+        },
+        {
+          "docs": [
+            "`global_fee_admin` of the FeeState"
+          ],
+          "name": "global_fee_admin",
+          "relations": [
+            "fee_state"
+          ],
+          "signer": true
+        },
+        {
+          "name": "fee_state",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  101,
+                  101,
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "enable_program_fee",
+          "type": "bool"
+        }
+      ],
+      "discriminator": [
+        231,
+        205,
+        66,
+        242,
+        220,
+        87,
+        145,
+        38
+      ],
+      "docs": [
+        "(global fee admin only) Enable or disable program fees for any group. Does not require the",
+        "group admin to sign: the global fee state admin can turn program fees on or off for any",
+        "group"
+      ],
+      "name": "config_group_fee"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "relations": [
+            "bank"
+          ]
+        },
+        {
+          "name": "admin",
+          "signer": true
+        },
+        {
+          "name": "bank",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "hourly_max_outflow",
+          "type": {
+            "option": "u64"
+          }
+        },
+        {
+          "name": "daily_max_outflow",
+          "type": {
+            "option": "u64"
+          }
+        }
+      ],
+      "discriminator": [
+        175,
+        84,
+        85,
+        221,
+        206,
+        220,
+        110,
+        174
+      ],
+      "docs": [
+        "(admin or delegate_limit_admin) Configure bank-level rate limits for withdraw/borrow.",
+        "Rate limits track net outflow in native tokens. Deposits offset withdraws.",
+        "Set to 0 to disable. Hourly and daily windows are independent."
+      ],
+      "name": "configure_bank_rate_limits"
+    },
+    {
+      "accounts": [
+        {
+          "name": "marginfi_group",
+          "writable": true
+        },
+        {
+          "name": "admin",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "limit",
+          "type": "u32"
+        }
+      ],
+      "discriminator": [
+        28,
+        132,
+        205,
+        158,
+        67,
+        77,
+        177,
+        63
+      ],
+      "docs": [
+        "(admin or delegate_limit_admin) Set the daily withdrawal limit for deleverages per group."
+      ],
+      "name": "configure_deleverage_withdrawal_limit"
+    },
+    {
+      "accounts": [
+        {
+          "name": "marginfi_group",
+          "writable": true
+        },
+        {
+          "name": "admin",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "hourly_max_outflow_usd",
+          "type": {
+            "option": "u64"
+          }
+        },
+        {
+          "name": "daily_max_outflow_usd",
+          "type": {
+            "option": "u64"
+          }
+        }
+      ],
+      "discriminator": [
+        111,
+        47,
+        213,
+        142,
+        158,
+        51,
+        226,
+        102
+      ],
+      "docs": [
+        "(admin or delegate_limit_admin) Configure group-level rate limits for withdraw/borrow.",
+        "Rate limits track aggregate net outflow in USD.",
+        "Example: $10M = 10_000_000. Set to 0 to disable."
+      ],
+      "name": "configure_group_rate_limits"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "relations": [
+            "marginfi_account",
+            "bank"
+          ]
+        },
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "bank",
+          "writable": true
+        },
+        {
+          "docs": [
+            "The oracle account for the asset (not needed if using oracle type QuoteAsset)"
+          ],
+          "name": "drift_oracle",
+          "optional": true
+        },
+        {
+          "docs": [
+            "The bank's liquidity vault authority, which owns the Drift user account"
+          ],
+          "name": "liquidity_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "docs": [
+            "Used as an intermediary to deposit tokens into Drift"
+          ],
+          "name": "liquidity_vault",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "docs": [
+            "Owned by authority, the source account for the token deposit"
+          ],
+          "name": "signer_token_account",
+          "writable": true
+        },
+        {
+          "docs": [
+            "The Drift state account"
+          ],
+          "name": "drift_state"
+        },
+        {
+          "docs": [
+            "The Drift user account owned by liquidity_vault_authority"
+          ],
+          "name": "integration_acc_2",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "docs": [
+            "The Drift user stats account owned by liquidity_vault_authority"
+          ],
+          "name": "integration_acc_3",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "docs": [
+            "The Drift spot market for this asset"
+          ],
+          "name": "integration_acc_1",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "docs": [
+            "The Drift spot market vault that will receive tokens"
+          ],
+          "name": "drift_spot_market_vault",
+          "writable": true
+        },
+        {
+          "docs": [
+            "Bank's liquidity token mint"
+          ],
+          "name": "mint",
+          "relations": [
+            "bank"
+          ]
+        },
+        {
+          "address": "dRiftyHA39MWEi3m9aunc5MzRF1JYuBsbn6VPcn33UH",
+          "name": "drift_program"
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ],
+      "discriminator": [
+        252,
+        63,
+        250,
+        201,
+        98,
+        55,
+        130,
+        12
+      ],
+      "docs": [
+        "(user) Deposit into a Drift spot market through a marginfi account",
+        "* amount - in the underlying token (e.g., USDC), in native decimals"
+      ],
+      "name": "drift_deposit"
+    },
+    {
+      "accounts": [
+        {
+          "name": "bank"
+        },
+        {
+          "docs": [
+            "Global fee state that contains the global_fee_wallet"
+          ],
+          "name": "fee_state",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  101,
+                  101,
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "docs": [
+            "The bank's liquidity vault authority"
+          ],
+          "name": "liquidity_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "docs": [
+            "To create this manually just send some of the reward token",
+            "to the liquidity vault authority address before claiming"
+          ],
+          "name": "intermediary_token_account",
+          "pda": {
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            },
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "liquidity_vault_authority"
+              },
+              {
+                "kind": "account",
+                "path": "token_program"
+              },
+              {
+                "kind": "account",
+                "path": "reward_mint"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "docs": [
+            "Destination token account must be owned by the global fee wallet"
+          ],
+          "name": "destination_token_account",
+          "pda": {
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            },
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "fee_state"
+              },
+              {
+                "kind": "account",
+                "path": "token_program"
+              },
+              {
+                "kind": "account",
+                "path": "reward_mint"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "docs": [
+            "Drift accounts"
+          ],
+          "name": "drift_state"
+        },
+        {
+          "name": "integration_acc_2",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "name": "integration_acc_3",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "docs": [
+            "The harvest spot market - MUST be different from bank's Drift spot market (integration_acc_1)",
+            "This is the market that contains admin deposits to harvest"
+          ],
+          "name": "harvest_drift_spot_market",
+          "writable": true
+        },
+        {
+          "docs": [
+            "The harvest spot market vault - derived from harvest_drift_spot_market"
+          ],
+          "name": "harvest_drift_spot_market_vault",
+          "writable": true
+        },
+        {
+          "docs": [
+            "The Drift signer PDA"
+          ],
+          "name": "drift_signer"
+        },
+        {
+          "name": "reward_mint"
+        },
+        {
+          "address": "dRiftyHA39MWEi3m9aunc5MzRF1JYuBsbn6VPcn33UH",
+          "name": "drift_program"
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        167,
+        161,
+        240,
+        194,
+        138,
+        54,
+        87,
+        189
+      ],
+      "docs": [
+        "(permissionless) Harvest rewards from admin deposits in Drift spot markets.",
+        "Rewards are always sent to the global fee wallet's canonical ATA.",
+        "The harvest spot market must be different from the bank's main drift spot market."
+      ],
+      "name": "drift_harvest_reward"
+    },
+    {
+      "accounts": [
+        {
+          "docs": [
+            "Pays to init the drift user and user stats accounts and provides initial deposit"
+          ],
+          "name": "fee_payer",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "docs": [
+            "The fee payer must provide a nominal amount of bank tokens so the account is not empty.",
+            "This amount is irrecoverable and will prevent the account from being closed."
+          ],
+          "name": "signer_token_account",
+          "writable": true
+        },
+        {
+          "name": "bank"
+        },
+        {
+          "docs": [
+            "The liquidity vault authority (PDA that will own the Drift user)"
+          ],
+          "name": "liquidity_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "docs": [
+            "Used as an intermediary to deposit a nominal amount of token into Drift."
+          ],
+          "name": "liquidity_vault",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "docs": [
+            "Bank's liquidity token mint (e.g., USDC)"
+          ],
+          "name": "mint",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "docs": [
+            "The user stats account to be created"
+          ],
+          "name": "integration_acc_3",
+          "pda": {
+            "program": {
+              "kind": "const",
+              "value": [
+                9,
+                84,
+                219,
+                190,
+                158,
+                201,
+                96,
+                201,
+                138,
+                122,
+                41,
+                63,
+                226,
+                19,
+                54,
+                150,
+                111,
+                225,
+                128,
+                209,
+                81,
+                174,
+                75,
+                129,
+                121,
+                86,
+                31,
+                137,
+                133,
+                74,
+                83,
+                246
+              ]
+            },
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  117,
+                  115,
+                  101,
+                  114,
+                  95,
+                  115,
+                  116,
+                  97,
+                  116,
+                  115
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_vault_authority"
+              }
+            ]
+          },
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "docs": [
+            "The user account to be created (sub_account_id = 0)"
+          ],
+          "name": "integration_acc_2",
+          "pda": {
+            "program": {
+              "kind": "const",
+              "value": [
+                9,
+                84,
+                219,
+                190,
+                158,
+                201,
+                96,
+                201,
+                138,
+                122,
+                41,
+                63,
+                226,
+                19,
+                54,
+                150,
+                111,
+                225,
+                128,
+                209,
+                81,
+                174,
+                75,
+                129,
+                121,
+                86,
+                31,
+                137,
+                133,
+                74,
+                83,
+                246
+              ]
+            },
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  117,
+                  115,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_vault_authority"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  0,
+                  0
+                ]
+              }
+            ]
+          },
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "name": "drift_state",
+          "writable": true
+        },
+        {
+          "name": "integration_acc_1",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "docs": [
+            "The Drift spot market vault where tokens will be deposited"
+          ],
+          "name": "drift_spot_market_vault",
+          "writable": true
+        },
+        {
+          "docs": [
+            "Oracle for the asset (can be null for USDC/market 0)"
+          ],
+          "name": "drift_oracle",
+          "optional": true
+        },
+        {
+          "address": "dRiftyHA39MWEi3m9aunc5MzRF1JYuBsbn6VPcn33UH",
+          "name": "drift_program"
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "address": "SysvarRent111111111111111111111111111111111",
+          "name": "rent"
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ],
+      "discriminator": [
+        29,
+        18,
+        236,
+        190,
+        29,
+        254,
+        114,
+        169
+      ],
+      "docs": [
+        "(permissionless) Initialize a Drift user and user stats for a marginfi bank",
+        "Creates user with sub_account_id = 0 and empty name",
+        "Requires a minimum deposit to ensure the account remains active",
+        "* amount - minimum deposit amount (at least 10 units) in native decimals"
+      ],
+      "name": "drift_init_user"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "relations": [
+            "marginfi_account",
+            "bank"
+          ]
+        },
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "bank",
+          "writable": true
+        },
+        {
+          "docs": [
+            "The oracle account for the asset (not needed if using oracle type QuoteAsset)"
+          ],
+          "name": "drift_oracle",
+          "optional": true
+        },
+        {
+          "docs": [
+            "The bank's liquidity vault authority, which owns the Drift user account"
+          ],
+          "name": "liquidity_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "docs": [
+            "Receives tokens from Drift withdrawal"
+          ],
+          "name": "liquidity_vault",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "docs": [
+            "Token account that will receive the withdrawn tokens"
+          ],
+          "name": "destination_token_account",
+          "writable": true
+        },
+        {
+          "docs": [
+            "The Drift state account"
+          ],
+          "name": "drift_state"
+        },
+        {
+          "docs": [
+            "The Drift user account owned by liquidity_vault_authority"
+          ],
+          "name": "integration_acc_2",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "docs": [
+            "The Drift user stats account owned by liquidity_vault_authority"
+          ],
+          "name": "integration_acc_3",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "docs": [
+            "The Drift spot market for this asset"
+          ],
+          "name": "integration_acc_1",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "docs": [
+            "The Drift spot market vault that holds tokens"
+          ],
+          "name": "drift_spot_market_vault",
+          "writable": true
+        },
+        {
+          "docs": [
+            "Optional: Oracle for first reward asset (only needed if rewards exist)"
+          ],
+          "name": "drift_reward_oracle",
+          "optional": true
+        },
+        {
+          "docs": [
+            "Optional: Spot market for first reward asset (only needed if rewards exist)"
+          ],
+          "name": "drift_reward_spot_market",
+          "optional": true
+        },
+        {
+          "docs": [
+            "Optional: Mint for first reward asset (only needed if rewards exist)"
+          ],
+          "name": "drift_reward_mint",
+          "optional": true
+        },
+        {
+          "docs": [
+            "Optional: Oracle for second reward asset (backup in case multiple rewards)"
+          ],
+          "name": "drift_reward_oracle_2",
+          "optional": true
+        },
+        {
+          "docs": [
+            "Optional: Spot market for second reward asset (backup in case multiple rewards)"
+          ],
+          "name": "drift_reward_spot_market_2",
+          "optional": true
+        },
+        {
+          "docs": [
+            "Optional: Mint for second reward asset (backup in case multiple rewards)"
+          ],
+          "name": "drift_reward_mint_2",
+          "optional": true
+        },
+        {
+          "docs": [
+            "The Drift signer PDA"
+          ],
+          "name": "drift_signer"
+        },
+        {
+          "docs": [
+            "Bank's liquidity token mint"
+          ],
+          "name": "mint",
+          "relations": [
+            "bank"
+          ]
+        },
+        {
+          "address": "dRiftyHA39MWEi3m9aunc5MzRF1JYuBsbn6VPcn33UH",
+          "name": "drift_program"
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        },
+        {
+          "name": "withdraw_all",
+          "type": {
+            "option": "bool"
+          }
+        }
+      ],
+      "discriminator": [
+        86,
+        59,
+        186,
+        123,
+        183,
+        181,
+        234,
+        137
+      ],
+      "docs": [
+        "(user) Withdraw from a Drift spot market through a marginfi account",
+        "* amount - in the underlying token (e.g., USDC), in native decimals",
+        "* withdraw_all - if true, withdraws entire position"
+      ],
+      "name": "drift_withdraw"
+    },
+    {
+      "accounts": [
+        {
+          "docs": [
+            "Admin of the global FeeState"
+          ],
+          "name": "global_fee_admin",
+          "relations": [
+            "fee_state"
+          ],
+          "signer": true
+        },
+        {
+          "name": "fee_state",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  101,
+                  101,
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          },
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "admin",
+          "type": "pubkey"
+        },
+        {
+          "name": "fee_wallet",
+          "type": "pubkey"
+        },
+        {
+          "name": "bank_init_flat_sol_fee",
+          "type": "u32"
+        },
+        {
+          "name": "liquidation_flat_sol_fee",
+          "type": "u32"
+        },
+        {
+          "name": "order_init_flat_sol_fee",
+          "type": "u32"
+        },
+        {
+          "name": "program_fee_fixed",
+          "type": {
+            "defined": {
+              "name": "WrappedI80F48"
+            }
+          }
+        },
+        {
+          "name": "program_fee_rate",
+          "type": {
+            "defined": {
+              "name": "WrappedI80F48"
+            }
+          }
+        },
+        {
+          "name": "liquidation_max_fee",
+          "type": {
+            "defined": {
+              "name": "WrappedI80F48"
+            }
+          }
+        },
+        {
+          "name": "order_execution_max_fee",
+          "type": {
+            "defined": {
+              "name": "WrappedI80F48"
+            }
+          }
+        }
+      ],
+      "discriminator": [
+        52,
+        62,
+        35,
+        129,
+        93,
+        69,
+        165,
+        202
+      ],
+      "docs": [
+        "(global fee admin only) Adjust fees, admin, or the destination wallet"
+      ],
+      "name": "edit_global_fee_state"
+    },
+    {
+      "accounts": [
+        {
+          "name": "marginfi_group",
+          "relations": [
+            "staked_settings"
+          ]
+        },
+        {
+          "name": "admin",
+          "relations": [
+            "marginfi_group"
+          ],
+          "signer": true
+        },
+        {
+          "name": "staked_settings",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "settings",
+          "type": {
+            "defined": {
+              "name": "StakedSettingsEditConfig"
+            }
+          }
+        }
+      ],
+      "discriminator": [
+        11,
+        108,
+        215,
+        87,
+        240,
+        9,
+        66,
+        241
+      ],
+      "docs": [
+        "(admin only) Edit the staked collateral settings for the group."
+      ],
+      "name": "edit_staked_settings"
+    },
+    {
+      "accounts": [
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "liquidation_record",
+          "relations": [
+            "marginfi_account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "group",
+          "relations": [
+            "marginfi_account"
+          ]
+        },
+        {
+          "name": "risk_admin",
+          "relations": [
+            "group"
+          ],
+          "signer": true
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        114,
+        14,
+        250,
+        143,
+        252,
+        104,
+        214,
+        209
+      ],
+      "docs": [
+        "(risk_admin only) End forced deleverage. Validates health did not worsen."
+      ],
+      "name": "end_deleverage"
+    },
+    {
+      "accounts": [
+        {
+          "docs": [
+            "Account under liquidation"
+          ],
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "docs": [
+            "The associated liquidation record PDA for the given `marginfi_account`"
+          ],
+          "name": "liquidation_record",
+          "relations": [
+            "marginfi_account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "liquidation_receiver",
+          "relations": [
+            "liquidation_record"
+          ],
+          "signer": true,
+          "writable": true
+        },
+        {
+          "name": "fee_state",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  101,
+                  101,
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "global_fee_wallet",
+          "relations": [
+            "fee_state"
+          ],
+          "writable": true
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        110,
+        11,
+        244,
+        54,
+        229,
+        181,
+        22,
+        184
+      ],
+      "docs": [
+        "(liquidation_receiver, set in start_liquidation) End receivership liquidation. Validates",
+        "health improved and seized assets are within fee limits. Charges a flat SOL fee."
+      ],
+      "name": "end_liquidation"
+    },
+    {
+      "accounts": [
+        {
+          "name": "bank"
+        },
+        {
+          "docs": [
+            "Pays the init fee"
+          ],
+          "name": "fee_payer",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "docs": [
+            "Note: unique per-bank."
+          ],
+          "name": "metadata",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  109,
+                  101,
+                  116,
+                  97,
+                  100,
+                  97,
+                  116,
+                  97
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        94,
+        239,
+        50,
+        136,
+        137,
+        204,
+        254,
+        213
+      ],
+      "docs": [
+        "(permissionless) pay the rent to open a bank's metadata."
+      ],
+      "name": "init_bank_metadata"
+    },
+    {
+      "accounts": [
+        {
+          "docs": [
+            "Pays the init fee"
+          ],
+          "name": "payer",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "name": "fee_state",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  101,
+                  101,
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "admin",
+          "type": "pubkey"
+        },
+        {
+          "name": "fee_wallet",
+          "type": "pubkey"
+        },
+        {
+          "name": "bank_init_flat_sol_fee",
+          "type": "u32"
+        },
+        {
+          "name": "liquidation_flat_sol_fee",
+          "type": "u32"
+        },
+        {
+          "name": "order_init_flat_sol_fee",
+          "type": "u32"
+        },
+        {
+          "name": "program_fee_fixed",
+          "type": {
+            "defined": {
+              "name": "WrappedI80F48"
+            }
+          }
+        },
+        {
+          "name": "program_fee_rate",
+          "type": {
+            "defined": {
+              "name": "WrappedI80F48"
+            }
+          }
+        },
+        {
+          "name": "liquidation_max_fee",
+          "type": {
+            "defined": {
+              "name": "WrappedI80F48"
+            }
+          }
+        },
+        {
+          "name": "order_execution_max_fee",
+          "type": {
+            "defined": {
+              "name": "WrappedI80F48"
+            }
+          }
+        }
+      ],
+      "discriminator": [
+        82,
+        48,
+        247,
+        59,
+        220,
+        109,
+        231,
+        44
+      ],
+      "docs": [
+        "(Runs once per program) Configures the fee state account, where the global admin sets fees",
+        "that are assessed to the protocol"
+      ],
+      "name": "init_global_fee_state"
+    },
+    {
+      "accounts": [
+        {
+          "name": "marginfi_group"
+        },
+        {
+          "name": "admin",
+          "relations": [
+            "marginfi_group"
+          ],
+          "signer": true
+        },
+        {
+          "docs": [
+            "Pays the init fee"
+          ],
+          "name": "fee_payer",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "name": "staked_settings",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  116,
+                  97,
+                  107,
+                  101,
+                  100,
+                  95,
+                  115,
+                  101,
+                  116,
+                  116,
+                  105,
+                  110,
+                  103,
+                  115
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "marginfi_group"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "settings",
+          "type": {
+            "defined": {
+              "name": "StakedSettingsConfig"
+            }
+          }
+        }
+      ],
+      "discriminator": [
+        52,
+        35,
+        149,
+        44,
+        69,
+        86,
+        69,
+        80
+      ],
+      "docs": [
+        "(group admin only) Init the Staked Settings account, which is used to create staked",
+        "collateral banks, and must run before any staked collateral bank can be created with",
+        "`add_pool_permissionless`. Running this ix effectively opts the group into the staked",
+        "collateral feature."
+      ],
+      "name": "init_staked_settings"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "relations": [
+            "marginfi_account",
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "bank",
+          "writable": true
+        },
+        {
+          "docs": [
+            "Owned by authority, the source account for the token deposit."
+          ],
+          "name": "signer_token_account",
+          "writable": true
+        },
+        {
+          "docs": [
+            "The bank's liquidity vault authority PDA (acts as signer for JupLend CPIs).",
+            "NOTE: JupLend marks the signer as writable in their deposit instruction."
+          ],
+          "name": "liquidity_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "docs": [
+            "Bank liquidity vault (holds underlying mint and is used as depositor_token_account)."
+          ],
+          "name": "liquidity_vault",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "docs": [
+            "Underlying mint."
+          ],
+          "name": "mint",
+          "relations": [
+            "bank"
+          ]
+        },
+        {
+          "docs": [
+            "JupLend lending state account."
+          ],
+          "name": "integration_acc_1",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "docs": [
+            "JupLend fToken mint."
+          ],
+          "name": "f_token_mint",
+          "relations": [
+            "integration_acc_1"
+          ],
+          "writable": true
+        },
+        {
+          "docs": [
+            "Bank's fToken vault (validated via has_one on bank)."
+          ],
+          "name": "integration_acc_2",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "name": "lending_admin"
+        },
+        {
+          "name": "supply_token_reserves_liquidity",
+          "writable": true
+        },
+        {
+          "name": "lending_supply_position_on_liquidity",
+          "writable": true
+        },
+        {
+          "name": "rate_model"
+        },
+        {
+          "name": "vault",
+          "writable": true
+        },
+        {
+          "name": "liquidity",
+          "writable": true
+        },
+        {
+          "name": "liquidity_program"
+        },
+        {
+          "name": "rewards_rate_model"
+        },
+        {
+          "address": "jup3YeL8QhtSx1e253b2FDvsMNC87fDrgQZivbrndc9",
+          "name": "juplend_program"
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+          "name": "associated_token_program"
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ],
+      "discriminator": [
+        114,
+        11,
+        218,
+        81,
+        183,
+        165,
+        143,
+        255
+      ],
+      "docs": [
+        "(user) Deposit into a JupLend lending pool through a marginfi account.",
+        "* amount - in the underlying token (e.g., USDC), in native decimals"
+      ],
+      "name": "juplend_deposit"
+    },
+    {
+      "accounts": [
+        {
+          "docs": [
+            "Provides a nominal deposit amount."
+          ],
+          "name": "fee_payer",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "docs": [
+            "Token account owned by the fee payer holding the underlying mint."
+          ],
+          "name": "signer_token_account",
+          "writable": true
+        },
+        {
+          "name": "bank",
+          "writable": true
+        },
+        {
+          "docs": [
+            "The bank's liquidity vault authority PDA (acts as signer for JupLend CPIs)."
+          ],
+          "name": "liquidity_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "docs": [
+            "Bank liquidity vault (holds underlying mint and is used as depositor_token_account)."
+          ],
+          "name": "liquidity_vault",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "docs": [
+            "Underlying mint (must match bank mint and JupLend lending state mint)."
+          ],
+          "name": "mint",
+          "relations": [
+            "bank"
+          ]
+        },
+        {
+          "docs": [
+            "JupLend lending state account."
+          ],
+          "name": "integration_acc_1",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "docs": [
+            "JupLend fToken mint."
+          ],
+          "name": "f_token_mint",
+          "relations": [
+            "integration_acc_1"
+          ],
+          "writable": true
+        },
+        {
+          "docs": [
+            "Bank's fToken vault (validated via has_one on bank)."
+          ],
+          "name": "integration_acc_2",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "name": "lending_admin"
+        },
+        {
+          "name": "supply_token_reserves_liquidity",
+          "writable": true
+        },
+        {
+          "name": "lending_supply_position_on_liquidity",
+          "writable": true
+        },
+        {
+          "name": "rate_model"
+        },
+        {
+          "name": "vault",
+          "writable": true
+        },
+        {
+          "name": "liquidity",
+          "writable": true
+        },
+        {
+          "name": "liquidity_program"
+        },
+        {
+          "name": "rewards_rate_model"
+        },
+        {
+          "address": "jup3YeL8QhtSx1e253b2FDvsMNC87fDrgQZivbrndc9",
+          "name": "juplend_program"
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+          "name": "associated_token_program"
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ],
+      "discriminator": [
+        176,
+        255,
+        151,
+        106,
+        5,
+        207,
+        74,
+        215
+      ],
+      "docs": [
+        "(permissionless) Initialize the bank-level JupLend position.",
+        "",
+        "This creates the bank's fToken ATA (owned by the bank liquidity vault authority) and",
+        "performs a nominal seed deposit into JupLend, then flips the bank from `Paused` to",
+        "`Operational`."
+      ],
+      "name": "juplend_init_position"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "relations": [
+            "marginfi_account",
+            "bank"
+          ]
+        },
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "bank",
+          "writable": true
+        },
+        {
+          "docs": [
+            "Token account that will receive the underlying withdrawal.",
+            "WARN: Completely unchecked!"
+          ],
+          "name": "destination_token_account",
+          "writable": true
+        },
+        {
+          "docs": [
+            "The bank's liquidity vault authority PDA (acts as signer for JupLend CPIs).",
+            "NOTE: JupLend marks the signer as writable in their withdraw instruction."
+          ],
+          "name": "liquidity_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "docs": [
+            "Underlying mint."
+          ],
+          "name": "mint",
+          "relations": [
+            "bank"
+          ]
+        },
+        {
+          "docs": [
+            "JupLend lending state account."
+          ],
+          "name": "integration_acc_1",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "docs": [
+            "JupLend fToken mint."
+          ],
+          "name": "f_token_mint",
+          "relations": [
+            "integration_acc_1"
+          ],
+          "writable": true
+        },
+        {
+          "docs": [
+            "Bank's fToken vault (validated via has_one on bank)."
+          ],
+          "name": "integration_acc_2",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "docs": [
+            "Withdraw intermediary ATA (authority = liquidity_vault_authority).",
+            "This must be an ATA to satisfy JupLend's withdraw constraints."
+          ],
+          "name": "integration_acc_3",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "name": "lending_admin"
+        },
+        {
+          "name": "supply_token_reserves_liquidity",
+          "writable": true
+        },
+        {
+          "name": "lending_supply_position_on_liquidity",
+          "writable": true
+        },
+        {
+          "name": "rate_model"
+        },
+        {
+          "name": "vault",
+          "writable": true
+        },
+        {
+          "docs": [
+            "JupLend claim account for liquidity_vault_authority.",
+            "TEMPORARY: Mainnet currently requires this account (passing None causes ConstraintMut errors),",
+            "but an upcoming upgrade is expected to make it truly optional. The account is never actually",
+            "validated or used - you can pass any mutable account. We create the canonical PDA for consistency.",
+            "Seeds: [\"user_claim\", liquidity_vault_authority, mint] on Liquidity program."
+          ],
+          "name": "claim_account",
+          "writable": true
+        },
+        {
+          "name": "liquidity",
+          "writable": true
+        },
+        {
+          "name": "liquidity_program"
+        },
+        {
+          "name": "rewards_rate_model"
+        },
+        {
+          "address": "jup3YeL8QhtSx1e253b2FDvsMNC87fDrgQZivbrndc9",
+          "name": "juplend_program"
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+          "name": "associated_token_program"
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        },
+        {
+          "name": "withdraw_all",
+          "type": {
+            "option": "bool"
+          }
+        }
+      ],
+      "discriminator": [
+        245,
+        164,
+        253,
+        202,
+        53,
+        77,
+        251,
+        221
+      ],
+      "docs": [
+        "(user) Withdraw from a JupLend lending pool through a marginfi account.",
+        "* amount - in the underlying token (e.g., USDC), in native decimals"
+      ],
+      "name": "juplend_withdraw"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "relations": [
+            "marginfi_account",
+            "bank"
+          ]
+        },
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "bank",
+          "writable": true
+        },
+        {
+          "docs": [
+            "Owned by authority, the source account for the token deposit."
+          ],
+          "name": "signer_token_account",
+          "writable": true
+        },
+        {
+          "docs": [
+            "The bank's liquidity vault authority, which owns the Kamino obligation. Note: Kamino needs",
+            "this to be mut because `deposit` might return the rent here"
+          ],
+          "name": "liquidity_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "docs": [
+            "Used as an intermediary to deposit token into Kamino"
+          ],
+          "name": "liquidity_vault",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "name": "integration_acc_2",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "name": "lending_market"
+        },
+        {
+          "name": "lending_market_authority"
+        },
+        {
+          "docs": [
+            "The Kamino reserve that holds liquidity"
+          ],
+          "name": "integration_acc_1",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "docs": [
+            "Bank's liquidity token mint (e.g., USDC). Kamino calls this the `reserve_liquidity_mint`"
+          ],
+          "name": "mint",
+          "relations": [
+            "bank"
+          ]
+        },
+        {
+          "name": "reserve_liquidity_supply",
+          "writable": true
+        },
+        {
+          "docs": [
+            "The reserve's mint for tokenized representations of Kamino deposits."
+          ],
+          "name": "reserve_collateral_mint",
+          "writable": true
+        },
+        {
+          "docs": [
+            "The reserve's destination for tokenized representations of deposits. Note: the",
+            "`reserve_collateral_mint` will mint tokens directly to this account."
+          ],
+          "name": "reserve_destination_deposit_collateral",
+          "writable": true
+        },
+        {
+          "docs": [
+            "Required if the Kamino reserve has an active farm."
+          ],
+          "name": "obligation_farm_user_state",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "docs": [
+            "Required if the Kamino reserve has an active farm."
+          ],
+          "name": "reserve_farm_state",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "address": "KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD",
+          "name": "kamino_program"
+        },
+        {
+          "address": "FarmsPZpWu9i7Kky8tPN37rs2TpmMrAZrC7S7vJa91Hr",
+          "docs": [
+            "Farms program for Kamino staking functionality"
+          ],
+          "name": "farms_program"
+        },
+        {
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+          "name": "collateral_token_program"
+        },
+        {
+          "name": "liquidity_token_program"
+        },
+        {
+          "address": "Sysvar1nstructions1111111111111111111111111",
+          "name": "instruction_sysvar_account"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ],
+      "discriminator": [
+        237,
+        8,
+        188,
+        187,
+        115,
+        99,
+        49,
+        85
+      ],
+      "docs": [
+        "(user) Deposit into a Kamino pool through a marginfi account",
+        "* amount - in the liquidity token (e.g. if there is a Kamino USDC bank, pass the amount of",
+        "USDC desired), in native decimals."
+      ],
+      "name": "kamino_deposit"
+    },
+    {
+      "accounts": [
+        {
+          "name": "bank"
+        },
+        {
+          "docs": [
+            "Global fee state that contains the global_fee_admin"
+          ],
+          "name": "fee_state",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  101,
+                  101,
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "docs": [
+            "Destination token account must be owned by the global fee admin"
+          ],
+          "name": "destination_token_account",
+          "pda": {
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            },
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "fee_state"
+              },
+              {
+                "kind": "account",
+                "path": "token_program"
+              },
+              {
+                "kind": "account",
+                "path": "reward_mint"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "docs": [
+            "The bank's liquidity vault authority, which owns the Kamino obligation."
+          ],
+          "name": "liquidity_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "name": "user_state",
+          "writable": true
+        },
+        {
+          "name": "farm_state",
+          "writable": true
+        },
+        {
+          "name": "global_config"
+        },
+        {
+          "name": "reward_mint"
+        },
+        {
+          "docs": [
+            "An initialized ATA of type reward mint owned by liquidity vault"
+          ],
+          "name": "user_reward_ata",
+          "writable": true
+        },
+        {
+          "name": "rewards_vault",
+          "writable": true
+        },
+        {
+          "name": "rewards_treasury_vault",
+          "writable": true
+        },
+        {
+          "name": "farm_vaults_authority"
+        },
+        {
+          "name": "scope_prices",
+          "optional": true
+        },
+        {
+          "address": "FarmsPZpWu9i7Kky8tPN37rs2TpmMrAZrC7S7vJa91Hr",
+          "name": "farms_program"
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "reward_index",
+          "type": "u64"
+        }
+      ],
+      "discriminator": [
+        163,
+        202,
+        248,
+        141,
+        106,
+        20,
+        116,
+        5
+      ],
+      "docs": [
+        "(permissionless) Harvest the specified reward index from the Kamino Farm attached to this",
+        "bank. Rewards are always sent to the global fee wallet's canonical ATA.",
+        "",
+        "* `reward_index` — index of the reward token in the Kamino Farm's reward list"
+      ],
+      "name": "kamino_harvest_reward"
+    },
+    {
+      "accounts": [
+        {
+          "docs": [
+            "Pays to init the obligation and pays a nominal amount to ensure the obligation has a",
+            "non-zero balance."
+          ],
+          "name": "fee_payer",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "name": "bank"
+        },
+        {
+          "docs": [
+            "The fee payer must provide a nominal amount of bank tokens so the obligation is not empty.",
+            "This amount is irrecoverable and and will prevent the obligation from ever being closed,",
+            "even if the bank is otherwise empty (Kamino normally closes empty obligations automatically)"
+          ],
+          "name": "signer_token_account",
+          "writable": true
+        },
+        {
+          "docs": [
+            "The liquidity vault authority (PDA that will own the Kamino obligation). Note: Kamino needs",
+            "this to be mut because `deposit` might return the rent here"
+          ],
+          "name": "liquidity_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "docs": [
+            "Used as an intermediary to deposit a nominal amount of token into the obligation."
+          ],
+          "name": "liquidity_vault",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "docs": [
+            "The obligation account to be created. Note that the key was already derived when",
+            "initializing the bank, and this must match the obligation recorded at that time."
+          ],
+          "name": "integration_acc_2",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "name": "user_metadata",
+          "writable": true
+        },
+        {
+          "name": "lending_market"
+        },
+        {
+          "name": "lending_market_authority"
+        },
+        {
+          "name": "integration_acc_1",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "docs": [
+            "Bank's liquidity token mint (e.g., USDC). Kamino calls this the `reserve_liquidity_mint`"
+          ],
+          "name": "mint",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "name": "reserve_liquidity_supply",
+          "writable": true
+        },
+        {
+          "docs": [
+            "The reserve's mint for tokenized representations of Kamino deposits."
+          ],
+          "name": "reserve_collateral_mint",
+          "writable": true
+        },
+        {
+          "docs": [
+            "The reserve's destination for tokenized representations of deposits. Note: the",
+            "`reserve_collateral_mint` will mint tokens directly to this account."
+          ],
+          "name": "reserve_destination_deposit_collateral",
+          "writable": true
+        },
+        {
+          "name": "pyth_oracle",
+          "optional": true
+        },
+        {
+          "name": "switchboard_price_oracle",
+          "optional": true
+        },
+        {
+          "name": "switchboard_twap_oracle",
+          "optional": true
+        },
+        {
+          "name": "scope_prices",
+          "optional": true
+        },
+        {
+          "docs": [
+            "Required if the Kamino reserve has an active farm."
+          ],
+          "name": "obligation_farm_user_state",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "docs": [
+            "Required if the Kamino reserve has an active farm."
+          ],
+          "name": "reserve_farm_state",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "address": "KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD",
+          "name": "kamino_program"
+        },
+        {
+          "address": "FarmsPZpWu9i7Kky8tPN37rs2TpmMrAZrC7S7vJa91Hr",
+          "docs": [
+            "Farms program for Kamino staking functionality"
+          ],
+          "name": "farms_program"
+        },
+        {
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+          "docs": [
+            "Note: the collateral token always uses Token classic, never Token22."
+          ],
+          "name": "collateral_token_program"
+        },
+        {
+          "docs": [
+            "Note: Kamino does not have full Token22 support, certain Token22 features are disallowed.",
+            "Expect this to update over time. Check with the Kamino source."
+          ],
+          "name": "liquidity_token_program"
+        },
+        {
+          "address": "Sysvar1nstructions1111111111111111111111111",
+          "name": "instruction_sysvar_account"
+        },
+        {
+          "address": "SysvarRent111111111111111111111111111111111",
+          "name": "rent"
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ],
+      "discriminator": [
+        253,
+        177,
+        160,
+        225,
+        70,
+        156,
+        217,
+        109
+      ],
+      "docs": [
+        "(permissionless) Initialize a Kamino obligation for a marginfi bank",
+        "* amount - In token, in native decimals. Must be >10 (i.e. 10 lamports, not 10 tokens). Lost",
+        "forever. Generally, try to make this the equivalent of around $1, in case Kamino ever",
+        "rounds small balances down to zero."
+      ],
+      "name": "kamino_init_obligation"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "relations": [
+            "marginfi_account",
+            "bank"
+          ]
+        },
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "bank",
+          "writable": true
+        },
+        {
+          "docs": [
+            "Token account that will receive the withdrawn tokens. Mint/owner are validated by the",
+            "SPL transfer; the caller controls the destination."
+          ],
+          "name": "destination_token_account",
+          "writable": true
+        },
+        {
+          "name": "liquidity_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "name": "liquidity_vault",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "name": "integration_acc_2",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "docs": [
+            "The Kamino lending market"
+          ],
+          "name": "lending_market"
+        },
+        {
+          "docs": [
+            "The Kamino lending market authority"
+          ],
+          "name": "lending_market_authority"
+        },
+        {
+          "docs": [
+            "The Kamino reserve that holds liquidity"
+          ],
+          "name": "integration_acc_1",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "docs": [
+            "The liquidity token mint (e.g., USDC)",
+            "Needs serde to get the mint decimals for transfer checked",
+            "TODO: rename to just 'mint' to make use of has_one and to be consistent with deposit"
+          ],
+          "name": "mint",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "docs": [
+            "The reserve's liquidity supply account"
+          ],
+          "name": "reserve_liquidity_supply",
+          "writable": true
+        },
+        {
+          "docs": [
+            "The reserve's collateral mint"
+          ],
+          "name": "reserve_collateral_mint",
+          "writable": true
+        },
+        {
+          "docs": [
+            "The reserve's source for collateral tokens"
+          ],
+          "name": "reserve_source_collateral",
+          "writable": true
+        },
+        {
+          "docs": [
+            "Optional farms accounts for Kamino staking functionality"
+          ],
+          "name": "obligation_farm_user_state",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "name": "reserve_farm_state",
+          "optional": true,
+          "writable": true
+        },
+        {
+          "address": "KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD",
+          "name": "kamino_program"
+        },
+        {
+          "address": "FarmsPZpWu9i7Kky8tPN37rs2TpmMrAZrC7S7vJa91Hr",
+          "docs": [
+            "Farms program for Kamino staking functionality"
+          ],
+          "name": "farms_program"
+        },
+        {
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+          "docs": [
+            "The token program for the collateral token"
+          ],
+          "name": "collateral_token_program"
+        },
+        {
+          "docs": [
+            "The token program for the liquidity token"
+          ],
+          "name": "liquidity_token_program"
+        },
+        {
+          "address": "Sysvar1nstructions1111111111111111111111111",
+          "docs": [
+            "Used by kamino validate CPI calls"
+          ],
+          "name": "instruction_sysvar_account"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        },
+        {
+          "name": "withdraw_all",
+          "type": {
+            "option": "bool"
+          }
+        }
+      ],
+      "discriminator": [
+        199,
+        101,
+        41,
+        45,
+        213,
+        98,
+        224,
+        200
+      ],
+      "docs": [
+        "(user) Withdraw from a Kamino pool through a marginfi account",
+        "* amount - in the collateral token (NOT liquidity token), in native decimals. Must convert",
+        "from collateral to liquidity token amounts using the current exchange rate.",
+        "* withdraw_all - if true, withdraw the entire mrgn balance (Note: due to rounding down, a",
+        "deposit and withdraw back to back may result in several lamports less)"
+      ],
+      "name": "kamino_withdraw"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "relations": [
+            "marginfi_account",
+            "bank"
+          ]
+        },
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "bank",
+          "writable": true
+        },
+        {
+          "name": "destination_token_account",
+          "writable": true
+        },
+        {
+          "name": "bank_liquidity_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_vault",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ],
+      "discriminator": [
+        4,
+        126,
+        116,
+        53,
+        48,
+        5,
+        212,
+        31
+      ],
+      "docs": [
+        "(account authority) Borrow assets from a bank. Accrues interest, records liability, applies",
+        "origination fee, transfers tokens, and runs a health check."
+      ],
+      "name": "lending_account_borrow"
+    },
+    {
+      "accounts": [
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "bank"
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        239,
+        4,
+        221,
+        98,
+        45,
+        167,
+        201,
+        244
+      ],
+      "docs": [
+        "(permissionless) Zero out `emissions_outstanding` on a balance after emissions are disabled",
+        "on the bank."
+      ],
+      "name": "lending_account_clear_emissions"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "relations": [
+            "marginfi_account",
+            "bank"
+          ]
+        },
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "bank",
+          "writable": true
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        245,
+        54,
+        41,
+        4,
+        243,
+        202,
+        31,
+        17
+      ],
+      "docs": [
+        "(account authority) Close a balance position with dust-level amounts."
+      ],
+      "name": "lending_account_close_balance"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "relations": [
+            "marginfi_account",
+            "bank"
+          ]
+        },
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "bank",
+          "writable": true
+        },
+        {
+          "name": "signer_token_account",
+          "writable": true
+        },
+        {
+          "name": "liquidity_vault",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        },
+        {
+          "name": "deposit_up_to_limit",
+          "type": {
+            "option": "bool"
+          }
+        }
+      ],
+      "discriminator": [
+        171,
+        94,
+        235,
+        103,
+        82,
+        64,
+        212,
+        140
+      ],
+      "docs": [
+        "(account authority) Deposit assets into a bank. Accrues interest, records deposit, and",
+        "transfers tokens from the signer's token account to the bank's liquidity vault."
+      ],
+      "name": "lending_account_deposit"
+    },
+    {
+      "accounts": [
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "relations": [
+            "marginfi_account"
+          ],
+          "signer": true
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        105,
+        124,
+        201,
+        106,
+        153,
+        2,
+        8,
+        156
+      ],
+      "docs": [
+        "(account authority) End a flash loan and run the health check."
+      ],
+      "name": "lending_account_end_flashloan"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "relations": [
+            "asset_bank",
+            "liab_bank",
+            "liquidator_marginfi_account",
+            "liquidatee_marginfi_account"
+          ]
+        },
+        {
+          "name": "asset_bank",
+          "writable": true
+        },
+        {
+          "name": "liab_bank",
+          "writable": true
+        },
+        {
+          "name": "liquidator_marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "liquidatee_marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "bank_liquidity_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liab_bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "bank_liquidity_vault",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liab_bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "name": "bank_insurance_vault",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  105,
+                  110,
+                  115,
+                  117,
+                  114,
+                  97,
+                  110,
+                  99,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liab_bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "asset_amount",
+          "type": "u64"
+        },
+        {
+          "name": "liquidatee_accounts",
+          "type": "u8"
+        },
+        {
+          "name": "liquidator_accounts",
+          "type": "u8"
+        }
+      ],
+      "discriminator": [
+        214,
+        169,
+        151,
+        213,
+        251,
+        167,
+        86,
+        219
+      ],
+      "docs": [
+        "(permissionless) Liquidate a lending account balance of an unhealthy marginfi account.",
+        "The liquidator takes on the liability and receives discounted collateral (2.5% liquidator",
+        "fee + 2.5% insurance fee).",
+        "* `asset_amount` - amount of collateral to liquidate",
+        "* `liquidatee_accounts` - number of remaining accounts for the liquidatee",
+        "* `liquidator_accounts` - number of remaining accounts for the liquidator"
+      ],
+      "name": "lending_account_liquidate"
+    },
+    {
+      "accounts": [
+        {
+          "name": "marginfi_account",
+          "writable": true
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        186,
+        52,
+        117,
+        97,
+        34,
+        74,
+        39,
+        253
+      ],
+      "docs": [
+        "(Permissionless) Refresh the internal risk engine health cache. Useful for liquidators and",
+        "other consumers that want to see the internal risk state of a user account. This cache is",
+        "read-only and serves no purpose except being populated by this ix.",
+        "* remaining accounts expected in the same order as borrow, etc. I.e., for each balance the",
+        "user has, pass bank and oracle: <bank1, oracle1, bank2, oracle2>"
+      ],
+      "name": "lending_account_pulse_health"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "relations": [
+            "marginfi_account",
+            "bank"
+          ]
+        },
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "docs": [
+            "Must be marginfi_account's authority, unless in liquidation/deleverage receivership or order execution",
+            "",
+            "Note: during receivership and order execution, there are no signer checks whatsoever: any key can repay as",
+            "long as the invariants checked at the end of execution are met."
+          ],
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "bank",
+          "writable": true
+        },
+        {
+          "name": "signer_token_account",
+          "writable": true
+        },
+        {
+          "name": "liquidity_vault",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        },
+        {
+          "name": "repay_all",
+          "type": {
+            "option": "bool"
+          }
+        }
+      ],
+      "discriminator": [
+        79,
+        209,
+        172,
+        177,
+        222,
+        51,
+        173,
+        151
+      ],
+      "docs": [
+        "(account authority, or any signer during receivership) Repay borrowed assets. Accrues",
+        "interest, records repayment, and transfers tokens to the bank's liquidity vault."
+      ],
+      "name": "lending_account_repay"
+    },
+    {
+      "accounts": [
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "relations": [
+            "marginfi_account"
+          ],
+          "signer": true
+        },
+        {
+          "address": "Sysvar1nstructions1111111111111111111111111",
+          "name": "ixs_sysvar"
+        }
+      ],
+      "args": [
+        {
+          "name": "end_index",
+          "type": "u64"
+        }
+      ],
+      "discriminator": [
+        14,
+        131,
+        33,
+        220,
+        81,
+        186,
+        180,
+        107
+      ],
+      "docs": [
+        "(account authority) Start a flash loan. Must have a corresponding `end_flashloan` ix in the",
+        "same tx. Health checks are skipped until the flash loan ends."
+      ],
+      "name": "lending_account_start_flashloan"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "relations": [
+            "marginfi_account",
+            "bank"
+          ]
+        },
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "docs": [
+            "Must be marginfi_account's authority, unless in liquidation/deleverage receivership or order execution",
+            "",
+            "Note: during receivership and order execution, there are no signer checks whatsoever: any key can repay as",
+            "long as the invariants checked at the end of execution are met."
+          ],
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "bank",
+          "writable": true
+        },
+        {
+          "name": "destination_token_account",
+          "writable": true
+        },
+        {
+          "name": "bank_liquidity_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_vault",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        },
+        {
+          "name": "withdraw_all",
+          "type": {
+            "option": "bool"
+          }
+        }
+      ],
+      "discriminator": [
+        36,
+        72,
+        74,
+        19,
+        210,
+        210,
+        192,
+        192
+      ],
+      "docs": [
+        "(account authority, or any signer during receivership) Withdraw assets from a bank. Accrues",
+        "interest, records withdrawal, transfers tokens, and runs a health check (skipped during",
+        "receivership)."
+      ],
+      "name": "lending_account_withdraw"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "relations": [
+            "bank"
+          ]
+        },
+        {
+          "name": "bank",
+          "writable": true
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        108,
+        201,
+        30,
+        87,
+        47,
+        65,
+        97,
+        188
+      ],
+      "docs": [
+        "(permissionless) Accrue interest on a bank, updating share values and collecting fees."
+      ],
+      "name": "lending_pool_accrue_bank_interest"
+    },
+    {
+      "accounts": [
+        {
+          "name": "marginfi_group",
+          "writable": true
+        },
+        {
+          "name": "admin",
+          "relations": [
+            "marginfi_group"
+          ],
+          "signer": true
+        },
+        {
+          "docs": [
+            "Pays to init accounts and pays `fee_state.bank_init_flat_sol_fee` lamports to the protocol"
+          ],
+          "name": "fee_payer",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "name": "fee_state",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  101,
+                  101,
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "global_fee_wallet",
+          "relations": [
+            "fee_state"
+          ],
+          "writable": true
+        },
+        {
+          "name": "bank_mint"
+        },
+        {
+          "name": "bank",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "name": "liquidity_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_vault",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "name": "insurance_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  105,
+                  110,
+                  115,
+                  117,
+                  114,
+                  97,
+                  110,
+                  99,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "insurance_vault",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  105,
+                  110,
+                  115,
+                  117,
+                  114,
+                  97,
+                  110,
+                  99,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "name": "fee_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  101,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "fee_vault",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  101,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "bank_config",
+          "type": {
+            "defined": {
+              "name": "BankConfigCompact"
+            }
+          }
+        }
+      ],
+      "discriminator": [
+        215,
+        68,
+        72,
+        78,
+        208,
+        218,
+        103,
+        182
+      ],
+      "docs": [
+        "(admin only) Add a new bank to the lending pool"
+      ],
+      "name": "lending_pool_add_bank"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "writable": true
+        },
+        {
+          "name": "admin",
+          "relations": [
+            "group"
+          ],
+          "signer": true
+        },
+        {
+          "name": "fee_payer",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "docs": [
+            "Must match the mint used by `integration_acc_1`"
+          ],
+          "name": "bank_mint"
+        },
+        {
+          "name": "bank",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "group"
+              },
+              {
+                "kind": "account",
+                "path": "bank_mint"
+              },
+              {
+                "kind": "arg",
+                "path": "bank_seed"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "docs": [
+            "Drift spot market account that must match the bank mint"
+          ],
+          "name": "integration_acc_1"
+        },
+        {
+          "docs": [
+            "Drift user account for the marginfi program (derived from liquidity_vault_authority)"
+          ],
+          "name": "integration_acc_2",
+          "pda": {
+            "program": {
+              "kind": "const",
+              "value": [
+                9,
+                84,
+                219,
+                190,
+                158,
+                201,
+                96,
+                201,
+                138,
+                122,
+                41,
+                63,
+                226,
+                19,
+                54,
+                150,
+                111,
+                225,
+                128,
+                209,
+                81,
+                174,
+                75,
+                129,
+                121,
+                86,
+                31,
+                137,
+                133,
+                74,
+                83,
+                246
+              ]
+            },
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  117,
+                  115,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_vault_authority"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  0,
+                  0
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "docs": [
+            "Drift user stats account for the marginfi program (derived from liquidity_vault_authority)"
+          ],
+          "name": "integration_acc_3",
+          "pda": {
+            "program": {
+              "kind": "const",
+              "value": [
+                9,
+                84,
+                219,
+                190,
+                158,
+                201,
+                96,
+                201,
+                138,
+                122,
+                41,
+                63,
+                226,
+                19,
+                54,
+                150,
+                111,
+                225,
+                128,
+                209,
+                81,
+                174,
+                75,
+                129,
+                121,
+                86,
+                31,
+                137,
+                133,
+                74,
+                83,
+                246
+              ]
+            },
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  117,
+                  115,
+                  101,
+                  114,
+                  95,
+                  115,
+                  116,
+                  97,
+                  116,
+                  115
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_vault_authority"
+              }
+            ]
+          }
+        },
+        {
+          "docs": [
+            "Will be authority of the bank's liquidity vault. Used as intermediary for deposits/withdraws"
+          ],
+          "name": "liquidity_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "docs": [
+            "For Drift banks, the `liquidity_vault` never holds assets, but is instead used as an",
+            "intermediary when depositing/withdrawing, e.g., withdrawn funds move from Drift -> here ->",
+            "the user's token account."
+          ],
+          "name": "liquidity_vault",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "docs": [
+            "Note: Currently does nothing."
+          ],
+          "name": "insurance_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  105,
+                  110,
+                  115,
+                  117,
+                  114,
+                  97,
+                  110,
+                  99,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "docs": [
+            "Note: Currently does nothing."
+          ],
+          "name": "insurance_vault",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  105,
+                  110,
+                  115,
+                  117,
+                  114,
+                  97,
+                  110,
+                  99,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "docs": [
+            "Note: Currently does nothing."
+          ],
+          "name": "fee_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  101,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "docs": [
+            "Note: Currently does nothing."
+          ],
+          "name": "fee_vault",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  101,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "bank_config",
+          "type": {
+            "defined": {
+              "name": "DriftConfigCompact"
+            }
+          }
+        },
+        {
+          "name": "bank_seed",
+          "type": "u64"
+        }
+      ],
+      "discriminator": [
+        62,
+        63,
+        49,
+        48,
+        76,
+        55,
+        108,
+        155
+      ],
+      "docs": [
+        "(group admin only) Add a Drift bank to the group."
+      ],
+      "name": "lending_pool_add_bank_drift"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "writable": true
+        },
+        {
+          "name": "admin",
+          "relations": [
+            "group"
+          ],
+          "signer": true
+        },
+        {
+          "name": "fee_payer",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "docs": [
+            "Must match the mint used by the JupLend lending state."
+          ],
+          "name": "bank_mint"
+        },
+        {
+          "name": "bank",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "group"
+              },
+              {
+                "kind": "account",
+                "path": "bank_mint"
+              },
+              {
+                "kind": "arg",
+                "path": "bank_seed"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "docs": [
+            "JupLend lending state account that must match the bank mint."
+          ],
+          "name": "integration_acc_1"
+        },
+        {
+          "docs": [
+            "Will be authority of the bank's liquidity vault. Used as intermediary for deposits/withdraws."
+          ],
+          "name": "liquidity_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "docs": [
+            "For JupLend banks, the `liquidity_vault` is used as an intermediary when depositing/",
+            "withdrawing, e.g., withdrawn funds move from JupLend -> here -> the user's token account."
+          ],
+          "name": "liquidity_vault",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "docs": [
+            "Note: Currently does nothing."
+          ],
+          "name": "insurance_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  105,
+                  110,
+                  115,
+                  117,
+                  114,
+                  97,
+                  110,
+                  99,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "docs": [
+            "Note: Currently does nothing."
+          ],
+          "name": "insurance_vault",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  105,
+                  110,
+                  115,
+                  117,
+                  114,
+                  97,
+                  110,
+                  99,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "name": "fee_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  101,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "fee_vault",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  101,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "name": "f_token_mint",
+          "relations": [
+            "integration_acc_1"
+          ]
+        },
+        {
+          "docs": [
+            "The bank's fToken vault holds the fTokens received when depositing into JupLend.",
+            ""
+          ],
+          "name": "integration_acc_2",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  95,
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "docs": [
+            "Token program for both underlying mint and fToken mint (SPL Token or Token-2022).",
+            "JupLend creates fToken mints using the same token program as the underlying."
+          ],
+          "name": "token_program"
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "bank_config",
+          "type": {
+            "defined": {
+              "name": "JuplendConfigCompact"
+            }
+          }
+        },
+        {
+          "name": "bank_seed",
+          "type": "u64"
+        }
+      ],
+      "discriminator": [
+        18,
+        208,
+        117,
+        90,
+        53,
+        111,
+        195,
+        41
+      ],
+      "docs": [
+        "(admin) Add a JupLend bank to the marginfi group.",
+        "",
+        "Remaining accounts (for oracle validation):",
+        "0. underlying oracle feed (pyth push or switchboard pull)",
+        "1. JupLend `Lending` state"
+      ],
+      "name": "lending_pool_add_bank_juplend"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "writable": true
+        },
+        {
+          "name": "admin",
+          "relations": [
+            "group"
+          ],
+          "signer": true
+        },
+        {
+          "name": "fee_payer",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "docs": [
+            "Must match the mint used by the Kamino reserve (integration_acc_1), Kamino calls this the",
+            "`reserve_liquidity_mint` aka `liquidity.mint_pubkey`"
+          ],
+          "name": "bank_mint"
+        },
+        {
+          "name": "bank",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "group"
+              },
+              {
+                "kind": "account",
+                "path": "bank_mint"
+              },
+              {
+                "kind": "arg",
+                "path": "bank_seed"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "name": "integration_acc_1"
+        },
+        {
+          "docs": [
+            "Note: not yet initialized in this instruction, run `init_obligation` after."
+          ],
+          "name": "integration_acc_2"
+        },
+        {
+          "docs": [
+            "Will be authority of the bank's Kamino obligation (integration_acc_2). Note: When",
+            "depositing/withdrawing Kamino assets, the source/destination must also be owned by the",
+            "obligation authority.",
+            "Kamino assets, the source/destination must also be owned by the obligation authority. This",
+            "account owns the `liquidity_vault`, and thus acts as intermediary for deposits/withdraws"
+          ],
+          "name": "liquidity_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "docs": [
+            "For Kamino banks, the `liquidity_vault` never holds assets, but is instead used as an",
+            "intermediary when depositing/withdrawing, e.g., withdrawn funds move from Kamino -> here ->",
+            "the user's token account."
+          ],
+          "name": "liquidity_vault",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "docs": [
+            "Note: Currently does nothing."
+          ],
+          "name": "insurance_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  105,
+                  110,
+                  115,
+                  117,
+                  114,
+                  97,
+                  110,
+                  99,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "docs": [
+            "Note: Currently does nothing."
+          ],
+          "name": "insurance_vault",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  105,
+                  110,
+                  115,
+                  117,
+                  114,
+                  97,
+                  110,
+                  99,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "docs": [
+            "Note: Currently does nothing."
+          ],
+          "name": "fee_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  101,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "docs": [
+            "Note: Currently does nothing."
+          ],
+          "name": "fee_vault",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  101,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "bank_config",
+          "type": {
+            "defined": {
+              "name": "KaminoConfigCompact"
+            }
+          }
+        },
+        {
+          "name": "bank_seed",
+          "type": "u64"
+        }
+      ],
+      "discriminator": [
+        118,
+        53,
+        16,
+        243,
+        255,
+        245,
+        149,
+        241
+      ],
+      "docs": [
+        "(group admin only) Add a Kamino bank to the group. Pass the oracle and reserve in remaining",
+        "accounts 0 and 1 respectively."
+      ],
+      "name": "lending_pool_add_bank_kamino"
+    },
+    {
+      "accounts": [
+        {
+          "name": "marginfi_group",
+          "relations": [
+            "staked_settings"
+          ],
+          "writable": true
+        },
+        {
+          "name": "staked_settings"
+        },
+        {
+          "name": "fee_payer",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "docs": [
+            "Mint of the spl-single-pool LST (a PDA derived from `stake_pool`)",
+            "",
+            "because the sol_pool and stake_pool will not derive to a valid PDA which is also owned by",
+            "the staking program and spl-single-pool program."
+          ],
+          "name": "bank_mint"
+        },
+        {
+          "name": "sol_pool"
+        },
+        {
+          "docs": [
+            "this key.",
+            "",
+            "If derives the same `bank_mint`, then this must be the correct stake pool for that mint, and",
+            "we can subsequently use it to validate the `sol_pool`"
+          ],
+          "name": "stake_pool"
+        },
+        {
+          "name": "bank",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "marginfi_group"
+              },
+              {
+                "kind": "account",
+                "path": "bank_mint"
+              },
+              {
+                "kind": "arg",
+                "path": "bank_seed"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "name": "liquidity_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_vault",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "name": "insurance_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  105,
+                  110,
+                  115,
+                  117,
+                  114,
+                  97,
+                  110,
+                  99,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "insurance_vault",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  105,
+                  110,
+                  115,
+                  117,
+                  114,
+                  97,
+                  110,
+                  99,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "name": "fee_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  101,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "fee_vault",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  101,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "bank_seed",
+          "type": "u64"
+        }
+      ],
+      "discriminator": [
+        127,
+        187,
+        121,
+        34,
+        187,
+        167,
+        238,
+        102
+      ],
+      "docs": [
+        "(permissionless) Add a staked collateral bank. Requires a valid SPL single-pool LST mint."
+      ],
+      "name": "lending_pool_add_bank_permissionless"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "writable": true
+        },
+        {
+          "name": "admin",
+          "relations": [
+            "group"
+          ],
+          "signer": true
+        },
+        {
+          "name": "fee_payer",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "docs": [
+            "Must match the mint used by `integration_acc_1`, Solend calls this the `liquidity.mint_pubkey`"
+          ],
+          "name": "bank_mint"
+        },
+        {
+          "name": "bank",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "group"
+              },
+              {
+                "kind": "account",
+                "path": "bank_mint"
+              },
+              {
+                "kind": "arg",
+                "path": "bank_seed"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "docs": [
+            "Solend reserve account that must match the bank mint"
+          ],
+          "name": "integration_acc_1"
+        },
+        {
+          "docs": [
+            "Obligation PDA for this bank in Solend",
+            "Will be initialized and transferred to Solend in init_obligation instruction"
+          ],
+          "name": "integration_acc_2",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  111,
+                  108,
+                  101,
+                  110,
+                  100,
+                  95,
+                  111,
+                  98,
+                  108,
+                  105,
+                  103,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "docs": [
+            "Will be authority of the bank's liquidity vault. Used as intermediary for deposits/withdraws"
+          ],
+          "name": "liquidity_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "docs": [
+            "For Solend banks, the `liquidity_vault` never holds assets, but is instead used as an",
+            "intermediary when depositing/withdrawing, e.g., withdrawn funds move from Solend -> here ->",
+            "the user's token account."
+          ],
+          "name": "liquidity_vault",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "docs": [
+            "Note: Currently does nothing."
+          ],
+          "name": "insurance_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  105,
+                  110,
+                  115,
+                  117,
+                  114,
+                  97,
+                  110,
+                  99,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "docs": [
+            "Note: Currently does nothing."
+          ],
+          "name": "insurance_vault",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  105,
+                  110,
+                  115,
+                  117,
+                  114,
+                  97,
+                  110,
+                  99,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "docs": [
+            "Note: Currently does nothing."
+          ],
+          "name": "fee_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  101,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "docs": [
+            "Note: Currently does nothing."
+          ],
+          "name": "fee_vault",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  101,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "bank_config",
+          "type": {
+            "defined": {
+              "name": "SolendConfigCompact"
+            }
+          }
+        },
+        {
+          "name": "bank_seed",
+          "type": "u64"
+        }
+      ],
+      "discriminator": [
+        81,
+        233,
+        203,
+        199,
+        47,
+        226,
+        0,
+        68
+      ],
+      "docs": [
+        "(admin) Add a Solend bank to the marginfi group"
+      ],
+      "name": "lending_pool_add_bank_solend"
+    },
+    {
+      "accounts": [
+        {
+          "name": "marginfi_group",
+          "writable": true
+        },
+        {
+          "name": "admin",
+          "relations": [
+            "marginfi_group"
+          ],
+          "signer": true
+        },
+        {
+          "docs": [
+            "Pays to init accounts and pays `fee_state.bank_init_flat_sol_fee` lamports to the protocol"
+          ],
+          "name": "fee_payer",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "name": "fee_state",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  101,
+                  101,
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "global_fee_wallet",
+          "relations": [
+            "fee_state"
+          ],
+          "writable": true
+        },
+        {
+          "name": "bank_mint"
+        },
+        {
+          "name": "bank",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "marginfi_group"
+              },
+              {
+                "kind": "account",
+                "path": "bank_mint"
+              },
+              {
+                "kind": "arg",
+                "path": "bank_seed"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "name": "liquidity_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_vault",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "name": "insurance_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  105,
+                  110,
+                  115,
+                  117,
+                  114,
+                  97,
+                  110,
+                  99,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "insurance_vault",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  105,
+                  110,
+                  115,
+                  117,
+                  114,
+                  97,
+                  110,
+                  99,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "name": "fee_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  101,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "fee_vault",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  101,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "bank_config",
+          "type": {
+            "defined": {
+              "name": "BankConfigCompact"
+            }
+          }
+        },
+        {
+          "name": "bank_seed",
+          "type": "u64"
+        }
+      ],
+      "discriminator": [
+        76,
+        211,
+        213,
+        171,
+        117,
+        78,
+        158,
+        76
+      ],
+      "docs": [
+        "(admin only) A copy of lending_pool_add_bank with an additional bank seed.",
+        "This seed is used to create a PDA for the bank's signature.",
+        "lending_pool_add_bank is preserved for backwards compatibility."
+      ],
+      "name": "lending_pool_add_bank_with_seed"
+    },
+    {
+      "accounts": [
+        {
+          "name": "marginfi_group",
+          "writable": true
+        },
+        {
+          "name": "admin",
+          "relations": [
+            "marginfi_group"
+          ],
+          "signer": true,
+          "writable": true
+        },
+        {
+          "name": "fee_payer",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "name": "bank_mint"
+        },
+        {
+          "docs": [
+            "Source bank to clone from mainnet program",
+            ""
+          ],
+          "name": "source_bank"
+        },
+        {
+          "name": "bank",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "marginfi_group"
+              },
+              {
+                "kind": "account",
+                "path": "bank_mint"
+              },
+              {
+                "kind": "arg",
+                "path": "bank_seed"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "name": "liquidity_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_vault",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "name": "insurance_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  105,
+                  110,
+                  115,
+                  117,
+                  114,
+                  97,
+                  110,
+                  99,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "insurance_vault",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  105,
+                  110,
+                  115,
+                  117,
+                  114,
+                  97,
+                  110,
+                  99,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "name": "fee_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  101,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "fee_vault",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  101,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "bank_seed",
+          "type": "u64"
+        }
+      ],
+      "discriminator": [
+        214,
+        93,
+        17,
+        236,
+        177,
+        228,
+        78,
+        17
+      ],
+      "docs": [
+        "(admin only) Staging or localnet only, panics on mainnet",
+        "This instruction is used to clone a bank to a new PDA."
+      ],
+      "name": "lending_pool_clone_bank"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "relations": [
+            "copy_from_bank",
+            "copy_to_bank"
+          ]
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "copy_from_bank"
+        },
+        {
+          "name": "copy_to_bank",
+          "writable": true
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        146,
+        167,
+        94,
+        106,
+        184,
+        202,
+        15,
+        10
+      ],
+      "docs": [
+        "(admin or emode_admin) Copies emode settings from one bank to another. Useful when applying",
+        "emode settings from e.g. one LST to another."
+      ],
+      "name": "lending_pool_clone_emode"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "name": "bank",
+          "writable": true
+        },
+        {
+          "name": "admin",
+          "relations": [
+            "group"
+          ],
+          "signer": true,
+          "writable": true
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        22,
+        115,
+        7,
+        130,
+        227,
+        85,
+        0,
+        47
+      ],
+      "docs": [
+        "(admin only) Close a bank. Requires CLOSE_ENABLED_FLAG and zero positions/shares."
+      ],
+      "name": "lending_pool_close_bank"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "relations": [
+            "bank"
+          ]
+        },
+        {
+          "name": "bank",
+          "writable": true
+        },
+        {
+          "name": "liquidity_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_vault",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "name": "insurance_vault",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  105,
+                  110,
+                  115,
+                  117,
+                  114,
+                  97,
+                  110,
+                  99,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "name": "fee_vault",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  101,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "name": "fee_state",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  101,
+                  101,
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "docs": [
+            "(validated in handler). Must already exist, may require initializing the ATA if it does not",
+            "already exist prior to this ix."
+          ],
+          "name": "fee_ata",
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        201,
+        5,
+        215,
+        116,
+        230,
+        92,
+        75,
+        150
+      ],
+      "docs": [
+        "(permissionless) Transfer accrued fees from the liquidity vault to insurance/fee/program",
+        "vaults."
+      ],
+      "name": "lending_pool_collect_bank_fees"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "relations": [
+            "bank"
+          ]
+        },
+        {
+          "name": "admin",
+          "relations": [
+            "group"
+          ],
+          "signer": true
+        },
+        {
+          "name": "bank",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "bank_config_opt",
+          "type": {
+            "defined": {
+              "name": "BankConfigOpt"
+            }
+          }
+        }
+      ],
+      "discriminator": [
+        121,
+        173,
+        156,
+        40,
+        93,
+        148,
+        56,
+        237
+      ],
+      "docs": [
+        "(admin only) Configure bank parameters. If the bank has `FREEZE_SETTINGS`, only",
+        "deposit/borrow limits are updated and all other config changes are silently ignored."
+      ],
+      "name": "lending_pool_configure_bank"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "relations": [
+            "bank"
+          ]
+        },
+        {
+          "name": "emode_admin",
+          "relations": [
+            "group"
+          ],
+          "signer": true
+        },
+        {
+          "name": "bank",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "emode_tag",
+          "type": "u16"
+        },
+        {
+          "name": "entries",
+          "type": {
+            "array": [
+              {
+                "defined": {
+                  "name": "EmodeEntry"
+                }
+              },
+              10
+            ]
+          }
+        }
+      ],
+      "discriminator": [
+        17,
+        175,
+        91,
+        57,
+        239,
+        86,
+        49,
+        71
+      ],
+      "docs": [
+        "(emode_admin only)"
+      ],
+      "name": "lending_pool_configure_bank_emode"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "relations": [
+            "bank"
+          ]
+        },
+        {
+          "name": "delegate_curve_admin",
+          "relations": [
+            "group"
+          ],
+          "signer": true
+        },
+        {
+          "name": "bank",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "interest_rate_config",
+          "type": {
+            "defined": {
+              "name": "InterestRateConfigOpt"
+            }
+          }
+        }
+      ],
+      "discriminator": [
+        245,
+        107,
+        83,
+        38,
+        103,
+        219,
+        163,
+        241
+      ],
+      "docs": [
+        "(delegate_curve_admin only) Update interest rate config. Does nothing if bank has",
+        "`FREEZE_SETTINGS`."
+      ],
+      "name": "lending_pool_configure_bank_interest_only"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "relations": [
+            "bank"
+          ]
+        },
+        {
+          "name": "delegate_limit_admin",
+          "relations": [
+            "group"
+          ],
+          "signer": true
+        },
+        {
+          "name": "bank",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "deposit_limit",
+          "type": {
+            "option": "u64"
+          }
+        },
+        {
+          "name": "borrow_limit",
+          "type": {
+            "option": "u64"
+          }
+        },
+        {
+          "name": "total_asset_value_init_limit",
+          "type": {
+            "option": "u64"
+          }
+        }
+      ],
+      "discriminator": [
+        157,
+        196,
+        221,
+        200,
+        202,
+        62,
+        84,
+        21
+      ],
+      "docs": [
+        "(delegate_limit_admin only) Update deposit/borrow/init limits only."
+      ],
+      "name": "lending_pool_configure_bank_limits_only"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "relations": [
+            "bank"
+          ]
+        },
+        {
+          "name": "admin",
+          "relations": [
+            "group"
+          ],
+          "signer": true
+        },
+        {
+          "name": "bank",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "setup",
+          "type": "u8"
+        },
+        {
+          "name": "oracle",
+          "type": "pubkey"
+        }
+      ],
+      "discriminator": [
+        209,
+        82,
+        255,
+        171,
+        124,
+        21,
+        71,
+        81
+      ],
+      "docs": [
+        "(admin only)"
+      ],
+      "name": "lending_pool_configure_bank_oracle"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "relations": [
+            "bank"
+          ]
+        },
+        {
+          "name": "risk_admin",
+          "relations": [
+            "group"
+          ],
+          "signer": true
+        },
+        {
+          "name": "bank",
+          "writable": true
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        15,
+        203,
+        147,
+        232,
+        199,
+        14,
+        231,
+        37
+      ],
+      "docs": [
+        "(risk_admin only) - Signals all of a bank's liability have been deleveraged. Used if a bank",
+        "still has liability dust after the risk admin has completed deleveraging all debts. The",
+        "risk admin is trusted not to execute this until all non-dust debts have been deleveraged."
+      ],
+      "name": "lending_pool_force_tokenless_repay_complete"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "relations": [
+            "bank",
+            "marginfi_account"
+          ]
+        },
+        {
+          "docs": [
+            "Must be risk_admin or admin, unless the bank has PERMISSIONLESS_BAD_DEBT_SETTLEMENT_FLAG",
+            "set, in which case any signer is accepted."
+          ],
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "bank",
+          "writable": true
+        },
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "liquidity_vault",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "name": "insurance_vault",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  105,
+                  110,
+                  115,
+                  117,
+                  114,
+                  97,
+                  110,
+                  99,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "name": "insurance_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  105,
+                  110,
+                  115,
+                  117,
+                  114,
+                  97,
+                  110,
+                  99,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        162,
+        11,
+        56,
+        139,
+        90,
+        128,
+        70,
+        173
+      ],
+      "docs": [
+        "(risk_admin or admin, unless `PERMISSIONLESS_BAD_DEBT_SETTLEMENT_FLAG` is set on the bank)",
+        "Handle bad debt of a bankrupt marginfi account for a given bank. Covers bad debt from the",
+        "insurance fund and socializes any remainder among depositors."
+      ],
+      "name": "lending_pool_handle_bankruptcy"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "relations": [
+            "bank"
+          ]
+        },
+        {
+          "name": "bank",
+          "writable": true
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        192,
+        19,
+        201,
+        135,
+        105,
+        203,
+        32,
+        222
+      ],
+      "docs": [
+        "(Permissionless) Refresh the cached oracle price for a bank."
+      ],
+      "name": "lending_pool_pulse_bank_price_cache"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "relations": [
+            "bank"
+          ]
+        },
+        {
+          "name": "bank",
+          "writable": true
+        },
+        {
+          "name": "emissions_mint"
+        },
+        {
+          "name": "emissions_auth",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  101,
+                  109,
+                  105,
+                  115,
+                  115,
+                  105,
+                  111,
+                  110,
+                  115,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  95,
+                  115,
+                  101,
+                  101,
+                  100
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              },
+              {
+                "kind": "account",
+                "path": "emissions_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "emissions_vault",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  101,
+                  109,
+                  105,
+                  115,
+                  115,
+                  105,
+                  111,
+                  110,
+                  115,
+                  95,
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  95,
+                  97,
+                  99,
+                  99,
+                  111,
+                  117,
+                  110,
+                  116,
+                  95,
+                  115,
+                  101,
+                  101,
+                  100
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              },
+              {
+                "kind": "account",
+                "path": "emissions_mint"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "name": "fee_state",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  101,
+                  101,
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "docs": [
+            "emissions mint (validated in handler)."
+          ],
+          "name": "destination_account",
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        206,
+        67,
+        186,
+        225,
+        41,
+        30,
+        95,
+        216
+      ],
+      "docs": [
+        "(permissionless) Reclaim all remaining tokens from the emissions vault",
+        "to the global fee wallet ATA, and disable emissions on the bank."
+      ],
+      "name": "lending_pool_reclaim_emissions_vault"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "relations": [
+            "bank"
+          ]
+        },
+        {
+          "name": "admin",
+          "relations": [
+            "group"
+          ],
+          "signer": true
+        },
+        {
+          "name": "bank",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "price",
+          "type": {
+            "defined": {
+              "name": "WrappedI80F48"
+            }
+          }
+        }
+      ],
+      "discriminator": [
+        28,
+        126,
+        127,
+        127,
+        60,
+        37,
+        211,
+        125
+      ],
+      "docs": [
+        "(admin only)"
+      ],
+      "name": "lending_pool_set_fixed_oracle_price"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "relations": [
+            "bank"
+          ]
+        },
+        {
+          "name": "bank",
+          "writable": true
+        },
+        {
+          "name": "admin",
+          "relations": [
+            "group"
+          ],
+          "signer": true
+        },
+        {
+          "docs": [
+            "Bank fees will be sent to this account which must be an ATA of the bank's mint."
+          ],
+          "name": "destination_account"
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        102,
+        4,
+        121,
+        243,
+        237,
+        110,
+        95,
+        13
+      ],
+      "docs": [
+        "(admin only) Set the destination wallet for permissionless fee withdrawals."
+      ],
+      "name": "lending_pool_update_fees_destination_account"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "relations": [
+            "bank"
+          ]
+        },
+        {
+          "name": "bank"
+        },
+        {
+          "name": "admin",
+          "relations": [
+            "group"
+          ],
+          "signer": true
+        },
+        {
+          "name": "fee_vault",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  101,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "name": "fee_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  101,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "dst_token_account",
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ],
+      "discriminator": [
+        92,
+        140,
+        215,
+        254,
+        170,
+        0,
+        83,
+        174
+      ],
+      "docs": [
+        "(admin only) Withdraw collected group fees from the fee vault."
+      ],
+      "name": "lending_pool_withdraw_fees"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "relations": [
+            "bank"
+          ]
+        },
+        {
+          "name": "bank"
+        },
+        {
+          "name": "fee_vault",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  101,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "name": "fee_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  101,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "fees_destination_account",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ],
+      "discriminator": [
+        57,
+        245,
+        1,
+        208,
+        130,
+        18,
+        145,
+        113
+      ],
+      "docs": [
+        "(permissionless) Withdraw group fees to the pre-configured `fees_destination_account`."
+      ],
+      "name": "lending_pool_withdraw_fees_permissionless"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "relations": [
+            "bank"
+          ]
+        },
+        {
+          "name": "bank"
+        },
+        {
+          "name": "admin",
+          "relations": [
+            "group"
+          ],
+          "signer": true
+        },
+        {
+          "name": "insurance_vault",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  105,
+                  110,
+                  115,
+                  117,
+                  114,
+                  97,
+                  110,
+                  99,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "name": "insurance_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  105,
+                  110,
+                  115,
+                  117,
+                  114,
+                  97,
+                  110,
+                  99,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "name": "dst_token_account",
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ],
+      "discriminator": [
+        108,
+        60,
+        60,
+        246,
+        104,
+        79,
+        159,
+        243
+      ],
+      "docs": [
+        "(admin only) Withdraw from the insurance vault."
+      ],
+      "name": "lending_pool_withdraw_insurance"
+    },
+    {
+      "accounts": [
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "relations": [
+            "marginfi_account"
+          ],
+          "signer": true
+        },
+        {
+          "name": "fee_payer",
+          "signer": true,
+          "writable": true
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        186,
+        221,
+        93,
+        34,
+        50,
+        97,
+        194,
+        241
+      ],
+      "docs": [
+        "(account authority) Close a marginfi account. Requires all balances to be empty and no",
+        "active flags (disabled, flashloan, receivership)."
+      ],
+      "name": "marginfi_account_close"
+    },
+    {
+      "accounts": [
+        {
+          "name": "marginfi_account",
+          "relations": [
+            "order"
+          ],
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "relations": [
+            "marginfi_account"
+          ],
+          "signer": true
+        },
+        {
+          "name": "order",
+          "writable": true
+        },
+        {
+          "name": "fee_recipient",
+          "writable": true
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        212,
+        223,
+        79,
+        182,
+        172,
+        183,
+        205,
+        237
+      ],
+      "docs": [
+        "(user) Close an existing Order, returning rent to the user"
+      ],
+      "name": "marginfi_account_close_order"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "relations": [
+            "marginfi_account"
+          ]
+        },
+        {
+          "docs": [
+            "The account owning the order"
+          ],
+          "name": "marginfi_account",
+          "relations": [
+            "order"
+          ],
+          "writable": true
+        },
+        {
+          "docs": [
+            "The executioner ☠️"
+          ],
+          "name": "executor",
+          "relations": [
+            "execute_record"
+          ],
+          "signer": true
+        },
+        {
+          "name": "fee_recipient",
+          "writable": true
+        },
+        {
+          "name": "order",
+          "relations": [
+            "execute_record"
+          ],
+          "writable": true
+        },
+        {
+          "docs": [
+            "This keeps track of the relevant state to be checked at the end of execution."
+          ],
+          "name": "execute_record",
+          "writable": true
+        },
+        {
+          "name": "fee_state",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  101,
+                  101,
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        115,
+        42,
+        20,
+        93,
+        121,
+        84,
+        178,
+        83
+      ],
+      "docs": [
+        "(permissionless keeper) End Order execution",
+        "* Closes the Order (keeper keeps the rent)",
+        "* Closes the borrow position involved in the Order, the lending position remains open",
+        "* User health must be \"unchanged\" (within Order requirements i.e. minus slippage). Keeper",
+        "may keep any slippage in excess of what was needed to complete the Order as profit.",
+        "* `StartExecuteOrder` must appear earlier in the tx",
+        "* Must appear last in the tx",
+        "* CPI is forbidden",
+        "* Returns rent for ephemeral accounts created during `StartExecuteOrder`"
+      ],
+      "name": "marginfi_account_end_execute_order"
+    },
+    {
+      "accounts": [
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "fee_payer",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "name": "liquidation_record",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  95,
+                  114,
+                  101,
+                  99,
+                  111,
+                  114,
+                  100
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "marginfi_account"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        236,
+        213,
+        238,
+        126,
+        147,
+        251,
+        164,
+        8
+      ],
+      "docs": [
+        "(permissionless) Initialize a liquidation record PDA for a marginfi account. The fee_payer",
+        "pays rent; the record is required for receivership liquidation."
+      ],
+      "name": "marginfi_account_init_liq_record"
+    },
+    {
+      "accounts": [
+        {
+          "name": "marginfi_group"
+        },
+        {
+          "name": "marginfi_account",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "fee_payer",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        43,
+        78,
+        61,
+        255,
+        148,
+        52,
+        249,
+        154
+      ],
+      "docs": [
+        "Initialize a marginfi account for a given group. The account is a fresh keypair, and must",
+        "sign. If you are a CPI caller, consider using `marginfi_account_initialize_pda` instead, or",
+        "create the account manually and use `transfer_to_new_account` to gift it to the owner you",
+        "wish."
+      ],
+      "name": "marginfi_account_initialize"
+    },
+    {
+      "accounts": [
+        {
+          "name": "marginfi_group"
+        },
+        {
+          "name": "marginfi_account",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  109,
+                  97,
+                  114,
+                  103,
+                  105,
+                  110,
+                  102,
+                  105,
+                  95,
+                  97,
+                  99,
+                  99,
+                  111,
+                  117,
+                  110,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "marginfi_group"
+              },
+              {
+                "kind": "account",
+                "path": "authority"
+              },
+              {
+                "kind": "arg",
+                "path": "account_index"
+              },
+              {
+                "kind": "arg",
+                "path": "third_party_id.unwrap_or(0)"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "fee_payer",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "address": "Sysvar1nstructions1111111111111111111111111",
+          "docs": [
+            "Instructions sysvar for CPI validation",
+            ""
+          ],
+          "name": "instructions_sysvar"
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "account_index",
+          "type": "u16"
+        },
+        {
+          "name": "third_party_id",
+          "type": {
+            "option": "u16"
+          }
+        }
+      ],
+      "discriminator": [
+        87,
+        177,
+        91,
+        80,
+        218,
+        119,
+        245,
+        31
+      ],
+      "docs": [
+        "The same as `marginfi_account_initialize`, except the created marginfi account uses a PDA",
+        "(Program Derived Address)",
+        "",
+        "seeds:",
+        "- marginfi_group",
+        "- authority: The account authority (owner)",
+        "- account_index: A u16 value to allow multiple accounts per authority",
+        "- third_party_id: Optional u16 for third-party tagging. Seeds < PDA_FREE_THRESHOLD can be",
+        "used freely. For a dedicated seed used by just your program (via CPI), contact us."
+      ],
+      "name": "marginfi_account_initialize_pda"
+    },
+    {
+      "accounts": [
+        {
+          "docs": [
+            "marginfi account was closed.",
+            "The ownership check is checked in the handler or/and type checks are made in the handler."
+          ],
+          "name": "marginfi_account",
+          "relations": [
+            "order"
+          ]
+        },
+        {
+          "name": "fee_recipient",
+          "writable": true
+        },
+        {
+          "name": "order",
+          "writable": true
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        128,
+        114,
+        71,
+        46,
+        194,
+        71,
+        186,
+        106
+      ],
+      "docs": [
+        "(permissionless keeper) Close an existing Order after the user account was closed, or it no",
+        "longer has the associated positions, or the user has executed",
+        "`marginfi_account_set_keeper_close_flags`. Keeper keeps the rent."
+      ],
+      "name": "marginfi_account_keeper_close_order"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "relations": [
+            "marginfi_account"
+          ]
+        },
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "fee_payer",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "relations": [
+            "marginfi_account"
+          ],
+          "signer": true
+        },
+        {
+          "name": "order",
+          "writable": true
+        },
+        {
+          "name": "fee_state",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  101,
+                  101,
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "global_fee_wallet",
+          "relations": [
+            "fee_state"
+          ],
+          "writable": true
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "bank_keys",
+          "type": {
+            "vec": "pubkey"
+          }
+        },
+        {
+          "name": "trigger",
+          "type": {
+            "defined": {
+              "name": "OrderTrigger"
+            }
+          }
+        }
+      ],
+      "discriminator": [
+        244,
+        112,
+        75,
+        138,
+        143,
+        108,
+        7,
+        186
+      ],
+      "docs": [
+        "(user) Create a new Order.",
+        "* bank_keys - Currently only two keys: the lending position and borrowing position in the",
+        "users's Balances for which the order is being placed",
+        "* trigger - the type of order (stop loss, take profit, or both), and the threshold at which",
+        "to trigger the order, in dollars"
+      ],
+      "name": "marginfi_account_place_order"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "relations": [
+            "marginfi_account"
+          ]
+        },
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "admin",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "frozen",
+          "type": "bool"
+        }
+      ],
+      "discriminator": [
+        199,
+        179,
+        231,
+        30,
+        138,
+        247,
+        110,
+        227
+      ],
+      "docs": [
+        "(admin only) Freeze or unfreeze a marginfi account. Frozen accounts can only be operated on",
+        "by the group admin."
+      ],
+      "name": "marginfi_account_set_freeze"
+    },
+    {
+      "accounts": [
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "relations": [
+            "marginfi_account"
+          ],
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "bank_keys_opt",
+          "type": {
+            "option": {
+              "vec": "pubkey"
+            }
+          }
+        }
+      ],
+      "discriminator": [
+        82,
+        163,
+        165,
+        222,
+        212,
+        255,
+        33,
+        210
+      ],
+      "docs": [
+        "(user) Purge flags from some balances, enabling a Keeper to call",
+        "`marginfi_account_keeper_close_order` on associated Orders. Typically, use",
+        "`marginfi_account_close_order` instead if trying to close an Order."
+      ],
+      "name": "marginfi_account_set_keeper_close_flags"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "relations": [
+            "marginfi_account"
+          ]
+        },
+        {
+          "docs": [
+            "The account owning the order"
+          ],
+          "name": "marginfi_account",
+          "relations": [
+            "order"
+          ],
+          "writable": true
+        },
+        {
+          "name": "fee_payer",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "docs": [
+            "This account will have the authority to withdraw/repay as if they are the user authority",
+            "until the end of the tx.",
+            ""
+          ],
+          "name": "executor"
+        },
+        {
+          "name": "order",
+          "writable": true
+        },
+        {
+          "docs": [
+            "This keeps track of the relevant state to be checked at the end of execution."
+          ],
+          "name": "execute_record",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  101,
+                  120,
+                  101,
+                  99,
+                  117,
+                  116,
+                  101,
+                  95,
+                  111,
+                  114,
+                  100,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "order"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "address": "Sysvar1nstructions1111111111111111111111111",
+          "name": "instruction_sysvar"
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        1,
+        70,
+        140,
+        134,
+        183,
+        29,
+        208,
+        224
+      ],
+      "docs": [
+        "(permissionless keeper) Begin Order execution",
+        "* Enables the Keeper to withdraw/repay associated positions until the end of the tx",
+        "* Only one `StartExecuteOrder` is allowed per tx",
+        "* Must appear before `EndExecuteOrder` in the tx, and before any instructions except certain",
+        "allowed ones (compute budget, kamino refresh, etc)",
+        "* `EndExecuteOrder` must also appear in the tx",
+        "* CPI is forbidden",
+        "* Costs a small amount of rent, which is returned at the end of the tx, make sure you have",
+        "enough SOL to start the tx."
+      ],
+      "name": "marginfi_account_start_execute_order"
+    },
+    {
+      "accounts": [
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "docs": [
+            "the canonical ATA for each emissions mint."
+          ],
+          "name": "destination_account"
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        73,
+        185,
+        162,
+        201,
+        111,
+        24,
+        116,
+        185
+      ],
+      "docs": [
+        "(account authority) Set the wallet whose canonical ATA will receive off-chain emissions."
+      ],
+      "name": "marginfi_account_update_emissions_destination_account"
+    },
+    {
+      "accounts": [
+        {
+          "name": "marginfi_group",
+          "writable": true
+        },
+        {
+          "name": "admin",
+          "relations": [
+            "marginfi_group"
+          ],
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "new_admin",
+          "type": {
+            "option": "pubkey"
+          }
+        },
+        {
+          "name": "new_emode_admin",
+          "type": {
+            "option": "pubkey"
+          }
+        },
+        {
+          "name": "new_curve_admin",
+          "type": {
+            "option": "pubkey"
+          }
+        },
+        {
+          "name": "new_limit_admin",
+          "type": {
+            "option": "pubkey"
+          }
+        },
+        {
+          "name": "new_flow_admin",
+          "type": {
+            "option": "pubkey"
+          }
+        },
+        {
+          "name": "new_emissions_admin",
+          "type": {
+            "option": "pubkey"
+          }
+        },
+        {
+          "name": "new_metadata_admin",
+          "type": {
+            "option": "pubkey"
+          }
+        },
+        {
+          "name": "new_risk_admin",
+          "type": {
+            "option": "pubkey"
+          }
+        },
+        {
+          "name": "emode_max_init_leverage",
+          "type": {
+            "option": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          }
+        },
+        {
+          "name": "emode_max_maint_leverage",
+          "type": {
+            "option": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          }
+        }
+      ],
+      "discriminator": [
+        62,
+        199,
+        81,
+        78,
+        33,
+        13,
+        236,
+        61
+      ],
+      "docs": [
+        "(admin only) Configure group admin keys and emode leverage caps. All admin keys must be",
+        "provided on every call. Emode leverage caps are set if provided, otherwise the existing",
+        "(non-zero) values are kept. Pass `Some(value)` to update, `None` to leave unchanged."
+      ],
+      "name": "marginfi_group_configure"
+    },
+    {
+      "accounts": [
+        {
+          "name": "marginfi_group",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "name": "admin",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "name": "fee_state",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  101,
+                  101,
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        255,
+        67,
+        67,
+        26,
+        94,
+        31,
+        34,
+        20
+      ],
+      "docs": [
+        "(admin only) Initialize a new marginfi group. The signer becomes the group admin."
+      ],
+      "name": "marginfi_group_initialize"
+    },
+    {
+      "accounts": [
+        {
+          "name": "bank",
+          "writable": true
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        151,
+        254,
+        50,
+        13,
+        112,
+        235,
+        152,
+        72
+      ],
+      "docs": [
+        "(Permissionless) Convert a bank from the legacy curve setup to the new setup, with no effect",
+        "on how interest accrues."
+      ],
+      "name": "migrate_curve"
+    },
+    {
+      "accounts": [
+        {
+          "docs": [
+            "Admin of the global FeeState (can trigger panic pause)"
+          ],
+          "name": "global_fee_admin",
+          "relations": [
+            "fee_state"
+          ],
+          "signer": true
+        },
+        {
+          "docs": [
+            "Global fee state account containing the panic state"
+          ],
+          "name": "fee_state",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  101,
+                  101,
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          },
+          "writable": true
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        76,
+        164,
+        123,
+        25,
+        4,
+        43,
+        79,
+        165
+      ],
+      "docs": [
+        "(global_fee_admin only) Pause the protocol. Auto-expires after 30 minutes. Limited to 3",
+        "pauses per day and 2 consecutive pauses."
+      ],
+      "name": "panic_pause"
+    },
+    {
+      "accounts": [
+        {
+          "docs": [
+            "Admin of the global FeeState (can manually unpause)"
+          ],
+          "name": "global_fee_admin",
+          "relations": [
+            "fee_state"
+          ],
+          "signer": true,
+          "writable": true
+        },
+        {
+          "name": "fee_state",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  101,
+                  101,
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          },
+          "writable": true
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        236,
+        107,
+        194,
+        242,
+        99,
+        51,
+        121,
+        128
+      ],
+      "docs": [
+        "(global_fee_admin only) Unpause the protocol before the auto-expiry."
+      ],
+      "name": "panic_unpause"
+    },
+    {
+      "accounts": [
+        {
+          "name": "fee_state",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  101,
+                  101,
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          },
+          "writable": true
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        245,
+        139,
+        50,
+        159,
+        213,
+        62,
+        91,
+        248
+      ],
+      "docs": [
+        "(permissionless) Unpause the protocol when pause time has expired"
+      ],
+      "name": "panic_unpause_permissionless"
+    },
+    {
+      "accounts": [
+        {
+          "name": "fee_state",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  101,
+                  101,
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "docs": [
+            "Any group, this ix is permisionless and can propagate the fee to any group"
+          ],
+          "name": "marginfi_group",
+          "writable": true
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        64,
+        3,
+        166,
+        194,
+        129,
+        21,
+        101,
+        155
+      ],
+      "docs": [
+        "(Permissionless) Force any group to adopt the current FeeState settings"
+      ],
+      "name": "propagate_fee_state"
+    },
+    {
+      "accounts": [
+        {
+          "name": "marginfi_group",
+          "relations": [
+            "staked_settings"
+          ]
+        },
+        {
+          "name": "staked_settings"
+        },
+        {
+          "name": "bank",
+          "writable": true
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        210,
+        30,
+        152,
+        69,
+        130,
+        99,
+        222,
+        170
+      ],
+      "docs": [
+        "(permissionless) Propagate updated staked settings to a staked collateral bank."
+      ],
+      "name": "propagate_staked_settings"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "relations": [
+            "marginfi_account",
+            "bank"
+          ]
+        },
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "risk_admin",
+          "relations": [
+            "group"
+          ],
+          "signer": true
+        },
+        {
+          "name": "bank",
+          "writable": true
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        132,
+        187,
+        25,
+        149,
+        181,
+        59,
+        253,
+        136
+      ],
+      "docs": [
+        "(risk admin only) Purge a user's lending balance without withdrawing anything. Only usable",
+        "after all the debt has been settled on a bank in deleveraging mode, e.g. when",
+        "`TOKENLESS_REPAYMENTS_ALLOWED` and `TOKENLESS_REPAYMENTS_COMPLETE`. used to purge remaining",
+        "lending assets in a now-worthless bank before it is fully sunset."
+      ],
+      "name": "purge_deleverage_balance"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "relations": [
+            "marginfi_account",
+            "bank"
+          ]
+        },
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "bank",
+          "writable": true
+        },
+        {
+          "docs": [
+            "Owned by authority, the source account for the token deposit."
+          ],
+          "name": "signer_token_account",
+          "writable": true
+        },
+        {
+          "docs": [
+            "The bank's liquidity vault authority, which owns the Solend obligation"
+          ],
+          "name": "liquidity_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "docs": [
+            "Used as an intermediary to deposit tokens into Solend"
+          ],
+          "name": "liquidity_vault",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "docs": [
+            "The Solend obligation account"
+          ],
+          "name": "integration_acc_2",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "name": "lending_market"
+        },
+        {
+          "docs": [
+            "Derived from the lending market"
+          ],
+          "name": "lending_market_authority"
+        },
+        {
+          "docs": [
+            "The Solend reserve that holds liquidity"
+          ],
+          "name": "integration_acc_1",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "docs": [
+            "Bank's liquidity token mint (e.g., USDC)"
+          ],
+          "name": "mint",
+          "relations": [
+            "bank"
+          ]
+        },
+        {
+          "docs": [
+            "Reserve's liquidity supply SPL Token account"
+          ],
+          "name": "reserve_liquidity_supply",
+          "writable": true
+        },
+        {
+          "docs": [
+            "The reserve's mint for cTokens"
+          ],
+          "name": "reserve_collateral_mint",
+          "writable": true
+        },
+        {
+          "docs": [
+            "The reserve's collateral supply account (where cTokens are stored)"
+          ],
+          "name": "reserve_collateral_supply",
+          "writable": true
+        },
+        {
+          "docs": [
+            "The user's destination for cTokens (collateral). This is a temporary account owned by",
+            "liquidity_vault_authority that will hold cTokens between deposit and obligation update."
+          ],
+          "name": "user_collateral",
+          "writable": true
+        },
+        {
+          "docs": [
+            "Oracle accounts - required by Solend even if not actively used"
+          ],
+          "name": "pyth_price"
+        },
+        {
+          "name": "switchboard_feed"
+        },
+        {
+          "address": "So1endDq2YkqhipRh3WViPa8hdiSpxWy6z3Z6tMCpAo",
+          "name": "solend_program"
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ],
+      "discriminator": [
+        56,
+        127,
+        176,
+        148,
+        12,
+        25,
+        3,
+        24
+      ],
+      "docs": [
+        "(user) Deposit into a Solend reserve through a marginfi account",
+        "* amount - in the underlying token (e.g., USDC), in native decimals"
+      ],
+      "name": "solend_deposit"
+    },
+    {
+      "accounts": [
+        {
+          "docs": [
+            "Pays to init the obligation and pays a nominal amount to ensure the obligation has a",
+            "non-zero balance."
+          ],
+          "name": "fee_payer",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "name": "bank"
+        },
+        {
+          "docs": [
+            "The fee payer must provide a nominal amount of bank tokens so the obligation is not empty.",
+            "This amount is irrecoverable and will prevent the obligation from ever being closed."
+          ],
+          "name": "signer_token_account",
+          "writable": true
+        },
+        {
+          "docs": [
+            "The liquidity vault authority (PDA that will own the Solend obligation)"
+          ],
+          "name": "liquidity_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          }
+        },
+        {
+          "docs": [
+            "Used as an intermediary to deposit a nominal amount of token into the obligation."
+          ],
+          "name": "liquidity_vault",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "name": "integration_acc_2",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  111,
+                  108,
+                  101,
+                  110,
+                  100,
+                  95,
+                  111,
+                  98,
+                  108,
+                  105,
+                  103,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "name": "lending_market"
+        },
+        {
+          "docs": [
+            "Derived from the lending market"
+          ],
+          "name": "lending_market_authority"
+        },
+        {
+          "name": "integration_acc_1",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "docs": [
+            "Bank's liquidity token mint (e.g., USDC)"
+          ],
+          "name": "mint",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "name": "reserve_liquidity_supply",
+          "writable": true
+        },
+        {
+          "docs": [
+            "The reserve's mint for cTokens"
+          ],
+          "name": "reserve_collateral_mint",
+          "writable": true
+        },
+        {
+          "docs": [
+            "The reserve's collateral supply account (where cTokens are stored)"
+          ],
+          "name": "reserve_collateral_supply",
+          "writable": true
+        },
+        {
+          "docs": [
+            "The user's destination for cTokens (collateral). This is a temporary account owned by",
+            "liquidity_vault_authority that will hold cTokens between deposit and obligation update."
+          ],
+          "name": "user_collateral",
+          "writable": true
+        },
+        {
+          "docs": [
+            "Oracle accounts - required by Solend even if not actively used"
+          ],
+          "name": "pyth_price"
+        },
+        {
+          "name": "switchboard_feed"
+        },
+        {
+          "address": "So1endDq2YkqhipRh3WViPa8hdiSpxWy6z3Z6tMCpAo",
+          "name": "solend_program"
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "address": "SysvarRent111111111111111111111111111111111",
+          "name": "rent"
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ],
+      "discriminator": [
+        81,
+        96,
+        123,
+        149,
+        218,
+        116,
+        235,
+        196
+      ],
+      "docs": [
+        "(permissionless) Initialize a Solend obligation for a marginfi bank",
+        "Requires a minimum deposit to ensure the obligation remains active",
+        "* amount - minimum deposit amount (at least 10 units) in native decimals"
+      ],
+      "name": "solend_init_obligation"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "relations": [
+            "marginfi_account",
+            "bank"
+          ]
+        },
+        {
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "bank",
+          "writable": true
+        },
+        {
+          "docs": [
+            "Token account that will receive the withdrawn tokens. Mint/owner are validated by the",
+            "SPL transfer; the caller controls the destination."
+          ],
+          "name": "destination_token_account",
+          "writable": true
+        },
+        {
+          "name": "liquidity_vault_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "bank"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "name": "liquidity_vault",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "docs": [
+            "The Solend obligation account"
+          ],
+          "name": "integration_acc_2",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "name": "lending_market",
+          "writable": true
+        },
+        {
+          "docs": [
+            "Derived from the lending market"
+          ],
+          "name": "lending_market_authority"
+        },
+        {
+          "docs": [
+            "The Solend reserve that holds liquidity"
+          ],
+          "name": "integration_acc_1",
+          "relations": [
+            "bank"
+          ],
+          "writable": true
+        },
+        {
+          "docs": [
+            "Bank's liquidity token mint (e.g., USDC)"
+          ],
+          "name": "mint",
+          "relations": [
+            "bank"
+          ]
+        },
+        {
+          "docs": [
+            "Reserve's liquidity supply SPL Token account"
+          ],
+          "name": "reserve_liquidity_supply",
+          "writable": true
+        },
+        {
+          "docs": [
+            "The reserve's mint for cTokens"
+          ],
+          "name": "reserve_collateral_mint",
+          "writable": true
+        },
+        {
+          "docs": [
+            "The reserve's collateral supply account (where cTokens are stored)"
+          ],
+          "name": "reserve_collateral_supply",
+          "writable": true
+        },
+        {
+          "docs": [
+            "The user's destination for cTokens (collateral). This is a temporary account owned by",
+            "liquidity_vault_authority that holds cTokens."
+          ],
+          "name": "user_collateral",
+          "writable": true
+        },
+        {
+          "address": "So1endDq2YkqhipRh3WViPa8hdiSpxWy6z3Z6tMCpAo",
+          "name": "solend_program"
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        },
+        {
+          "name": "withdraw_all",
+          "type": {
+            "option": "bool"
+          }
+        }
+      ],
+      "discriminator": [
+        238,
+        144,
+        170,
+        199,
+        21,
+        72,
+        155,
+        36
+      ],
+      "docs": [
+        "(user) Withdraw from a Solend reserve through a marginfi account",
+        "* amount - in collateral tokens (cTokens), in native decimals",
+        "* withdraw_all - withdraw entire position if true"
+      ],
+      "name": "solend_withdraw"
+    },
+    {
+      "accounts": [
+        {
+          "docs": [
+            "Account to deleverage"
+          ],
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "docs": [
+            "The associated liquidation record PDA for the given `marginfi_account`"
+          ],
+          "name": "liquidation_record",
+          "relations": [
+            "marginfi_account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "group",
+          "relations": [
+            "marginfi_account"
+          ]
+        },
+        {
+          "docs": [
+            "The risk admin will have the authority to withdraw/repay as if they are the user authority",
+            "until the end of the tx."
+          ],
+          "name": "risk_admin",
+          "relations": [
+            "group"
+          ],
+          "signer": true
+        },
+        {
+          "address": "Sysvar1nstructions1111111111111111111111111",
+          "name": "instruction_sysvar"
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        10,
+        138,
+        10,
+        57,
+        40,
+        232,
+        182,
+        193
+      ],
+      "docs": [
+        "(risk_admin only) Begin forced deleverage on an account. Similar to start_liquidation but",
+        "does not require the account to be unhealthy."
+      ],
+      "name": "start_deleverage"
+    },
+    {
+      "accounts": [
+        {
+          "docs": [
+            "Account under liquidation"
+          ],
+          "name": "marginfi_account",
+          "writable": true
+        },
+        {
+          "docs": [
+            "The associated liquidation record PDA for the given `marginfi_account`"
+          ],
+          "name": "liquidation_record",
+          "relations": [
+            "marginfi_account"
+          ],
+          "writable": true
+        },
+        {
+          "docs": [
+            "This account will have the authority to withdraw/repay as if they are the user authority",
+            "until the end of the tx.",
+            ""
+          ],
+          "name": "liquidation_receiver"
+        },
+        {
+          "address": "Sysvar1nstructions1111111111111111111111111",
+          "name": "instruction_sysvar"
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        244,
+        93,
+        90,
+        214,
+        192,
+        166,
+        191,
+        21
+      ],
+      "docs": [
+        "(permissionless) Begin receivership liquidation on an unhealthy account. Snapshots health",
+        "and marks the account in receivership. Must have `end_liquidation` as the last ix in the tx."
+      ],
+      "name": "start_liquidation"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "relations": [
+            "old_marginfi_account"
+          ]
+        },
+        {
+          "name": "old_marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "new_marginfi_account",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "fee_payer",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "name": "new_authority"
+        },
+        {
+          "name": "global_fee_wallet",
+          "writable": true
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        }
+      ],
+      "args": [],
+      "discriminator": [
+        28,
+        79,
+        129,
+        231,
+        169,
+        69,
+        69,
+        65
+      ],
+      "docs": [
+        "(account authority) Transfer all positions to a new account under a new authority. The old",
+        "account is disabled. Pays a flat SOL fee to the protocol."
+      ],
+      "name": "transfer_to_new_account"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "relations": [
+            "old_marginfi_account"
+          ]
+        },
+        {
+          "name": "old_marginfi_account",
+          "writable": true
+        },
+        {
+          "name": "new_marginfi_account",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  109,
+                  97,
+                  114,
+                  103,
+                  105,
+                  110,
+                  102,
+                  105,
+                  95,
+                  97,
+                  99,
+                  99,
+                  111,
+                  117,
+                  110,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "group"
+              },
+              {
+                "kind": "account",
+                "path": "new_authority"
+              },
+              {
+                "kind": "arg",
+                "path": "account_index"
+              },
+              {
+                "kind": "arg",
+                "path": "third_party_id.unwrap_or(0)"
+              }
+            ]
+          },
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "fee_payer",
+          "signer": true,
+          "writable": true
+        },
+        {
+          "name": "new_authority"
+        },
+        {
+          "name": "global_fee_wallet",
+          "writable": true
+        },
+        {
+          "address": "Sysvar1nstructions1111111111111111111111111",
+          "docs": [
+            "Instructions sysvar for CPI validation"
+          ],
+          "name": "instructions_sysvar"
+        },
+        {
+          "address": "11111111111111111111111111111111",
+          "name": "system_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "account_index",
+          "type": "u16"
+        },
+        {
+          "name": "third_party_id",
+          "type": {
+            "option": "u16"
+          }
+        }
+      ],
+      "discriminator": [
+        172,
+        210,
+        224,
+        220,
+        146,
+        212,
+        253,
+        49
+      ],
+      "docs": [
+        "(account authority) Same as `transfer_to_new_account` except the resulting account is a PDA",
+        "",
+        "seeds:",
+        "- marginfi_group",
+        "- authority: The account authority (owner)",
+        "- account_index: A u16 value to allow multiple accounts per authority",
+        "- third_party_id: Optional u16 for third-party tagging. Seeds < PDA_FREE_THRESHOLD can be",
+        "used freely. For a dedicated seed used by just your program (via CPI), contact us."
+      ],
+      "name": "transfer_to_new_account_pda"
+    },
+    {
+      "accounts": [
+        {
+          "name": "marginfi_group",
+          "writable": true
+        },
+        {
+          "name": "delegate_flow_admin",
+          "relations": [
+            "marginfi_group"
+          ],
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "outflow_usd",
+          "type": "u32"
+        },
+        {
+          "name": "update_seq",
+          "type": "u64"
+        },
+        {
+          "name": "event_start_slot",
+          "type": "u64"
+        },
+        {
+          "name": "event_end_slot",
+          "type": "u64"
+        }
+      ],
+      "discriminator": [
+        56,
+        3,
+        181,
+        118,
+        27,
+        247,
+        207,
+        227
+      ],
+      "docs": [
+        "(delegate_flow_admin only) Update the deleverage daily withdraw outflow with",
+        "aggregated data. The delegate flow admin aggregates",
+        "`DeleverageWithdrawFlowEvent` events off-chain and calls this instruction at intervals."
+      ],
+      "name": "update_deleverage_withdrawals"
+    },
+    {
+      "accounts": [
+        {
+          "name": "marginfi_group",
+          "writable": true
+        },
+        {
+          "name": "delegate_flow_admin",
+          "relations": [
+            "marginfi_group"
+          ],
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "outflow_usd",
+          "type": {
+            "option": "u64"
+          }
+        },
+        {
+          "name": "inflow_usd",
+          "type": {
+            "option": "u64"
+          }
+        },
+        {
+          "name": "update_seq",
+          "type": "u64"
+        },
+        {
+          "name": "event_start_slot",
+          "type": "u64"
+        },
+        {
+          "name": "event_end_slot",
+          "type": "u64"
+        }
+      ],
+      "discriminator": [
+        23,
+        78,
+        60,
+        139,
+        187,
+        44,
+        129,
+        37
+      ],
+      "docs": [
+        "(delegate_flow_admin only) Update the group rate limiter with aggregated",
+        "inflow/outflow. The delegate flow admin aggregates",
+        "`RateLimitFlowEvent` events off-chain, converts to USD, and calls this instruction at",
+        "intervals to update group rate limiter state."
+      ],
+      "name": "update_group_rate_limiter"
+    },
+    {
+      "accounts": [
+        {
+          "name": "group",
+          "relations": [
+            "bank"
+          ]
+        },
+        {
+          "name": "bank",
+          "relations": [
+            "metadata"
+          ]
+        },
+        {
+          "name": "metadata_admin",
+          "relations": [
+            "group"
+          ],
+          "signer": true,
+          "writable": true
+        },
+        {
+          "name": "metadata",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "ticker",
+          "type": {
+            "option": "bytes"
+          }
+        },
+        {
+          "name": "description",
+          "type": {
+            "option": "bytes"
+          }
+        }
+      ],
+      "discriminator": [
+        147,
+        78,
+        81,
+        133,
+        129,
+        138,
+        233,
+        59
+      ],
+      "docs": [
+        "(metadata admin only) Write ticker/description information for a bank on-chain. Optional, not",
+        "all Banks are guaranteed to have metadata."
+      ],
+      "name": "write_bank_metadata"
+    }
+  ],
+  "metadata": {
+    "description": "Borrow Lending Prime Broker",
+    "name": "marginfi",
+    "spec": "0.1.0",
+    "version": "0.1.8"
+  },
+  "types": [
+    {
+      "name": "AccountEventHeader",
+      "type": {
+        "fields": [
+          {
+            "name": "signer",
+            "type": {
+              "option": "pubkey"
+            }
+          },
+          {
+            "name": "marginfi_account",
+            "type": "pubkey"
+          },
+          {
+            "name": "marginfi_account_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "marginfi_group",
+            "type": "pubkey"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "Balance",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "fields": [
+          {
+            "docs": [
+              "Whether this balance slot is in use (nonzero = active)"
+            ],
+            "name": "active",
+            "type": "u8"
+          },
+          {
+            "docs": [
+              "The bank this balance corresponds to"
+            ],
+            "name": "bank_pk",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "Inherited from the bank when the position is first created and CANNOT BE CHANGED after that.",
+              "Note that all balances created before the addition of this feature use `ASSET_TAG_DEFAULT`"
+            ],
+            "name": "bank_asset_tag",
+            "type": "u8"
+          },
+          {
+            "docs": [
+              "Tag used by orders to reference this balance (0 means unused/unassigned).",
+              "A tag may also have a non-zero value while having no orders."
+            ],
+            "name": "tag",
+            "type": "u16"
+          },
+          {
+            "name": "_pad0",
+            "type": {
+              "array": [
+                "u8",
+                4
+              ]
+            }
+          },
+          {
+            "docs": [
+              "The user's asset (deposit) shares in the bank. Multiply by `bank.asset_share_value` for",
+              "the token amount."
+            ],
+            "name": "asset_shares",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "The user's liability (borrow) shares in the bank. Multiply by `bank.liability_share_value`",
+              "for the token amount."
+            ],
+            "name": "liability_shares",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Unclaimed emissions rewards for this position"
+            ],
+            "name": "emissions_outstanding",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Unix timestamp (u64) of the last emissions calculation for this position"
+            ],
+            "name": "last_update",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "Reserved for future use"
+            ],
+            "name": "_padding",
+            "type": {
+              "array": [
+                "u64",
+                1
+              ]
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "Bank",
+      "repr": {
+        "kind": "c"
+      },
+      "serialization": "bytemuck",
+      "type": {
+        "fields": [
+          {
+            "docs": [
+              "The SPL token mint this bank manages"
+            ],
+            "name": "mint",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "Number of decimals of the `mint`. Must be < 24."
+            ],
+            "name": "mint_decimals",
+            "type": "u8"
+          },
+          {
+            "docs": [
+              "The `MarginfiGroup` this bank belongs to"
+            ],
+            "name": "group",
+            "type": "pubkey"
+          },
+          {
+            "name": "_pad0",
+            "type": {
+              "array": [
+                "u8",
+                7
+              ]
+            }
+          },
+          {
+            "docs": [
+              "Monotonically increases as interest rate accumulates. For typical banks, a user's asset",
+              "value in token = (number of shares the user has * asset_share_value).",
+              "* A float (arbitrary decimals)",
+              "* Initially 1"
+            ],
+            "name": "asset_share_value",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Monotonically increases as interest rate accumulates. For typical banks, a user's liabilty",
+              "value in token = (number of shares the user has * liability_share_value)",
+              "* A float (arbitrary decimals)",
+              "* Initially 1"
+            ],
+            "name": "liability_share_value",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "The SPL token account holding deposited liquidity"
+            ],
+            "name": "liquidity_vault",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "PDA bump for the liquidity vault"
+            ],
+            "name": "liquidity_vault_bump",
+            "type": "u8"
+          },
+          {
+            "docs": [
+              "PDA bump for the liquidity vault authority"
+            ],
+            "name": "liquidity_vault_authority_bump",
+            "type": "u8"
+          },
+          {
+            "docs": [
+              "The SPL token account holding insurance fund tokens"
+            ],
+            "name": "insurance_vault",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "PDA bump for the insurance vault"
+            ],
+            "name": "insurance_vault_bump",
+            "type": "u8"
+          },
+          {
+            "docs": [
+              "PDA bump for the insurance vault authority"
+            ],
+            "name": "insurance_vault_authority_bump",
+            "type": "u8"
+          },
+          {
+            "name": "_pad1",
+            "type": {
+              "array": [
+                "u8",
+                4
+              ]
+            }
+          },
+          {
+            "docs": [
+              "Fees collected and pending withdraw for the `insurance_vault`"
+            ],
+            "name": "collected_insurance_fees_outstanding",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "The SPL token account holding collected group fees"
+            ],
+            "name": "fee_vault",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "PDA bump for the fee vault"
+            ],
+            "name": "fee_vault_bump",
+            "type": "u8"
+          },
+          {
+            "docs": [
+              "PDA bump for the fee vault authority"
+            ],
+            "name": "fee_vault_authority_bump",
+            "type": "u8"
+          },
+          {
+            "name": "_pad2",
+            "type": {
+              "array": [
+                "u8",
+                6
+              ]
+            }
+          },
+          {
+            "docs": [
+              "Fees collected and pending withdraw for the `fee_vault`"
+            ],
+            "name": "collected_group_fees_outstanding",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Sum of all liability shares held by all borrowers in this bank.",
+              "Multiply by `liability_share_value` to get the total liability amount in native token units."
+            ],
+            "name": "total_liability_shares",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Sum of all asset shares held by all depositors in this bank.",
+              "Multiply by `asset_share_value` to get the total asset amount in native token units.",
+              "* For Kamino banks, this is the quantity of collateral tokens (NOT liquidity tokens) in the",
+              "bank, and also uses `mint_decimals`, though the mint itself will always show (6) decimals",
+              "exactly (i.e Kamino ignores this and treats it as if it was using `mint_decimals`)"
+            ],
+            "name": "total_asset_shares",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Unix timestamp (i64) of the last interest accrual"
+            ],
+            "name": "last_update",
+            "type": "i64"
+          },
+          {
+            "docs": [
+              "The bank's configuration parameters (weights, limits, oracle setup, interest rate config)"
+            ],
+            "name": "config",
+            "type": {
+              "defined": {
+                "name": "BankConfig"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Bank flags bitfield (u64).",
+              "",
+              "- Bit 0 (1): `EMISSIONS_FLAG_BORROW_ACTIVE` — borrow-side emissions are active",
+              "- Bit 1 (2): `EMISSIONS_FLAG_LENDING_ACTIVE` — lending-side emissions are active",
+              "- Bit 2 (4): `PERMISSIONLESS_BAD_DEBT_SETTLEMENT_FLAG` — anyone can settle bad debt",
+              "- Bit 3 (8): `FREEZE_SETTINGS` — bank configuration is frozen (only limits can change)",
+              "- Bit 4 (16): `CLOSE_ENABLED_FLAG` — bank can be closed (set at creation for banks >= 0.1.4)",
+              "- Bit 5 (32): `TOKENLESS_REPAYMENTS_ALLOWED` — risk admin can repay debt without tokens",
+              "- Bit 6 (64): `TOKENLESS_REPAYMENTS_COMPLETE` — all debt cleared, lender purge enabled"
+            ],
+            "name": "flags",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "Emissions APR. Number of emitted tokens (emissions_mint) per 1e(bank.mint_decimal) tokens",
+              "(bank mint) (native amount) per 1 YEAR."
+            ],
+            "name": "emissions_rate",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "Remaining emissions tokens available for distribution"
+            ],
+            "name": "emissions_remaining",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "The SPL token mint used for emissions rewards"
+            ],
+            "name": "emissions_mint",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "Fees collected and pending withdraw for the `FeeState.global_fee_wallet`'s canonical ATA for `mint`"
+            ],
+            "name": "collected_program_fees_outstanding",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Controls this bank's emode configuration, which enables some banks to treat the assets of",
+              "certain other banks more preferentially as collateral."
+            ],
+            "name": "emode",
+            "type": {
+              "defined": {
+                "name": "EmodeSettings"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Set with `update_fees_destination_account`. Fees can be withdrawn to the canonical ATA of",
+              "this wallet without the admin's input (withdraw_fees_permissionless). If pubkey default, the",
+              "bank doesn't support this feature, and the fees must be collected manually (withdraw_fees)."
+            ],
+            "name": "fees_destination_account",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "Cached bank metrics (interest rates, oracle price, etc.)"
+            ],
+            "name": "cache",
+            "type": {
+              "defined": {
+                "name": "BankCache"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Number of user lending positions currently open in this bank",
+              "* For banks created prior to 0.1.4, this is the number of positions opened/closed after",
+              "0.1.4 goes live, and may be negative.",
+              "* For banks created in 0.1.4 or later, this is the number of positions open in total, and",
+              "the bank may safely be closed if this is zero. Will never go negative."
+            ],
+            "name": "lending_position_count",
+            "type": "i32"
+          },
+          {
+            "docs": [
+              "Number of user borrowing positions currently open in this bank",
+              "* For banks created prior to 0.1.4, this is the number of positions opened/closed after",
+              "0.1.4 goes live, and may be negative.",
+              "* For banks created in 0.1.4 or later, this is the number of positions open in total, and",
+              "the bank may safely be closed if this is zero. Will never go negative."
+            ],
+            "name": "borrowing_position_count",
+            "type": "i32"
+          },
+          {
+            "docs": [
+              "Reserved for future use"
+            ],
+            "name": "_padding_0",
+            "type": {
+              "array": [
+                "u8",
+                16
+              ]
+            }
+          },
+          {
+            "docs": [
+              "Integration account slot 1 (default Pubkey for non-integrations).",
+              "- Kamino: reserve",
+              "- Drift: spot market",
+              "- Solend: reserve",
+              "- JupLend: lending state"
+            ],
+            "name": "integration_acc_1",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "Integration account slot 2 (default Pubkey for non-integrations).",
+              "- Kamino: obligation",
+              "- Drift: user",
+              "- Solend: obligation",
+              "- JupLend: fToken vault"
+            ],
+            "name": "integration_acc_2",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "Integration account slot 3 (default Pubkey for non-integrations).",
+              "- Drift: user stats",
+              "- JupLend: withdraw intermediary ATA (ATA of liquidity_vault_authority for bank mint)"
+            ],
+            "name": "integration_acc_3",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "Rate limiter for controlling withdraw/borrow outflow.",
+              "Tracks net outflow (outflows - inflows) in native tokens."
+            ],
+            "name": "rate_limiter",
+            "type": {
+              "defined": {
+                "name": "BankRateLimiter"
+              }
+            }
+          },
+          {
+            "name": "_pad_0",
+            "type": {
+              "array": [
+                "u8",
+                16
+              ]
+            }
+          },
+          {
+            "name": "_padding_1",
+            "type": {
+              "array": [
+                {
+                  "array": [
+                    "u64",
+                    2
+                  ]
+                },
+                7
+              ]
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "docs": [
+        "A read-only cache of the bank's key metrics, e.g. spot interest/fee rates."
+      ],
+      "name": "BankCache",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "fields": [
+          {
+            "docs": [
+              "Actual (spot) interest/fee rates of the bank, based on utilization",
+              "* APR (annual percentage rate) values",
+              "* From 0-1000%, as u32, e.g. u32::MAX = 1000%, u32::MAX/2 = 500%, etc"
+            ],
+            "name": "base_rate",
+            "type": "u32"
+          },
+          {
+            "docs": [
+              "Equivalent to `base_rate` * utilization",
+              "* From 0-1000%, as u32, e.g. u32::MAX = 1000%, u32::MAX/2 = 500%, etc"
+            ],
+            "name": "lending_rate",
+            "type": "u32"
+          },
+          {
+            "docs": [
+              "Equivalent to `base_rate` * (1 + ir_fees) + fixed_fees",
+              "* From 0-1000%, as u32, e.g. u32::MAX = 1000%, u32::MAX/2 = 500%, etc"
+            ],
+            "name": "borrowing_rate",
+            "type": "u32"
+          },
+          {
+            "docs": [
+              "* in seconds"
+            ],
+            "name": "interest_accumulated_for",
+            "type": "u32"
+          },
+          {
+            "docs": [
+              "equivalent to (share value increase in the last `interest_accumulated_for` seconds *",
+              "shares), i.e. the delta in `asset_share_value`, in token.",
+              "* Note: if the tx that triggered this cache update increased or decreased the net shares,",
+              "this value still reports using the PRE-CHANGE share amount, since interest is always",
+              "earned on that amount.",
+              "* in token, in native decimals, as I80F48"
+            ],
+            "name": "accumulated_since_last_update",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Oracle price used in the last instruction that consumed an oracle price",
+              "* Only updated when instruction uses an oracle price, not updated for operations that don't",
+              "require prices (e.g., deposit, repay)",
+              "* Price in USD, with no price bias",
+              "* Zero if never updated"
+            ],
+            "name": "last_oracle_price",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Unix timestamp (seconds) when last_oracle_price was last updated",
+              "* Used to determine staleness of cached price",
+              "* Zero if never updated"
+            ],
+            "name": "last_oracle_price_timestamp",
+            "type": "i64"
+          },
+          {
+            "docs": [
+              "Confidence interval reported by the oracle when last_oracle_price was fetched",
+              "* Always non-negative",
+              "* Zero if never updated",
+              "* Note: this value is the confidence reported by oracles, multiplied by `STD_DEV_MULTIPLE`"
+            ],
+            "name": "last_oracle_price_confidence",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Liquidation cache flags, set during receivership flow.",
+              "* 1 (LIQ_CACHE_LOCKED_FLAG) - We \"lock\" the liquidation cache when writing to it in Start",
+              "Liquidate as an additional safeguard, if the liquidation prices stored here were to be",
+              "edited between start and end, it would completely break the risk engine. End validates that",
+              "the lock is set, panics if not, and removes it - which prevents footguns if the cache was",
+              "e.g. accidently set to default. The lock is also removed when a Balance is closed via",
+              "withdraw_all, repay_all, or close_balance, but only when the account has",
+              "ACCOUNT_IN_RECEIVERSHIP set, so that operations on unrelated accounts sharing the same",
+              "bank do not interfere with an in-progress liquidation."
+            ],
+            "name": "liq_cache_flags",
+            "type": "u8"
+          },
+          {
+            "name": "_padding",
+            "type": {
+              "array": [
+                "u8",
+                23
+              ]
+            }
+          },
+          {
+            "docs": [
+              "Cached real-time price for receivership liquidation."
+            ],
+            "name": "liquidation_price_rt",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Cached real-time price confidence for receivership liquidation."
+            ],
+            "name": "liquidation_price_rt_confidence",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Cached TWAP price for receivership liquidation."
+            ],
+            "name": "liquidation_price_twap",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Cached TWAP price confidence for receivership liquidation."
+            ],
+            "name": "liquidation_price_twap_confidence",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "BankConfig",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "fields": [
+          {
+            "docs": [
+              "Discount factor for asset values in initial margin calculation (0 to 1).",
+              "E.g., 0.8 means assets count as 80% of their value for borrowing purposes."
+            ],
+            "name": "asset_weight_init",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Discount factor for asset values in maintenance margin calculation (0 to 2).",
+              "Used for liquidation eligibility. Generally >= asset_weight_init."
+            ],
+            "name": "asset_weight_maint",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Premium factor for liability values in initial margin calculation (>= 1).",
+              "E.g., 1.2 means liabilities count as 120% of their value for borrowing purposes."
+            ],
+            "name": "liability_weight_init",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Premium factor for liability values in maintenance margin calculation (>= 1).",
+              "Used for liquidation eligibility. Generally <= liability_weight_init."
+            ],
+            "name": "liability_weight_maint",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Maximum total deposits allowed in this bank, in native token units (0 = no limit)"
+            ],
+            "name": "deposit_limit",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "Interest rate model configuration"
+            ],
+            "name": "interest_rate_config",
+            "type": {
+              "defined": {
+                "name": "InterestRateConfig"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Current operational state of the bank (Paused, Operational, ReduceOnly, KilledByBankruptcy)"
+            ],
+            "name": "operational_state",
+            "type": {
+              "defined": {
+                "name": "BankOperationalState"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Oracle type used for price feeds"
+            ],
+            "name": "oracle_setup",
+            "type": {
+              "defined": {
+                "name": "OracleSetup"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Oracle account keys (usage depends on oracle_setup type)"
+            ],
+            "name": "oracle_keys",
+            "type": {
+              "array": [
+                "pubkey",
+                5
+              ]
+            }
+          },
+          {
+            "name": "_pad0",
+            "type": {
+              "array": [
+                "u8",
+                6
+              ]
+            }
+          },
+          {
+            "docs": [
+              "Maximum total borrows allowed in this bank, in native token units (0 = no limit)"
+            ],
+            "name": "borrow_limit",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "Risk tier for this bank (Collateral or Isolated)"
+            ],
+            "name": "risk_tier",
+            "type": {
+              "defined": {
+                "name": "RiskTier"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Determines what kinds of assets users of this bank can interact with. Options:",
+              "* `ASSET_TAG_DEFAULT` (0) - A regular asset that can be comingled with any other regular",
+              "asset or with `ASSET_TAG_SOL`",
+              "* `ASSET_TAG_SOL` (1) - Accounts with a SOL position can comingle with **either**",
+              "`ASSET_TAG_DEFAULT` or `ASSET_TAG_STAKED` positions, but not both",
+              "* `ASSET_TAG_STAKED` (2) - Staked SOL assets. Accounts with a STAKED position can only",
+              "deposit other STAKED assets or SOL (`ASSET_TAG_SOL`) and can only borrow SOL",
+              "* `ASSET_TAG_KAMINO` (3) - Treated the same as `ASSET_TAG_DEFAULT`",
+              "* `ASSET_TAG_DRIFT` (4) - Treated the same as `ASSET_TAG_DEFAULT`",
+              "* `ASSET_TAG_SOLEND` (5) - Treated the same as `ASSET_TAG_DEFAULT`"
+            ],
+            "name": "asset_tag",
+            "type": "u8"
+          },
+          {
+            "docs": [
+              "Flags for various config options",
+              "* 1 - Always set if bank created in 0.1.4 or later, or if migrated to the new pyth oracle",
+              "setup from a prior version. Not set in 0.1.3 or earlier banks using pyth that have not yet",
+              "migrated. Does nothing for banks that use switchboard.",
+              "* 2, 4, 8, 16, etc - reserved for future use."
+            ],
+            "name": "config_flags",
+            "type": "u8"
+          },
+          {
+            "name": "_pad1",
+            "type": {
+              "array": [
+                "u8",
+                5
+              ]
+            }
+          },
+          {
+            "docs": [
+              "USD denominated limit for calculating asset value for initialization margin requirements.",
+              "Example, if total SOL deposits are equal to $1M and the limit it set to $500K, then SOL",
+              "assets will be discounted by 50%.",
+              "",
+              "In other words the max value of liabilities that can be backed by the asset is $500K. This",
+              "is useful for limiting the damage of oracle attacks.",
+              "",
+              "Value is UI USD value, for example value 100 -> $100"
+            ],
+            "name": "total_asset_value_init_limit",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "Time window in seconds for the oracle price feed to be considered live."
+            ],
+            "name": "oracle_max_age",
+            "type": "u16"
+          },
+          {
+            "name": "_padding0",
+            "type": {
+              "array": [
+                "u8",
+                2
+              ]
+            }
+          },
+          {
+            "docs": [
+              "From 0-100%, if the confidence exceeds this value, the oracle is considered invalid. Note:",
+              "the confidence adjustment is capped at 5% regardless of this value.",
+              "* 0 falls back to using the default 10% instead, i.e., U32_MAX_DIV_10",
+              "* A %, as u32, e.g. 100% = u32::MAX, 50% = u32::MAX/2, etc."
+            ],
+            "name": "oracle_max_confidence",
+            "type": "u32"
+          },
+          {
+            "docs": [
+              "Stored oracle price for `OracleSetup::Fixed`, otherwise does nothing"
+            ],
+            "name": "fixed_price",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "_padding1",
+            "type": {
+              "array": [
+                "u8",
+                16
+              ]
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "BankConfigCompact",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "fields": [
+          {
+            "name": "asset_weight_init",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "asset_weight_maint",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "liability_weight_init",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "liability_weight_maint",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "deposit_limit",
+            "type": "u64"
+          },
+          {
+            "name": "interest_rate_config",
+            "type": {
+              "defined": {
+                "name": "InterestRateConfigCompact"
+              }
+            }
+          },
+          {
+            "name": "operational_state",
+            "type": {
+              "defined": {
+                "name": "BankOperationalState"
+              }
+            }
+          },
+          {
+            "name": "borrow_limit",
+            "type": "u64"
+          },
+          {
+            "name": "risk_tier",
+            "type": {
+              "defined": {
+                "name": "RiskTier"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Determines what kinds of assets users of this bank can interact with. Options:",
+              "* `ASSET_TAG_DEFAULT` (0) - A regular asset that can be comingled with any other regular",
+              "asset or with `ASSET_TAG_SOL`",
+              "* `ASSET_TAG_SOL` (1) - Accounts with a SOL position can comingle with **either**",
+              "`ASSET_TAG_DEFAULT` or `ASSET_TAG_STAKED` positions, but not both",
+              "* `ASSET_TAG_STAKED` (2) - Staked SOL assets. Accounts with a STAKED position can only",
+              "deposit other STAKED assets or SOL (`ASSET_TAG_SOL`) and can only borrow SOL",
+              "* `ASSET_TAG_KAMINO` (3) - Treated the same as `ASSET_TAG_DEFAULT`",
+              "* `ASSET_TAG_DRIFT` (4) - Treated the same as `ASSET_TAG_DEFAULT`",
+              "* `ASSET_TAG_SOLEND` (5) - Treated the same as `ASSET_TAG_DEFAULT`"
+            ],
+            "name": "asset_tag",
+            "type": "u8"
+          },
+          {
+            "docs": [
+              "Flags for various config options",
+              "* 1 - Always set if bank created in 0.1.4 or later, or if migrated to the new oracle setup",
+              "from a prior version. Not set in 0.1.3 or earlier banks that have not yet migrated.",
+              "* 2, 4, 8, 16, etc - reserved for future use."
+            ],
+            "name": "config_flags",
+            "type": "u8"
+          },
+          {
+            "name": "_pad0",
+            "type": {
+              "array": [
+                "u8",
+                5
+              ]
+            }
+          },
+          {
+            "docs": [
+              "USD denominated limit for calculating asset value for initialization margin requirements.",
+              "Example, if total SOL deposits are equal to $1M and the limit it set to $500K, then SOL",
+              "assets will be discounted by 50%.",
+              "",
+              "In other words the max value of liabilities that can be backed by the asset is $500K. This",
+              "is useful for limiting the damage of oracle attacks.",
+              "",
+              "Value is UI USD value, for example value 100 -> $100"
+            ],
+            "name": "total_asset_value_init_limit",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "Time window in seconds for the oracle price feed to be considered live."
+            ],
+            "name": "oracle_max_age",
+            "type": "u16"
+          },
+          {
+            "docs": [
+              "From 0-100%, if the confidence exceeds this value, the oracle is considered invalid. Note:",
+              "the confidence adjustment is capped at 5% regardless of this value.",
+              "* 0% = use the default (10%)",
+              "* A %, as u32, e.g. 100% = u32::MAX, 50% = u32::MAX/2, etc."
+            ],
+            "name": "oracle_max_confidence",
+            "type": "u32"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "BankConfigOpt",
+      "type": {
+        "fields": [
+          {
+            "name": "asset_weight_init",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "WrappedI80F48"
+                }
+              }
+            }
+          },
+          {
+            "name": "asset_weight_maint",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "WrappedI80F48"
+                }
+              }
+            }
+          },
+          {
+            "name": "liability_weight_init",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "WrappedI80F48"
+                }
+              }
+            }
+          },
+          {
+            "name": "liability_weight_maint",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "WrappedI80F48"
+                }
+              }
+            }
+          },
+          {
+            "name": "deposit_limit",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "borrow_limit",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "operational_state",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "BankOperationalState"
+                }
+              }
+            }
+          },
+          {
+            "name": "interest_rate_config",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "InterestRateConfigOpt"
+                }
+              }
+            }
+          },
+          {
+            "name": "risk_tier",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "RiskTier"
+                }
+              }
+            }
+          },
+          {
+            "name": "asset_tag",
+            "type": {
+              "option": "u8"
+            }
+          },
+          {
+            "name": "total_asset_value_init_limit",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "oracle_max_confidence",
+            "type": {
+              "option": "u32"
+            }
+          },
+          {
+            "name": "oracle_max_age",
+            "type": {
+              "option": "u16"
+            }
+          },
+          {
+            "name": "permissionless_bad_debt_settlement",
+            "type": {
+              "option": "bool"
+            }
+          },
+          {
+            "name": "freeze_settings",
+            "type": {
+              "option": "bool"
+            }
+          },
+          {
+            "name": "tokenless_repayments_allowed",
+            "type": {
+              "option": "bool"
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "BankMetadata",
+      "repr": {
+        "kind": "c"
+      },
+      "serialization": "bytemuck",
+      "type": {
+        "fields": [
+          {
+            "docs": [
+              "Bank this metadata corresponds to"
+            ],
+            "name": "bank",
+            "type": "pubkey"
+          },
+          {
+            "name": "placeholder",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "The token's ticker name, e.g. USDC",
+              "* utf-8"
+            ],
+            "name": "ticker",
+            "type": {
+              "array": [
+                "u8",
+                64
+              ]
+            }
+          },
+          {
+            "docs": [
+              "The token's plain english description, e.g US Dollar Coin",
+              "* utf-8"
+            ],
+            "name": "description",
+            "type": {
+              "array": [
+                "u8",
+                128
+              ]
+            }
+          },
+          {
+            "docs": [
+              "Reserved for future use. Room for a very small icon or something else cool"
+            ],
+            "name": "data_blob",
+            "type": {
+              "array": [
+                "u8",
+                256
+              ]
+            }
+          },
+          {
+            "docs": [
+              "The last data byte in description (padding follows)"
+            ],
+            "name": "end_description_byte",
+            "type": "u16"
+          },
+          {
+            "docs": [
+              "The last data byte in data_blob (padding follows)"
+            ],
+            "name": "end_data_blob",
+            "type": "u16"
+          },
+          {
+            "docs": [
+              "The last data byte in ticker (padding follows)"
+            ],
+            "name": "end_ticker_byte",
+            "type": "u8"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "_pad0",
+            "type": {
+              "array": [
+                "u8",
+                2
+              ]
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "BankOperationalState",
+      "repr": {
+        "kind": "rust"
+      },
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Paused"
+          },
+          {
+            "name": "Operational"
+          },
+          {
+            "name": "ReduceOnly"
+          },
+          {
+            "name": "KilledByBankruptcy"
+          }
+        ]
+      }
+    },
+    {
+      "docs": [
+        "Per-bank rate limiting configuration and state.",
+        "Tracks net outflow in native tokens."
+      ],
+      "name": "BankRateLimiter",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "fields": [
+          {
+            "docs": [
+              "Hourly window rate limiter (native tokens)."
+            ],
+            "name": "hourly",
+            "type": {
+              "defined": {
+                "name": "RateLimitWindow"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Daily window rate limiter (native tokens)."
+            ],
+            "name": "daily",
+            "type": {
+              "defined": {
+                "name": "RateLimitWindow"
+              }
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "DeleverageEvent",
+      "type": {
+        "fields": [
+          {
+            "name": "marginfi_account",
+            "type": "pubkey"
+          },
+          {
+            "name": "risk_admin",
+            "type": "pubkey"
+          },
+          {
+            "name": "deleveragee_assets_seized",
+            "type": "f64"
+          },
+          {
+            "name": "deleveragee_liability_repaid",
+            "type": "f64"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "docs": [
+        "Emitted for deleverage-only withdraw outflows.",
+        "The delegate flow admin aggregates these off-chain and",
+        "updates the deleverage daily withdraws via `update_deleverage_withdrawals`."
+      ],
+      "name": "DeleverageWithdrawFlowEvent",
+      "type": {
+        "fields": [
+          {
+            "name": "group",
+            "type": "pubkey"
+          },
+          {
+            "name": "bank",
+            "type": "pubkey"
+          },
+          {
+            "name": "mint",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "Equity-denominated outflow value in USD, rounded to integer."
+            ],
+            "name": "outflow_usd",
+            "type": "u32"
+          },
+          {
+            "docs": [
+              "Unix timestamp when the flow was recorded"
+            ],
+            "name": "current_timestamp",
+            "type": "i64"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "docs": [
+        "Used to configure Drift banks. A simplified version of `BankConfigCompact` which omits most",
+        "values related to interest since Drift banks cannot earn interest or be borrowed against."
+      ],
+      "name": "DriftConfigCompact",
+      "type": {
+        "fields": [
+          {
+            "name": "oracle",
+            "type": "pubkey"
+          },
+          {
+            "name": "asset_weight_init",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "asset_weight_maint",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "deposit_limit",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "Either `DriftPythPull` or `DriftSwitchboardPull`"
+            ],
+            "name": "oracle_setup",
+            "type": {
+              "defined": {
+                "name": "OracleSetup"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Bank operational state - allows starting banks in paused state"
+            ],
+            "name": "operational_state",
+            "type": {
+              "defined": {
+                "name": "BankOperationalState"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Risk tier - determines if assets can be borrowed in isolation"
+            ],
+            "name": "risk_tier",
+            "type": {
+              "defined": {
+                "name": "RiskTier"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Config flags for future-proofing"
+            ],
+            "name": "config_flags",
+            "type": "u8"
+          },
+          {
+            "name": "total_asset_value_init_limit",
+            "type": "u64"
+          },
+          {
+            "name": "oracle_max_age",
+            "type": "u16"
+          },
+          {
+            "docs": [
+              "Oracle confidence threshold (0 = use default 10%)"
+            ],
+            "name": "oracle_max_confidence",
+            "type": "u32"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "EditStakedSettingsEvent",
+      "type": {
+        "fields": [
+          {
+            "name": "group",
+            "type": "pubkey"
+          },
+          {
+            "name": "settings",
+            "type": {
+              "defined": {
+                "name": "StakedSettingsEditConfig"
+              }
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "docs": [
+        "An emode configuration. Each bank has one such configuration, but this may also be the",
+        "intersection of many configurations (see `reconcile_emode_configs`). For example, the risk",
+        "engine creates such an intersection from all the emode config of all banks the user is borrowing",
+        "from."
+      ],
+      "name": "EmodeConfig",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "fields": [
+          {
+            "name": "entries",
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "EmodeEntry"
+                  }
+                },
+                10
+              ]
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "EmodeEntry",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "fields": [
+          {
+            "docs": [
+              "emode_tag of the bank(s) whose collateral you wish to treat preferentially."
+            ],
+            "name": "collateral_bank_emode_tag",
+            "type": "u16"
+          },
+          {
+            "docs": [
+              "* APPLIES_TO_ISOLATED (1) - (NOT YET IMPLEMENTED) if set, isolated banks with this tag",
+              "also benefit. If not set, isolated banks continue to offer zero collateral, even if they",
+              "use this tag.",
+              "* 2, 4, 8, 16, 32, etc - reserved for future use"
+            ],
+            "name": "flags",
+            "type": "u8"
+          },
+          {
+            "name": "pad0",
+            "type": {
+              "array": [
+                "u8",
+                5
+              ]
+            }
+          },
+          {
+            "docs": [
+              "Note: If set below the collateral bank's weight, does nothing."
+            ],
+            "name": "asset_weight_init",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Note: If set below the collateral bank's weight, does nothing."
+            ],
+            "name": "asset_weight_maint",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "docs": [
+        "Controls the bank's e-mode configuration, allowing certain collateral sources to be treated more",
+        "favorably as collateral when used to borrow from this bank."
+      ],
+      "name": "EmodeSettings",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "fields": [
+          {
+            "docs": [
+              "This bank's NON-unique id that other banks will use to determine what emode rate to use when",
+              "this bank is offered as collateral.",
+              "",
+              "For example, all stablecoin banks might share the same emode_tag, and in their entries, each",
+              "such stablecoin bank will recognize that collateral sources with this \"stable\" tag get",
+              "preferential weights. When a new stablecoin is added that is considered riskier, it may get",
+              "a new, less favorable emode tag, and eventually get upgraded to the same one as the other",
+              "stables",
+              "",
+              "* 0 is in an invalid tag and will do nothing."
+            ],
+            "name": "emode_tag",
+            "type": "u16"
+          },
+          {
+            "name": "pad0",
+            "type": {
+              "array": [
+                "u8",
+                6
+              ]
+            }
+          },
+          {
+            "docs": [
+              "Unix timestamp from the system clock when emode state was last updated"
+            ],
+            "name": "timestamp",
+            "type": "i64"
+          },
+          {
+            "docs": [
+              "EMODE_ON (1) - If set, at least one entry is configured",
+              "2, 4, 8, etc, Reserved for future use"
+            ],
+            "name": "flags",
+            "type": "u64"
+          },
+          {
+            "name": "emode_config",
+            "type": {
+              "defined": {
+                "name": "EmodeConfig"
+              }
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "ExecuteOrderBalanceRecord",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "fields": [
+          {
+            "name": "bank",
+            "type": "pubkey"
+          },
+          {
+            "name": "is_asset",
+            "type": "u8"
+          },
+          {
+            "name": "_pad0",
+            "type": {
+              "array": [
+                "u8",
+                5
+              ]
+            }
+          },
+          {
+            "name": "tag",
+            "type": "u16"
+          },
+          {
+            "name": "shares",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "ExecuteOrderRecord",
+      "repr": {
+        "kind": "c"
+      },
+      "serialization": "bytemuck",
+      "type": {
+        "fields": [
+          {
+            "name": "order",
+            "type": "pubkey"
+          },
+          {
+            "name": "executor",
+            "type": "pubkey"
+          },
+          {
+            "name": "balance_states",
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "ExecuteOrderBalanceRecord"
+                  }
+                },
+                14
+              ]
+            }
+          },
+          {
+            "name": "active_balance_count",
+            "type": "u8"
+          },
+          {
+            "name": "inactive_balance_count",
+            "type": "u8"
+          },
+          {
+            "name": "_reserved0",
+            "type": {
+              "array": [
+                "u8",
+                6
+              ]
+            }
+          },
+          {
+            "name": "order_start_health",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "docs": [
+        "Unique per-program. The Program Owner uses this account to administrate fees collected by the protocol"
+      ],
+      "name": "FeeState",
+      "repr": {
+        "kind": "c"
+      },
+      "serialization": "bytemuck",
+      "type": {
+        "fields": [
+          {
+            "docs": [
+              "The fee state's own key. A PDA derived from just `b\"feestate\"`"
+            ],
+            "name": "key",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "Can modify fees"
+            ],
+            "name": "global_fee_admin",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "The base wallet for all protocol fees. All SOL fees go to this wallet. All non-SOL fees go",
+              "to the cannonical ATA of this wallet for that asset."
+            ],
+            "name": "global_fee_wallet",
+            "type": "pubkey"
+          },
+          {
+            "name": "placeholder0",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "Flat fee assessed when a new bank is initialized, in lamports.",
+              "* In SOL, in native decimals."
+            ],
+            "name": "bank_init_flat_sol_fee",
+            "type": "u32"
+          },
+          {
+            "name": "bump_seed",
+            "type": "u8"
+          },
+          {
+            "name": "_padding0",
+            "type": {
+              "array": [
+                "u8",
+                3
+              ]
+            }
+          },
+          {
+            "docs": [
+              "Liquidators can claim at this premium, when liquidating an asset in receivership",
+              "liquidation, e.g. (1 + this) * amount repaid >= asset seized",
+              "* A percentage"
+            ],
+            "name": "liquidation_max_fee",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Fee collected by the program owner from all groups",
+              "* A percentage"
+            ],
+            "name": "program_fee_fixed",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Fee collected by the program owner from all groups",
+              "* A percentage"
+            ],
+            "name": "program_fee_rate",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "When the global admin pauses the protocol in the event of an emergency, information about",
+              "the pause duration will be stored here and propagated to groups."
+            ],
+            "name": "panic_state",
+            "type": {
+              "defined": {
+                "name": "PanicState"
+              }
+            }
+          },
+          {
+            "name": "placeholder1",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "Flat fee assessed for insurance/program use when a liquidation is executed",
+              "* In SOL, in native decimals."
+            ],
+            "name": "liquidation_flat_sol_fee",
+            "type": "u32"
+          },
+          {
+            "docs": [
+              "Flat fee assessed for preventing spam use when creating an order",
+              "* In SOL, in native decimals."
+            ],
+            "name": "order_init_flat_sol_fee",
+            "type": "u32"
+          },
+          {
+            "docs": [
+              "Take-profit Orders can be executed at this premium, which Keepers are allowed to keep (no",
+              "pun intended) e.g. (1 + this) * amount repaid >= asset seized",
+              "* A percentage"
+            ],
+            "name": "order_execution_max_fee",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "_reserved1",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "docs": [
+        "Cached fee configuration propagated from the global FeeState"
+      ],
+      "name": "FeeStateCache",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "fields": [
+          {
+            "docs": [
+              "The wallet that receives program-level fees"
+            ],
+            "name": "global_fee_wallet",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "Fixed fee APR charged to borrowers (program-level)"
+            ],
+            "name": "program_fee_fixed",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Proportional fee rate on interest (program-level)"
+            ],
+            "name": "program_fee_rate",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Unix timestamp of the last fee state propagation"
+            ],
+            "name": "last_update",
+            "type": "i64"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "GroupEventHeader",
+      "type": {
+        "fields": [
+          {
+            "name": "signer",
+            "type": {
+              "option": "pubkey"
+            }
+          },
+          {
+            "name": "marginfi_group",
+            "type": "pubkey"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "docs": [
+        "Per-group rate limiting configuration and state.",
+        "Tracks aggregate net outflow in USD."
+      ],
+      "name": "GroupRateLimiter",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "fields": [
+          {
+            "docs": [
+              "Hourly window rate limiter (USD)."
+            ],
+            "name": "hourly",
+            "type": {
+              "defined": {
+                "name": "RateLimitWindow"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Daily window rate limiter (USD)."
+            ],
+            "name": "daily",
+            "type": {
+              "defined": {
+                "name": "RateLimitWindow"
+              }
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "docs": [
+        "A read-only cache of the internal risk engine's information. Only valid in borrow/withdraw if",
+        "the tx does not fail. To see the state in any context, e.g. to figure out if the risk engine is",
+        "failing due to some bad price information, use `pulse_health`."
+      ],
+      "name": "HealthCache",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "fields": [
+          {
+            "docs": [
+              "Internal risk engine asset value, using initial weight (e.g. what is used for borrowing",
+              "purposes), with all confidence adjustments, and other discounts on price.",
+              "* Uses EMA price",
+              "* In dollars"
+            ],
+            "name": "asset_value",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Internal risk engine liability value, using initial weight (e.g. what is used for borrowing",
+              "purposes), with all confidence adjustments, and other discounts on price.",
+              "* Uses EMA price",
+              "* In dollars"
+            ],
+            "name": "liability_value",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Internal risk engine asset value, using maintenance weight (e.g. what is used for",
+              "liquidation purposes), with all confidence adjustments.",
+              "* Zero if the risk engine failed to load",
+              "* Uses SPOT price",
+              "* In dollars"
+            ],
+            "name": "asset_value_maint",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Internal risk engine liability value, using maintenance weight (e.g. what is used for",
+              "liquidation purposes), with all confidence adjustments.",
+              "* Zero if the risk engine failed to load",
+              "* Uses SPOT price",
+              "* In dollars"
+            ],
+            "name": "liability_value_maint",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "The \"true\" value of assets without any confidence or weight adjustments. Internally, used",
+              "only for bankruptcies.",
+              "* Zero if the risk engine failed to load",
+              "* Uses EMA price",
+              "* In dollars"
+            ],
+            "name": "asset_value_equity",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "The \"true\" value of liabilities without any confidence or weight adjustments.",
+              "Internally, used only for bankruptcies.",
+              "* Zero if the risk engine failed to load",
+              "* Uses EMA price",
+              "* In dollars"
+            ],
+            "name": "liability_value_equity",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Unix timestamp from the system clock when this cache was last updated"
+            ],
+            "name": "timestamp",
+            "type": "i64"
+          },
+          {
+            "docs": [
+              "The flags that indicate the state of the health cache. This is a u32 bitfield, where each",
+              "bit represents a flag.",
+              "",
+              "* HEALTHY = 1 - If set, the account cannot be liquidated. If 0, the account is unhealthy and",
+              "can be liquidated.",
+              "* ENGINE STATUS = 2 - If set, the engine did not error during the last health pulse. If 0,",
+              "the engine would have errored and this cache is likely invalid. `RiskEngineInitRejected`",
+              "is ignored and will allow the flag to be set anyways.",
+              "* ORACLE OK = 4 - If set, the engine did not error due to an oracle issue. If 0, engine was",
+              "passed a bad bank or oracle account, or an oracle was stale. Check the order in which",
+              "accounts were passed and ensure each balance has the correct banks/oracles, and that",
+              "oracle cranks ran recently enough. Check `internal_err` and `err_index` for more details",
+              "in some circumstances. Invalid if generated after borrow/withdraw (these instructions will",
+              "ignore oracle issues if health is still satisfactory with some balance zeroed out).",
+              "* 8, 16, 32, 64, 128, etc - reserved for future use"
+            ],
+            "name": "flags",
+            "type": "u32"
+          },
+          {
+            "docs": [
+              "If the engine errored, look here for the error code. If the engine returns ok, you may also",
+              "check here to see if the risk engine rejected this tx (3009)."
+            ],
+            "name": "mrgn_err",
+            "type": "u32"
+          },
+          {
+            "docs": [
+              "Each price corresponds to that index of Balances in the LendingAccount. Useful for debugging",
+              "or liquidator consumption, to determine how a user's position is priced internally.",
+              "* An f64 stored as bytes"
+            ],
+            "name": "prices",
+            "type": {
+              "array": [
+                {
+                  "array": [
+                    "u8",
+                    8
+                  ]
+                },
+                16
+              ]
+            }
+          },
+          {
+            "docs": [
+              "Errors in asset oracles are ignored (with prices treated as zero). If you see a zero price",
+              "and the `ORACLE_OK` flag is not set, check here to see what error was ignored internally."
+            ],
+            "name": "internal_err",
+            "type": "u32"
+          },
+          {
+            "docs": [
+              "Index in `balances` where `internal_err` appeared"
+            ],
+            "name": "err_index",
+            "type": "u8"
+          },
+          {
+            "docs": [
+              "Since 0.1.3, the version will be encoded here. See PROGRAM_VERSION."
+            ],
+            "name": "program_version",
+            "type": "u8"
+          },
+          {
+            "name": "pad0",
+            "type": {
+              "array": [
+                "u8",
+                2
+              ]
+            }
+          },
+          {
+            "docs": [
+              "Error code from the liquidation health check during the last health pulse (0 if none)"
+            ],
+            "name": "internal_liq_err",
+            "type": "u32"
+          },
+          {
+            "docs": [
+              "Error code from the bankruptcy check during the last health pulse (0 if none)"
+            ],
+            "name": "internal_bankruptcy_err",
+            "type": "u32"
+          },
+          {
+            "name": "reserved0",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "reserved1",
+            "type": {
+              "array": [
+                "u8",
+                16
+              ]
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "HealthPulseEvent",
+      "type": {
+        "fields": [
+          {
+            "name": "account",
+            "type": "pubkey"
+          },
+          {
+            "name": "health_cache",
+            "type": {
+              "defined": {
+                "name": "HealthCache"
+              }
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "InterestRateConfig",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "fields": [
+          {
+            "name": "optimal_utilization_rate",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "plateau_interest_rate",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "max_interest_rate",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Goes to insurance, funds `collected_insurance_fees_outstanding`"
+            ],
+            "name": "insurance_fee_fixed_apr",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Goes to insurance, funds `collected_insurance_fees_outstanding`"
+            ],
+            "name": "insurance_ir_fee",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Earned by the group, goes to `collected_group_fees_outstanding`"
+            ],
+            "name": "protocol_fixed_fee_apr",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Earned by the group, goes to `collected_group_fees_outstanding`"
+            ],
+            "name": "protocol_ir_fee",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "protocol_origination_fee",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "The base rate at utilization = 0",
+              "* a %, as u32, out of 1000%, e.g. 100% = 0.1 * u32::MAX"
+            ],
+            "name": "zero_util_rate",
+            "type": "u32"
+          },
+          {
+            "docs": [
+              "The base rate at utilization = 100",
+              "* a %, as u32, out of 1000%, e.g. 100% = 0.1 * u32::MAX"
+            ],
+            "name": "hundred_util_rate",
+            "type": "u32"
+          },
+          {
+            "docs": [
+              "The base rate at various points between 0 and 100%, exclusive. Essentially a piece-wise",
+              "linear curve.",
+              "* always in ascending order, e.g. points[0] = first kink point, points[1] = second kink",
+              "point, and so forth.",
+              "* points where util = 0 are unused"
+            ],
+            "name": "points",
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "RatePoint"
+                  }
+                },
+                5
+              ]
+            }
+          },
+          {
+            "docs": [
+              "Determines which interest rate curve implementation is active. 0 (INTEREST_CURVE_LEGACY) =",
+              "legacy three point curve, 1 (INTEREST_CURVE_SEVEN_POINT) = multi-point curve."
+            ],
+            "name": "curve_type",
+            "type": "u8"
+          },
+          {
+            "name": "_pad0",
+            "type": {
+              "array": [
+                "u8",
+                7
+              ]
+            }
+          },
+          {
+            "name": "_padding1",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "_padding2",
+            "type": {
+              "array": [
+                "u8",
+                16
+              ]
+            }
+          },
+          {
+            "name": "_padding3",
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "InterestRateConfigCompact",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "fields": [
+          {
+            "name": "insurance_fee_fixed_apr",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "insurance_ir_fee",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "protocol_fixed_fee_apr",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "protocol_ir_fee",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "protocol_origination_fee",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "The base rate at utilization = 0",
+              "* a %, as u32, out of 1000%, e.g. 100% = 0.1 * u32::MAX"
+            ],
+            "name": "zero_util_rate",
+            "type": "u32"
+          },
+          {
+            "docs": [
+              "The base rate at utilization = 100",
+              "* a %, as u32, out of 1000%, e.g. 100% = 0.1 * u32::MAX"
+            ],
+            "name": "hundred_util_rate",
+            "type": "u32"
+          },
+          {
+            "docs": [
+              "The base rate at various points between 0 and 100%, exclusive. Essentially a piece-wise",
+              "linear curve.",
+              "* always in ascending order, e.g. points[0] = first kink point, points[1] = second kink",
+              "point, and so forth.",
+              "* points where util = 0 are unused"
+            ],
+            "name": "points",
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "RatePoint"
+                  }
+                },
+                5
+              ]
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "InterestRateConfigOpt",
+      "type": {
+        "fields": [
+          {
+            "name": "insurance_fee_fixed_apr",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "WrappedI80F48"
+                }
+              }
+            }
+          },
+          {
+            "name": "insurance_ir_fee",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "WrappedI80F48"
+                }
+              }
+            }
+          },
+          {
+            "name": "protocol_fixed_fee_apr",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "WrappedI80F48"
+                }
+              }
+            }
+          },
+          {
+            "name": "protocol_ir_fee",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "WrappedI80F48"
+                }
+              }
+            }
+          },
+          {
+            "name": "protocol_origination_fee",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "WrappedI80F48"
+                }
+              }
+            }
+          },
+          {
+            "docs": [
+              "The base rate at utilization = 0",
+              "* a %, as u32, out of 1000%, e.g. 100% = 0.1 * u32::MAX"
+            ],
+            "name": "zero_util_rate",
+            "type": {
+              "option": "u32"
+            }
+          },
+          {
+            "docs": [
+              "The base rate at utilization = 100",
+              "* a %, as u32, out of 1000%, e.g. 100% = 0.1 * u32::MAX"
+            ],
+            "name": "hundred_util_rate",
+            "type": {
+              "option": "u32"
+            }
+          },
+          {
+            "docs": [
+              "The base rate at various points between 0 and 100%, exclusive. Essentially a piece-wise",
+              "linear curve.",
+              "* always in ascending order, e.g. points[0] = first kink point, points[1] = second kink",
+              "point, and so forth.",
+              "* points where util = 0 are unused"
+            ],
+            "name": "points",
+            "type": {
+              "option": {
+                "array": [
+                  {
+                    "defined": {
+                      "name": "RatePoint"
+                    }
+                  },
+                  5
+                ]
+              }
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "docs": [
+        "Used to configure JupLend banks. A simplified version of `BankConfigCompact` which omits most",
+        "values related to interest since JupLend banks cannot earn interest or be borrowed against.",
+        "",
+        "Note: JupLend banks do not take an Operational State, they always start in `Paused` state and",
+        "are set to `Operational` via `juplend_init_position` (seed deposit + protocol fToken vault)."
+      ],
+      "name": "JuplendConfigCompact",
+      "type": {
+        "fields": [
+          {
+            "name": "oracle",
+            "type": "pubkey"
+          },
+          {
+            "name": "asset_weight_init",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "asset_weight_maint",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "deposit_limit",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "Either `JuplendPythPull` or `JuplendSwitchboardPull`"
+            ],
+            "name": "oracle_setup",
+            "type": {
+              "defined": {
+                "name": "OracleSetup"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Isolated or Collateral"
+            ],
+            "name": "risk_tier",
+            "type": {
+              "defined": {
+                "name": "RiskTier"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Config flags for future-proofing, currently ignored"
+            ],
+            "name": "config_flags",
+            "type": "u8"
+          },
+          {
+            "docs": [
+              "In $"
+            ],
+            "name": "total_asset_value_init_limit",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "In seconds"
+            ],
+            "name": "oracle_max_age",
+            "type": "u16"
+          },
+          {
+            "docs": [
+              "Oracle confidence threshold (0 = use default 10%)"
+            ],
+            "name": "oracle_max_confidence",
+            "type": "u32"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "docs": [
+        "Used to configure Kamino banks. A simplified version of `BankConfigCompact` which omits most",
+        "values related to interest since Kamino banks cannot earn interest or be borrowed against."
+      ],
+      "name": "KaminoConfigCompact",
+      "type": {
+        "fields": [
+          {
+            "name": "oracle",
+            "type": "pubkey"
+          },
+          {
+            "name": "asset_weight_init",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "asset_weight_maint",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "deposit_limit",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "Either `KaminoPythPush` or `KaminoSwitchboardPull`"
+            ],
+            "name": "oracle_setup",
+            "type": {
+              "defined": {
+                "name": "OracleSetup"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Bank operational state - allows starting banks in paused state"
+            ],
+            "name": "operational_state",
+            "type": {
+              "defined": {
+                "name": "BankOperationalState"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Risk tier - determines if assets can be borrowed in isolation"
+            ],
+            "name": "risk_tier",
+            "type": {
+              "defined": {
+                "name": "RiskTier"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Config flags for future-proofing"
+            ],
+            "name": "config_flags",
+            "type": "u8"
+          },
+          {
+            "name": "total_asset_value_init_limit",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "Currently unused: Kamino's oracle age applies to kamino banks."
+            ],
+            "name": "oracle_max_age",
+            "type": "u16"
+          },
+          {
+            "docs": [
+              "Oracle confidence threshold (0 = use default 10%)"
+            ],
+            "name": "oracle_max_confidence",
+            "type": "u32"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "KeeperCloseOrderEvent",
+      "type": {
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": {
+                "name": "AccountEventHeader"
+              }
+            }
+          },
+          {
+            "name": "order",
+            "type": "pubkey"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "docs": [
+        "Minimal representation of the on-chain JupLend `Lending` account.",
+        "",
+        "Notes:",
+        "- We intentionally use a **zero-copy** layout here to match how other integrations load large",
+        "external accounts (and to avoid paying Borsh (de)serialization cost on every access).",
+        "- `repr(C, packed)` keeps the byte layout identical to a field-by-field serialization",
+        "(i.e. no implicit padding). This is important because `Pubkey` has alignment=1 while `u64`",
+        "has alignment=8; using plain `repr(C)` would insert padding before the first `u64`."
+      ],
+      "name": "Lending",
+      "repr": {
+        "kind": "c",
+        "packed": true
+      },
+      "serialization": "bytemuck",
+      "type": {
+        "fields": [
+          {
+            "name": "mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "f_token_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "lending_id",
+            "type": "u16"
+          },
+          {
+            "docs": [
+              "number of decimals for the fToken, same as underlying mint"
+            ],
+            "name": "decimals",
+            "type": "u8"
+          },
+          {
+            "docs": [
+              "PDA of rewards rate model (LRRM)"
+            ],
+            "name": "rewards_rate_model",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "exchange price in the liquidity layer (no rewards)"
+            ],
+            "name": "liquidity_exchange_price",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "exchange price between fToken and underlying (with rewards)"
+            ],
+            "name": "token_exchange_price",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "unix timestamp when exchange prices were updated last"
+            ],
+            "name": "last_update_timestamp",
+            "type": "u64"
+          },
+          {
+            "name": "token_reserves_liquidity",
+            "type": "pubkey"
+          },
+          {
+            "name": "supply_position_on_liquidity",
+            "type": "pubkey"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "docs": [
+        "The lending account holds up to 16 balance positions for a user."
+      ],
+      "name": "LendingAccount",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "fields": [
+          {
+            "docs": [
+              "Array of balance positions (max 16). Sorted in descending order by bank_pk."
+            ],
+            "name": "balances",
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "Balance"
+                  }
+                },
+                16
+              ]
+            }
+          },
+          {
+            "docs": [
+              "Last allocated balance tag (u16), used to find the next unused tag."
+            ],
+            "name": "last_tag_used",
+            "type": "u16"
+          },
+          {
+            "docs": [
+              "Reserved for future use"
+            ],
+            "name": "_pad1",
+            "type": {
+              "array": [
+                "u8",
+                6
+              ]
+            }
+          },
+          {
+            "docs": [
+              "Reserved for future use"
+            ],
+            "name": "_padding",
+            "type": {
+              "array": [
+                "u64",
+                7
+              ]
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "LendingAccountBorrowEvent",
+      "type": {
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": {
+                "name": "AccountEventHeader"
+              }
+            }
+          },
+          {
+            "name": "bank",
+            "type": "pubkey"
+          },
+          {
+            "name": "mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "LendingAccountDepositEvent",
+      "type": {
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": {
+                "name": "AccountEventHeader"
+              }
+            }
+          },
+          {
+            "name": "bank",
+            "type": "pubkey"
+          },
+          {
+            "name": "mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "LendingAccountLiquidateEvent",
+      "type": {
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": {
+                "name": "AccountEventHeader"
+              }
+            }
+          },
+          {
+            "name": "liquidatee_marginfi_account",
+            "type": "pubkey"
+          },
+          {
+            "name": "liquidatee_marginfi_account_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "asset_bank",
+            "type": "pubkey"
+          },
+          {
+            "name": "asset_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "liability_bank",
+            "type": "pubkey"
+          },
+          {
+            "name": "liability_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "liquidatee_pre_health",
+            "type": "f64"
+          },
+          {
+            "name": "liquidatee_post_health",
+            "type": "f64"
+          },
+          {
+            "name": "pre_balances",
+            "type": {
+              "defined": {
+                "name": "LiquidationBalances"
+              }
+            }
+          },
+          {
+            "name": "post_balances",
+            "type": {
+              "defined": {
+                "name": "LiquidationBalances"
+              }
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "LendingAccountRepayEvent",
+      "type": {
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": {
+                "name": "AccountEventHeader"
+              }
+            }
+          },
+          {
+            "name": "bank",
+            "type": "pubkey"
+          },
+          {
+            "name": "mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "close_balance",
+            "type": "bool"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "LendingAccountWithdrawEvent",
+      "type": {
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": {
+                "name": "AccountEventHeader"
+              }
+            }
+          },
+          {
+            "name": "bank",
+            "type": "pubkey"
+          },
+          {
+            "name": "mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "close_balance",
+            "type": "bool"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "LendingPoolBankAccrueInterestEvent",
+      "type": {
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": {
+                "name": "GroupEventHeader"
+              }
+            }
+          },
+          {
+            "name": "bank",
+            "type": "pubkey"
+          },
+          {
+            "name": "mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "delta",
+            "type": "u64"
+          },
+          {
+            "name": "fees_collected",
+            "type": "f64"
+          },
+          {
+            "name": "insurance_collected",
+            "type": "f64"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "LendingPoolBankCollectFeesEvent",
+      "type": {
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": {
+                "name": "GroupEventHeader"
+              }
+            }
+          },
+          {
+            "name": "bank",
+            "type": "pubkey"
+          },
+          {
+            "name": "mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "group_fees_collected",
+            "type": "f64"
+          },
+          {
+            "name": "group_fees_outstanding",
+            "type": "f64"
+          },
+          {
+            "name": "insurance_fees_collected",
+            "type": "f64"
+          },
+          {
+            "name": "insurance_fees_outstanding",
+            "type": "f64"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "LendingPoolBankConfigureEvent",
+      "type": {
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": {
+                "name": "GroupEventHeader"
+              }
+            }
+          },
+          {
+            "name": "bank",
+            "type": "pubkey"
+          },
+          {
+            "name": "mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "config",
+            "type": {
+              "defined": {
+                "name": "BankConfigOpt"
+              }
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "LendingPoolBankConfigureFrozenEvent",
+      "type": {
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": {
+                "name": "GroupEventHeader"
+              }
+            }
+          },
+          {
+            "name": "bank",
+            "type": "pubkey"
+          },
+          {
+            "name": "mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "deposit_limit",
+            "type": "u64"
+          },
+          {
+            "name": "borrow_limit",
+            "type": "u64"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "LendingPoolBankConfigureOracleEvent",
+      "type": {
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": {
+                "name": "GroupEventHeader"
+              }
+            }
+          },
+          {
+            "name": "bank",
+            "type": "pubkey"
+          },
+          {
+            "name": "oracle_setup",
+            "type": "u8"
+          },
+          {
+            "name": "oracle",
+            "type": "pubkey"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "LendingPoolBankCreateEvent",
+      "type": {
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": {
+                "name": "GroupEventHeader"
+              }
+            }
+          },
+          {
+            "name": "bank",
+            "type": "pubkey"
+          },
+          {
+            "name": "mint",
+            "type": "pubkey"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "LendingPoolBankHandleBankruptcyEvent",
+      "type": {
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": {
+                "name": "AccountEventHeader"
+              }
+            }
+          },
+          {
+            "name": "bank",
+            "type": "pubkey"
+          },
+          {
+            "name": "mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "bad_debt",
+            "type": "f64"
+          },
+          {
+            "name": "covered_amount",
+            "type": "f64"
+          },
+          {
+            "name": "socialized_amount",
+            "type": "f64"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "LendingPoolBankSetFixedOraclePriceEvent",
+      "type": {
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": {
+                "name": "GroupEventHeader"
+              }
+            }
+          },
+          {
+            "name": "bank",
+            "type": "pubkey"
+          },
+          {
+            "name": "price",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "LiquidationBalances",
+      "type": {
+        "fields": [
+          {
+            "name": "liquidatee_asset_balance",
+            "type": "f64"
+          },
+          {
+            "name": "liquidatee_liability_balance",
+            "type": "f64"
+          },
+          {
+            "name": "liquidator_asset_balance",
+            "type": "f64"
+          },
+          {
+            "name": "liquidator_liability_balance",
+            "type": "f64"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "LiquidationCache",
+      "repr": {
+        "kind": "c"
+      },
+      "serialization": "bytemuck",
+      "type": {
+        "fields": [
+          {
+            "docs": [
+              "Internal risk engine asset value snapshot taken when liquidation begins, using maintenance",
+              "weight with all confidence adjustments.",
+              "* Uses SPOT price",
+              "* In dollars"
+            ],
+            "name": "asset_value_maint",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Internal risk engine liability value snapshot taken when liquidation begins, using",
+              "maintenance weight with all confidence adjustments.",
+              "* Uses SPOT price",
+              "* In dollars"
+            ],
+            "name": "liability_value_maint",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Actual cash value of assets pre-liquidation (inclusive of price adjustment for oracle",
+              "confidence, but without any weights)",
+              "* Liquidator is allowed to seize up to `liability_value_equity` - this amount",
+              "* Uses EMA price",
+              "* In dollars"
+            ],
+            "name": "asset_value_equity",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Actual cash value of liabilities pre-liquidation (inclusive of price adjustment for oracle",
+              "confidence, but without any weights)",
+              "* Liquidator is allowed to seize up to this amount - `asset_value_equity`",
+              "* Uses EMA price",
+              "* In dollars"
+            ],
+            "name": "liability_value_equity",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "_placeholder",
+            "type": "u64"
+          },
+          {
+            "name": "_reserved0",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "docs": [
+        "Used to record key details of the last few liquidation events on the account"
+      ],
+      "name": "LiquidationEntry",
+      "repr": {
+        "kind": "c"
+      },
+      "serialization": "bytemuck",
+      "type": {
+        "fields": [
+          {
+            "docs": [
+              "Dollar amount seized",
+              "* An f64 stored as bytes"
+            ],
+            "name": "asset_amount_seized",
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          },
+          {
+            "docs": [
+              "Dollar amount repaid",
+              "* An f64 stored as bytes"
+            ],
+            "name": "liab_amount_repaid",
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          },
+          {
+            "name": "placeholder0",
+            "type": "u64"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          },
+          {
+            "name": "_reserved0",
+            "type": {
+              "array": [
+                "u8",
+                16
+              ]
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "LiquidationReceiverEvent",
+      "type": {
+        "fields": [
+          {
+            "name": "marginfi_account",
+            "type": "pubkey"
+          },
+          {
+            "name": "liquidation_receiver",
+            "type": "pubkey"
+          },
+          {
+            "name": "liquidatee_assets_seized",
+            "type": "f64"
+          },
+          {
+            "name": "liquidatee_liability_repaid",
+            "type": "f64"
+          },
+          {
+            "name": "lamps_fee_paid",
+            "type": "u32"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "LiquidationRecord",
+      "repr": {
+        "kind": "c"
+      },
+      "serialization": "bytemuck",
+      "type": {
+        "fields": [
+          {
+            "docs": [
+              "This account's own key. A PDA derived from `marginfi_account`"
+            ],
+            "name": "key",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "Account this record tracks"
+            ],
+            "name": "marginfi_account",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "The key that paid to create this account. At some point, we may allow this wallet to reclaim",
+              "the rent paid to open a record."
+            ],
+            "name": "record_payer",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "The liquidator taking receivership of the `marginfi_account` to complete a liquidation. Pays",
+              "the liquidation fee.",
+              "* Always pubkey default unless actively within a liquidation event."
+            ],
+            "name": "liquidation_receiver",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "Basic historical data for the last few liquidation events on this account"
+            ],
+            "name": "entries",
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "LiquidationEntry"
+                  }
+                },
+                4
+              ]
+            }
+          },
+          {
+            "name": "cache",
+            "type": {
+              "defined": {
+                "name": "LiquidationCache"
+              }
+            }
+          },
+          {
+            "name": "_reserved0",
+            "type": {
+              "array": [
+                "u8",
+                64
+              ]
+            }
+          },
+          {
+            "name": "_reserved2",
+            "type": {
+              "array": [
+                "u8",
+                16
+              ]
+            }
+          },
+          {
+            "name": "_reserved3",
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "MarginfiAccount",
+      "repr": {
+        "kind": "c"
+      },
+      "serialization": "bytemuck",
+      "type": {
+        "fields": [
+          {
+            "name": "group",
+            "type": "pubkey"
+          },
+          {
+            "name": "authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "lending_account",
+            "type": {
+              "defined": {
+                "name": "LendingAccount"
+              }
+            }
+          },
+          {
+            "docs": [
+              "The flags that indicate the state of the account. This is u64 bitfield, where each bit",
+              "represents a flag.",
+              "",
+              "Flags:MarginfiAccount",
+              "- 1: `ACCOUNT_DISABLED` - Indicates that the account is disabled and no further actions can",
+              "be taken on it.",
+              "- 2: `ACCOUNT_IN_FLASHLOAN` - Only set when an account is within a flash loan, e.g. when",
+              "start_flashloan is called, then unset when the flashloan ends.",
+              "- 4: `ACCOUNT_FLAG_DEPRECATED` - Deprecated, available for future use",
+              "- 8: `ACCOUNT_TRANSFER_AUTHORITY_DEPRECATED` - the admin has flagged with account to be",
+              "moved, original owner can now call `set_account_transfer_authority`",
+              "- 16: `ACCOUNT_IN_RECEIVERSHIP` - the account is eligible to be liquidated and has entered",
+              "receivership, a liquidator is able to control borrows and withdraws until the end of the",
+              "tx. This flag will only appear within a tx.",
+              "- 32: `ACCOUNT_IN_DELEVERAGE - the account is being deleveraged by the risk admin",
+              "- 64: `ACCOUNT_FROZEN` - the admin has frozen the account; only the group admin may perform",
+              "actions until unfrozen."
+            ],
+            "name": "account_flags",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "Wallet whose canonical ATA receives off-chain emissions distributions."
+            ],
+            "name": "emissions_destination_account",
+            "type": "pubkey"
+          },
+          {
+            "name": "health_cache",
+            "type": {
+              "defined": {
+                "name": "HealthCache"
+              }
+            }
+          },
+          {
+            "docs": [
+              "If this account was migrated from another one, store the original account key"
+            ],
+            "name": "migrated_from",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "If this account has been migrated to another one, store the destination account key"
+            ],
+            "name": "migrated_to",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "Unix timestamp (u64) of the last account interaction. Note: Bank.last_update uses i64."
+            ],
+            "name": "last_update",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "If a PDA-based account, the account index, a seed used to derive the PDA that can be chosen",
+              "arbitrarily (0.1.5 or later). Otherwise, does nothing."
+            ],
+            "name": "account_index",
+            "type": "u16"
+          },
+          {
+            "docs": [
+              "If a PDA-based account (0.1.5 or later), a \"vendor specific\" id. Values < PDA_FREE_THRESHOLD",
+              "can be used by anyone with no restrictions. Values >= PDA_FREE_THRESHOLD can only be used by",
+              "a particular program via CPI. These values require being added to a list, contact us for",
+              "more details. For legacy non-pda accounts, does nothing.",
+              "",
+              "Note: use a unique seed to tag accounts related to some particular program or campaign so",
+              "you can easily fetch them all later."
+            ],
+            "name": "third_party_index",
+            "type": "u16"
+          },
+          {
+            "docs": [
+              "This account's bump, if a PDA-based account (0.1.5 or later). Otherwise, does nothing."
+            ],
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "_pad0",
+            "type": {
+              "array": [
+                "u8",
+                3
+              ]
+            }
+          },
+          {
+            "docs": [
+              "Stores information related to liquidations made against this account. A pda of this",
+              "account's key, and \"liq_record\"",
+              "* Typically pubkey default if this account has never been liquidated or close to liquidation",
+              "* Opening this account is permissionless. Typically the liquidator pays, but e.g. we may",
+              "also charge the user if they are opening a risky position on the front end."
+            ],
+            "name": "liquidation_record",
+            "type": "pubkey"
+          },
+          {
+            "name": "_padding0",
+            "type": {
+              "array": [
+                "u64",
+                7
+              ]
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "MarginfiAccountCloseOrderEvent",
+      "type": {
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": {
+                "name": "AccountEventHeader"
+              }
+            }
+          },
+          {
+            "name": "order",
+            "type": "pubkey"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "MarginfiAccountCreateEvent",
+      "type": {
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": {
+                "name": "AccountEventHeader"
+              }
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "MarginfiAccountFreezeEvent",
+      "type": {
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": {
+                "name": "AccountEventHeader"
+              }
+            }
+          },
+          {
+            "name": "frozen",
+            "type": "bool"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "MarginfiAccountPlaceOrderEvent",
+      "type": {
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": {
+                "name": "AccountEventHeader"
+              }
+            }
+          },
+          {
+            "name": "order",
+            "type": "pubkey"
+          },
+          {
+            "name": "trigger",
+            "type": {
+              "defined": {
+                "name": "OrderTriggerType"
+              }
+            }
+          },
+          {
+            "name": "stop_loss",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "take_profit",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "tags",
+            "type": {
+              "array": [
+                "u16",
+                2
+              ]
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "MarginfiAccountTransferToNewAccount",
+      "type": {
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": {
+                "name": "AccountEventHeader"
+              }
+            }
+          },
+          {
+            "name": "old_account",
+            "type": "pubkey"
+          },
+          {
+            "name": "old_account_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "new_account_authority",
+            "type": "pubkey"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "MarginfiGroup",
+      "repr": {
+        "kind": "c"
+      },
+      "serialization": "bytemuck",
+      "type": {
+        "fields": [
+          {
+            "docs": [
+              "Broadly able to modify anything, and can set/remove other admins at will."
+            ],
+            "name": "admin",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "Bitmask for group settings flags.",
+              "* Bit 0 (1): `PROGRAM_FEES_ENABLED` — If set, program-level fees are enabled.",
+              "* Bits 1-63: Reserved for future use."
+            ],
+            "name": "group_flags",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "Caches information from the global `FeeState` so the FeeState can be omitted on certain ixes"
+            ],
+            "name": "fee_state_cache",
+            "type": {
+              "defined": {
+                "name": "FeeStateCache"
+              }
+            }
+          },
+          {
+            "docs": [
+              "For groups initialized in versions 0.1.2 or greater, this is an authoritative count",
+              "of the number of banks under this group. For groups initialized prior to 0.1.2,",
+              "a non-authoritative count of the number of banks initiated after 0.1.2 went live."
+            ],
+            "name": "banks",
+            "type": "u16"
+          },
+          {
+            "name": "pad0",
+            "type": {
+              "array": [
+                "u8",
+                6
+              ]
+            }
+          },
+          {
+            "docs": [
+              "This admin can configure collateral ratios above (but not below) the collateral ratio of",
+              "certain banks, e.g. allow SOL to count as 90% collateral when borrowing an LST instead of",
+              "the default rate."
+            ],
+            "name": "emode_admin",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "Can modify the fields in `config.interest_rate_config` but nothing else, for every bank",
+              "under this group"
+            ],
+            "name": "delegate_curve_admin",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "Can modify the `deposit_limit`, `borrow_limit`, `total_asset_value_init_limit` but nothing",
+              "else, for every bank under this group"
+            ],
+            "name": "delegate_limit_admin",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "Can modify the emissions `flags`, `emissions_rate` and `emissions_mint`, but nothing else,",
+              "for every bank under this group"
+            ],
+            "name": "delegate_emissions_admin",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "When program keeper temporarily puts the program into panic mode, information about the",
+              "duration of the lockup will be available here."
+            ],
+            "name": "panic_state_cache",
+            "type": {
+              "defined": {
+                "name": "PanicStateCache"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Keeps track of the liquidity withdrawn from the group over the day as a result of",
+              "deleverages. Used as a protection mechanism against too big (and unwanted) withdrawals (e.g.",
+              "when the risk admin is compromised)."
+            ],
+            "name": "deleverage_withdraw_window_cache",
+            "type": {
+              "defined": {
+                "name": "WithdrawWindowCache"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Can run bankruptcy and forced deleverage ixes to e.g. sunset risky/illiquid assets"
+            ],
+            "name": "risk_admin",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "Can modify a Bank's metadata, and nothing else."
+            ],
+            "name": "metadata_admin",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "Maximum leverage allowed for emode positions (initial margin), stored as u32 basis.",
+              "Use `u32_to_basis` to convert to I80F48. Range: 1-100."
+            ],
+            "name": "emode_max_init_leverage",
+            "type": "u32"
+          },
+          {
+            "docs": [
+              "Maximum leverage allowed for emode positions (maintenance margin), stored as u32 basis.",
+              "Must be > emode_max_init_leverage. Range: 1-100."
+            ],
+            "name": "emode_max_maint_leverage",
+            "type": "u32"
+          },
+          {
+            "docs": [
+              "Reserved for future use"
+            ],
+            "name": "_padding",
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          },
+          {
+            "docs": [
+              "Rate limiter for controlling aggregate withdraw/borrow outflow across all banks.",
+              "Tracks net outflow in USD."
+            ],
+            "name": "rate_limiter",
+            "type": {
+              "defined": {
+                "name": "GroupRateLimiter"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Last slot covered by an admin group rate limiter aggregation update."
+            ],
+            "name": "rate_limiter_last_admin_update_slot",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "Monotonic sequence number for admin group rate limiter updates.",
+              "This is used to enforce strict ordering and prevent duplicate/replayed batches",
+              "when slot ranges overlap or multiple updates happen in the same slot."
+            ],
+            "name": "rate_limiter_last_admin_update_seq",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "Last slot covered by an admin deleverage withdraw-limit aggregation update."
+            ],
+            "name": "deleverage_withdraw_last_admin_update_slot",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "Monotonic sequence number for admin deleverage withdraw-limit updates."
+            ],
+            "name": "deleverage_withdraw_last_admin_update_seq",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "Can modify flow-control status for the group, i.e. update the withdraw caches with flow",
+              "information from banks. Typically this is a hot wallet that lives in e.g. some cron job. If",
+              "compromised, flow control can be effectively disabled until the admin is restored, which",
+              "does not itself compromise any funds, and is merely annoying."
+            ],
+            "name": "delegate_flow_admin",
+            "type": "pubkey"
+          },
+          {
+            "name": "_padding_0",
+            "type": {
+              "array": [
+                {
+                  "array": [
+                    "u64",
+                    2
+                  ]
+                },
+                2
+              ]
+            }
+          },
+          {
+            "name": "_padding_1",
+            "type": {
+              "array": [
+                {
+                  "array": [
+                    "u64",
+                    2
+                  ]
+                },
+                32
+              ]
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "MarginfiGroupConfigureEvent",
+      "type": {
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": {
+                "name": "GroupEventHeader"
+              }
+            }
+          },
+          {
+            "name": "admin",
+            "type": {
+              "option": "pubkey"
+            }
+          },
+          {
+            "name": "flags",
+            "type": "u64"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "MarginfiGroupCreateEvent",
+      "type": {
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": {
+                "name": "GroupEventHeader"
+              }
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "docs": [
+        "A minimal copy of Kamino's Obligation for zero-copy deserialization"
+      ],
+      "name": "MinimalObligation",
+      "repr": {
+        "kind": "c"
+      },
+      "serialization": "bytemuck",
+      "type": {
+        "fields": [
+          {
+            "name": "tag",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "Kamino obligations are only good for one slot, e.g. `refresh_obligation` must have run within the",
+              "same slot as any ix that needs a non-stale obligation e.g. withdraw."
+            ],
+            "name": "last_update_slot",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "True if the obligation is stale, which will cause various ixes like withdraw to fail. Typically",
+              "set to true in any tx that modifies obligation balance, and set to false at the end of a",
+              "successful `refresh_obligation`",
+              "* 0 = false, 1 = true"
+            ],
+            "name": "last_update_stale",
+            "type": "u8"
+          },
+          {
+            "docs": [
+              "Each bit represents a passed check in price status.",
+              "* 63 = all checks passed",
+              "",
+              "Otherwise:",
+              "* PRICE_LOADED =        0b_0000_0001; // 1",
+              "* PRICE_AGE_CHECKED =   0b_0000_0010; // 2",
+              "* TWAP_CHECKED =        0b_0000_0100; // 4",
+              "* TWAP_AGE_CHECKED =    0b_0000_1000; // 8",
+              "* HEURISTIC_CHECKED =   0b_0001_0000; // 16",
+              "* PRICE_USAGE_ALLOWED = 0b_0010_0000; // 32"
+            ],
+            "name": "last_update_price_status",
+            "type": "u8"
+          },
+          {
+            "name": "last_update_placeholder",
+            "type": {
+              "array": [
+                "u8",
+                6
+              ]
+            }
+          },
+          {
+            "name": "lending_market",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "For mrgn banks, the bank's Liquidity Vault Authority (a pda which can be derived if the bank",
+              "key is known)"
+            ],
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "deposits",
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "MinimalObligationCollateral"
+                  }
+                },
+                8
+              ]
+            }
+          },
+          {
+            "name": "lowest_reserve_deposit_liquidation_ltv",
+            "type": "u64"
+          },
+          {
+            "name": "deposited_value_sf",
+            "type": {
+              "array": [
+                "u8",
+                16
+              ]
+            }
+          },
+          {
+            "name": "padding_part1",
+            "type": {
+              "array": [
+                "u8",
+                512
+              ]
+            }
+          },
+          {
+            "name": "padding_part2",
+            "type": {
+              "array": [
+                "u8",
+                512
+              ]
+            }
+          },
+          {
+            "name": "padding_part3",
+            "type": {
+              "array": [
+                "u8",
+                512
+              ]
+            }
+          },
+          {
+            "name": "padding_part4",
+            "type": {
+              "array": [
+                "u8",
+                512
+              ]
+            }
+          },
+          {
+            "name": "padding_part5a",
+            "type": {
+              "array": [
+                "u8",
+                64
+              ]
+            }
+          },
+          {
+            "name": "padding_part5c",
+            "type": {
+              "array": [
+                "u8",
+                24
+              ]
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "MinimalObligationCollateral",
+      "repr": {
+        "kind": "c"
+      },
+      "serialization": "bytemuck",
+      "type": {
+        "fields": [
+          {
+            "name": "deposit_reserve",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "In collateral token (NOT liquidity token), use `collateral_to_liquidity` to convert back to",
+              "liquidity token!",
+              "* Always 6 decimals"
+            ],
+            "name": "deposited_amount",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "* In dollars, based on last oracle price update",
+              "* Actually an I68F60, stored as a u128 (i.e. BN) in Kamino.",
+              "* A float (arbitrary decimals)"
+            ],
+            "name": "market_value_sf",
+            "type": {
+              "array": [
+                "u8",
+                16
+              ]
+            }
+          },
+          {
+            "name": "borrowed_amount_against_this_collateral_in_elevation_group",
+            "type": "u64"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u64",
+                9
+              ]
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "MinimalReserve",
+      "repr": {
+        "kind": "c"
+      },
+      "serialization": "bytemuck",
+      "type": {
+        "fields": [
+          {
+            "name": "version",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "Kamino reserves are only good for one slot, e.g. `refresh_reserve` must have run within the",
+              "same slot as any ix that needs a non-stale reserve e.g. withdraw."
+            ],
+            "name": "slot",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "True if the reserve is stale, which will cause various ixes like withdraw to fail. Typically",
+              "set to true in any tx that modifies reserve balance, and set to false at the end of a",
+              "successful `refresh_reserve`",
+              "* 0 = false, 1 = true"
+            ],
+            "name": "stale",
+            "type": "u8"
+          },
+          {
+            "docs": [
+              "Each bit represents a passed check in price status.",
+              "* 63 = all checks passed",
+              "",
+              "Otherwise:",
+              "* PRICE_LOADED =        0b_0000_0001; // 1",
+              "* PRICE_AGE_CHECKED =   0b_0000_0010; // 2",
+              "* TWAP_CHECKED =        0b_0000_0100; // 4",
+              "* TWAP_AGE_CHECKED =    0b_0000_1000; // 8",
+              "* HEURISTIC_CHECKED =   0b_0001_0000; // 16",
+              "* PRICE_USAGE_ALLOWED = 0b_0010_0000; // 32"
+            ],
+            "name": "price_status",
+            "type": "u8"
+          },
+          {
+            "name": "placeholder",
+            "type": {
+              "array": [
+                "u8",
+                6
+              ]
+            }
+          },
+          {
+            "name": "lending_market",
+            "type": "pubkey"
+          },
+          {
+            "name": "farm_collateral",
+            "type": "pubkey"
+          },
+          {
+            "name": "farm_debt",
+            "type": "pubkey"
+          },
+          {
+            "name": "mint_pubkey",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "* A PDA"
+            ],
+            "name": "supply_vault",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "* A PDA"
+            ],
+            "name": "fee_vault",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "In simple terms: (amount in supply vault - outstanding borrows)",
+              "* In token, with `mint_decimals`"
+            ],
+            "name": "available_amount",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "* In token, with `mint_decimals`",
+              "* Actually an I68F60, stored as a u128 (i.e. BN) in Kamino."
+            ],
+            "name": "borrowed_amount_sf",
+            "type": {
+              "array": [
+                "u8",
+                16
+              ]
+            }
+          },
+          {
+            "docs": [
+              "* Actually an I68F60, stored as a u128 (i.e. BN) in Kamino."
+            ],
+            "name": "market_price_sf",
+            "type": {
+              "array": [
+                "u8",
+                16
+              ]
+            }
+          },
+          {
+            "name": "market_price_last_updated_ts",
+            "type": "u64"
+          },
+          {
+            "name": "mint_decimals",
+            "type": "u64"
+          },
+          {
+            "name": "deposit_limit_crossed_timestamp",
+            "type": "u64"
+          },
+          {
+            "name": "borrow_limit_crossed_timestamp",
+            "type": "u64"
+          },
+          {
+            "name": "cumulative_borrow_rate_bsf",
+            "type": {
+              "array": [
+                "u8",
+                48
+              ]
+            }
+          },
+          {
+            "docs": [
+              "* In token, with `mint_decimals`",
+              "* Actually an I68F60, stored as a u128 (i.e. BN) in Kamino."
+            ],
+            "name": "accumulated_protocol_fees_sf",
+            "type": {
+              "array": [
+                "u8",
+                16
+              ]
+            }
+          },
+          {
+            "docs": [
+              "* In token, with `mint_decimals`",
+              "* Actually an I68F60, stored as a u128 (i.e. BN) in Kamino."
+            ],
+            "name": "accumulated_referrer_fees_sf",
+            "type": {
+              "array": [
+                "u8",
+                16
+              ]
+            }
+          },
+          {
+            "docs": [
+              "* In token, with `mint_decimals`",
+              "* Actually an I68F60, stored as a u128 (i.e. BN) in Kamino."
+            ],
+            "name": "pending_referrer_fees_sf",
+            "type": {
+              "array": [
+                "u8",
+                16
+              ]
+            }
+          },
+          {
+            "docs": [
+              "* In token, with `mint_decimals`",
+              "* Actually an I68F60, stored as a u128 (i.e. BN) in Kamino."
+            ],
+            "name": "absolute_referral_rate_sf",
+            "type": {
+              "array": [
+                "u8",
+                16
+              ]
+            }
+          },
+          {
+            "docs": [
+              "Token or Token22. If token22, note that Kamino does not support all Token22 extensions."
+            ],
+            "name": "token_program",
+            "type": "pubkey"
+          },
+          {
+            "name": "padding2_part1",
+            "type": {
+              "array": [
+                "u8",
+                256
+              ]
+            }
+          },
+          {
+            "name": "padding2_part2",
+            "type": {
+              "array": [
+                "u8",
+                128
+              ]
+            }
+          },
+          {
+            "name": "padding2_part3",
+            "type": {
+              "array": [
+                "u8",
+                24
+              ]
+            }
+          },
+          {
+            "name": "padding3",
+            "type": {
+              "array": [
+                "u8",
+                512
+              ]
+            }
+          },
+          {
+            "name": "padding_part1",
+            "type": {
+              "array": [
+                "u8",
+                512
+              ]
+            }
+          },
+          {
+            "name": "padding_part2",
+            "type": {
+              "array": [
+                "u8",
+                512
+              ]
+            }
+          },
+          {
+            "name": "padding_part3",
+            "type": {
+              "array": [
+                "u8",
+                128
+              ]
+            }
+          },
+          {
+            "name": "padding_part4",
+            "type": {
+              "array": [
+                "u8",
+                48
+              ]
+            }
+          },
+          {
+            "docs": [
+              "Mints collateral tokens",
+              "* A PDA",
+              "* technically 6 decimals, but uses `mint_decimals` regardless for all purposes",
+              "* authority = lending_market_authority"
+            ],
+            "name": "collateral_mint_pubkey",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "Total number of collateral tokens",
+              "* uses `mint_decimals`, even though it's technically 6 decimals under the hood"
+            ],
+            "name": "mint_total_supply",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "* A PDA"
+            ],
+            "name": "collateral_supply_vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "padding1_reserve_collateral",
+            "type": {
+              "array": [
+                "u8",
+                512
+              ]
+            }
+          },
+          {
+            "name": "padding2_reserve_collateral",
+            "type": {
+              "array": [
+                "u8",
+                512
+              ]
+            }
+          },
+          {
+            "name": "padding4_part1",
+            "type": {
+              "array": [
+                "u8",
+                4096
+              ]
+            }
+          },
+          {
+            "name": "padding4_part2",
+            "type": {
+              "array": [
+                "u8",
+                512
+              ]
+            }
+          },
+          {
+            "name": "padding4_part3",
+            "type": {
+              "array": [
+                "u8",
+                256
+              ]
+            }
+          },
+          {
+            "name": "padding4_part4",
+            "type": {
+              "array": [
+                "u8",
+                64
+              ]
+            }
+          },
+          {
+            "name": "padding4_part5",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "padding4_part6",
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "docs": [
+        "Minimal representation of Drift's SpotMarket account",
+        "Only includes the fields we actually need for marginfi integration",
+        "https://github.com/drift-labs/protocol-v2/tree/master/programs/drift/src/state/spot_market.rs#L35"
+      ],
+      "name": "MinimalSpotMarket",
+      "repr": {
+        "kind": "c"
+      },
+      "serialization": "bytemuck",
+      "type": {
+        "fields": [
+          {
+            "docs": [
+              "The address of the spot market. It is a pda of the market index"
+            ],
+            "name": "pubkey",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "The oracle used to price the markets deposits/borrows"
+            ],
+            "name": "oracle",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "The token mint of the market"
+            ],
+            "name": "mint",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "The vault used to store the market's deposits"
+            ],
+            "name": "vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "_padding1",
+            "type": {
+              "array": [
+                {
+                  "array": [
+                    "u64",
+                    4
+                  ]
+                },
+                9
+              ]
+            }
+          },
+          {
+            "name": "_padding2",
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          },
+          {
+            "docs": [
+              "All the fields we need for testing (stored as raw bytes for simplicity)"
+            ],
+            "name": "deposit_balance",
+            "type": {
+              "array": [
+                "u8",
+                16
+              ]
+            }
+          },
+          {
+            "name": "borrow_balance",
+            "type": {
+              "array": [
+                "u8",
+                16
+              ]
+            }
+          },
+          {
+            "name": "cumulative_deposit_interest",
+            "type": {
+              "array": [
+                "u8",
+                16
+              ]
+            }
+          },
+          {
+            "name": "cumulative_borrow_interest",
+            "type": {
+              "array": [
+                "u8",
+                16
+              ]
+            }
+          },
+          {
+            "name": "_padding3",
+            "type": {
+              "array": [
+                "u64",
+                9
+              ]
+            }
+          },
+          {
+            "docs": [
+              "Last time the cumulative deposit and borrow interest was updated",
+              "Offset: 568 bytes from start of struct (including discriminator)"
+            ],
+            "name": "last_interest_ts",
+            "type": "u64"
+          },
+          {
+            "name": "_padding4",
+            "type": {
+              "array": [
+                "u64",
+                13
+              ]
+            }
+          },
+          {
+            "name": "decimals",
+            "type": "u32"
+          },
+          {
+            "name": "market_index",
+            "type": "u16"
+          },
+          {
+            "name": "_padding5",
+            "type": {
+              "array": [
+                "u16",
+                24
+              ]
+            }
+          },
+          {
+            "name": "_padding6",
+            "type": {
+              "array": [
+                "u8",
+                1
+              ]
+            }
+          },
+          {
+            "name": "pool_id",
+            "type": "u8"
+          },
+          {
+            "docs": [
+              "Padding to reach 776 bytes total (including discriminator)"
+            ],
+            "name": "_padding7",
+            "type": {
+              "array": [
+                "u64",
+                5
+              ]
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "docs": [
+        "Minimal representation of Drift's User account",
+        "Only includes the fields we actually need"
+      ],
+      "name": "MinimalUser",
+      "repr": {
+        "kind": "c"
+      },
+      "serialization": "bytemuck",
+      "type": {
+        "fields": [
+          {
+            "docs": [
+              "The owner/authority of the account"
+            ],
+            "name": "authority",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "An addresses that can control the account on the authority's behalf"
+            ],
+            "name": "delegate",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "Encoded display name for the account"
+            ],
+            "name": "name",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "docs": [
+              "The user's spot positions (8 positions)"
+            ],
+            "name": "spot_positions",
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "SpotPosition"
+                  }
+                },
+                8
+              ]
+            }
+          },
+          {
+            "docs": [
+              "Skip to the fields we need at the end"
+            ],
+            "name": "_padding1",
+            "type": {
+              "array": [
+                "u64",
+                256
+              ]
+            }
+          },
+          {
+            "name": "_padding2",
+            "type": {
+              "array": [
+                "u64",
+                128
+              ]
+            }
+          },
+          {
+            "name": "_padding3",
+            "type": {
+              "array": [
+                "u64",
+                64
+              ]
+            }
+          },
+          {
+            "name": "_padding4",
+            "type": {
+              "array": [
+                "u64",
+                32
+              ]
+            }
+          },
+          {
+            "name": "_padding5",
+            "type": {
+              "array": [
+                "u64",
+                8
+              ]
+            }
+          },
+          {
+            "name": "_padding6",
+            "type": {
+              "array": [
+                "u64",
+                2
+              ]
+            }
+          },
+          {
+            "name": "_padding7",
+            "type": {
+              "array": [
+                "u16",
+                1
+              ]
+            }
+          },
+          {
+            "docs": [
+              "Sub account id for this user account"
+            ],
+            "name": "sub_account_id",
+            "type": "u16"
+          },
+          {
+            "name": "status",
+            "type": {
+              "defined": {
+                "name": "UserStatus"
+              }
+            }
+          },
+          {
+            "name": "_padding8",
+            "type": {
+              "array": [
+                "u8",
+                27
+              ]
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "OracleSetup",
+      "repr": {
+        "kind": "rust"
+      },
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "None"
+          },
+          {
+            "name": "PythLegacy"
+          },
+          {
+            "name": "SwitchboardV2"
+          },
+          {
+            "name": "PythPushOracle"
+          },
+          {
+            "name": "SwitchboardPull"
+          },
+          {
+            "name": "StakedWithPythPush"
+          },
+          {
+            "name": "KaminoPythPush"
+          },
+          {
+            "name": "KaminoSwitchboardPull"
+          },
+          {
+            "name": "Fixed"
+          },
+          {
+            "name": "DriftPythPull"
+          },
+          {
+            "name": "DriftSwitchboardPull"
+          },
+          {
+            "name": "SolendPythPull"
+          },
+          {
+            "name": "SolendSwitchboardPull"
+          },
+          {
+            "name": "FixedKamino"
+          },
+          {
+            "name": "FixedDrift"
+          },
+          {
+            "name": "JuplendPythPull"
+          },
+          {
+            "name": "JuplendSwitchboardPull"
+          },
+          {
+            "name": "FixedJuplend"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Order",
+      "repr": {
+        "kind": "c"
+      },
+      "serialization": "bytemuck",
+      "type": {
+        "fields": [
+          {
+            "name": "marginfi_account",
+            "type": "pubkey"
+          },
+          {
+            "name": "stop_loss",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "take_profit",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Reserved for future use"
+            ],
+            "name": "placeholder",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "* a %, as u32, out of 100%, e.g. 50% = .5 * u32::MAX"
+            ],
+            "name": "max_slippage",
+            "type": "u32"
+          },
+          {
+            "name": "pad0",
+            "type": {
+              "array": [
+                "u8",
+                4
+              ]
+            }
+          },
+          {
+            "docs": [
+              "Active tags (currently 2). Remaining capacity is stored in padding for layout compatibility.",
+              "Padding byte `ORDER_TAG_PADDING - 1` stores the tag count for forward compatibility. (u16 *",
+              "2 = 4 bytes)"
+            ],
+            "name": "tags",
+            "type": {
+              "array": [
+                "u16",
+                2
+              ]
+            }
+          },
+          {
+            "name": "pad1",
+            "type": {
+              "array": [
+                "u8",
+                4
+              ]
+            }
+          },
+          {
+            "name": "_tags_padding",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "docs": [
+              "Stop Loss (0), Take Profit (1), or Both (2)"
+            ],
+            "name": "trigger",
+            "type": {
+              "defined": {
+                "name": "OrderTriggerType"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Bump to derive this pda"
+            ],
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "pad2",
+            "type": {
+              "array": [
+                "u8",
+                6
+              ]
+            }
+          },
+          {
+            "name": "_reserved1",
+            "type": {
+              "array": [
+                {
+                  "array": [
+                    "u8",
+                    32
+                  ]
+                },
+                4
+              ]
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "OrderTrigger",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "fields": [
+              {
+                "name": "threshold",
+                "type": {
+                  "defined": {
+                    "name": "WrappedI80F48"
+                  }
+                }
+              },
+              {
+                "name": "max_slippage",
+                "type": "u32"
+              }
+            ],
+            "name": "StopLoss"
+          },
+          {
+            "fields": [
+              {
+                "name": "threshold",
+                "type": {
+                  "defined": {
+                    "name": "WrappedI80F48"
+                  }
+                }
+              },
+              {
+                "name": "max_slippage",
+                "type": "u32"
+              }
+            ],
+            "name": "TakeProfit"
+          },
+          {
+            "fields": [
+              {
+                "name": "stop_loss",
+                "type": {
+                  "defined": {
+                    "name": "WrappedI80F48"
+                  }
+                }
+              },
+              {
+                "name": "take_profit",
+                "type": {
+                  "defined": {
+                    "name": "WrappedI80F48"
+                  }
+                }
+              },
+              {
+                "name": "max_slippage",
+                "type": "u32"
+              }
+            ],
+            "name": "Both"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OrderTriggerType",
+      "repr": {
+        "kind": "rust"
+      },
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "StopLoss"
+          },
+          {
+            "name": "TakeProfit"
+          },
+          {
+            "name": "Both"
+          }
+        ]
+      }
+    },
+    {
+      "docs": [
+        "Panic state for emergency protocol pausing"
+      ],
+      "name": "PanicState",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "fields": [
+          {
+            "docs": [
+              "Whether the protocol is currently paused (1 = paused, 0 = not paused)"
+            ],
+            "name": "pause_flags",
+            "type": "u8"
+          },
+          {
+            "docs": [
+              "Number of times paused today (resets every 24 hours)"
+            ],
+            "name": "daily_pause_count",
+            "type": "u8"
+          },
+          {
+            "docs": [
+              "Number of consecutive pauses (resets when unpause happens)"
+            ],
+            "name": "consecutive_pause_count",
+            "type": "u8"
+          },
+          {
+            "name": "_reserved",
+            "type": {
+              "array": [
+                "u8",
+                5
+              ]
+            }
+          },
+          {
+            "docs": [
+              "Timestamp when the current pause started (0 if not paused)",
+              "* When a pause is extended before expiring, this could be in the future."
+            ],
+            "name": "pause_start_timestamp",
+            "type": "i64"
+          },
+          {
+            "docs": [
+              "Timestamp of the last daily reset (for tracking daily pause count)"
+            ],
+            "name": "last_daily_reset_timestamp",
+            "type": "i64"
+          },
+          {
+            "docs": [
+              "Reserved for future use (making total struct 32 bytes)"
+            ],
+            "name": "_reserved_space",
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "docs": [
+        "Cached panic state information for fast checking during user operations"
+      ],
+      "name": "PanicStateCache",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "fields": [
+          {
+            "docs": [
+              "Whether the protocol is currently paused (1 = paused, 0 = not paused)"
+            ],
+            "name": "pause_flags",
+            "type": "u8"
+          },
+          {
+            "name": "_reserved",
+            "type": {
+              "array": [
+                "u8",
+                7
+              ]
+            }
+          },
+          {
+            "docs": [
+              "Timestamp when the current pause started (0 if not paused)"
+            ],
+            "name": "pause_start_timestamp",
+            "type": "i64"
+          },
+          {
+            "docs": [
+              "Timestamp when this cache was last updated"
+            ],
+            "name": "last_cache_update",
+            "type": "i64"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "docs": [
+        "Emitted when a bank-level inflow or outflow is recorded.",
+        "The delegate flow admin aggregates these off-chain and",
+        "updates the group rate limiter via `update_group_rate_limiter`."
+      ],
+      "name": "RateLimitFlowEvent",
+      "type": {
+        "fields": [
+          {
+            "name": "group",
+            "type": "pubkey"
+          },
+          {
+            "name": "bank",
+            "type": "pubkey"
+          },
+          {
+            "name": "mint",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "0 = outflow (withdraw/borrow), 1 = inflow (deposit/repay)"
+            ],
+            "name": "flow_direction",
+            "type": "u8"
+          },
+          {
+            "docs": [
+              "Amount in native tokens"
+            ],
+            "name": "native_amount",
+            "type": "u64"
+          },
+          {
+            "name": "mint_decimals",
+            "type": "u8"
+          },
+          {
+            "docs": [
+              "Unix timestamp when the flow was recorded"
+            ],
+            "name": "current_timestamp",
+            "type": "i64"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "docs": [
+        "A sliding window rate limiter that tracks net outflow over a time window.",
+        "Uses weighted blend of previous and current windows for smooth transitions.",
+        "",
+        "Net outflow = (withdraws + borrows) - (deposits + repays).",
+        "A negative net outflow increases remaining capacity for subsequent outflows."
+      ],
+      "name": "RateLimitWindow",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "fields": [
+          {
+            "docs": [
+              "Maximum net outflow allowed per window (0 = disabled).",
+              "For bank-level: denominated in native tokens.",
+              "For group-level: denominated in USD."
+            ],
+            "name": "max_outflow",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "Window duration in seconds (e.g., 3600 for hourly, 86400 for daily)."
+            ],
+            "name": "window_duration",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "Unix timestamp when the current window started."
+            ],
+            "name": "window_start",
+            "type": "i64"
+          },
+          {
+            "docs": [
+              "Net outflow accumulated in the previous window.",
+              "Signed to allow tracking when inflows exceed outflows."
+            ],
+            "name": "prev_window_outflow",
+            "type": "i64"
+          },
+          {
+            "docs": [
+              "Net outflow accumulated in the current window.",
+              "Signed to allow tracking when inflows exceed outflows."
+            ],
+            "name": "cur_window_outflow",
+            "type": "i64"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "RatePoint",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "fields": [
+          {
+            "docs": [
+              "The utilization rate where `rate` applies",
+              "* a %, as u32, out of 100%, e.g. 50% = .5 * u32::MAX"
+            ],
+            "name": "util",
+            "type": "u32"
+          },
+          {
+            "docs": [
+              "The base rate that applies",
+              "* a %, as u32, out of 1000%, e.g. 100% = 0.1 * u32::MAX"
+            ],
+            "name": "rate",
+            "type": "u32"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "RiskTier",
+      "repr": {
+        "kind": "rust"
+      },
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Collateral"
+          },
+          {
+            "name": "Isolated"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SetKeeperCloseFlagsEvent",
+      "type": {
+        "fields": [
+          {
+            "name": "header",
+            "type": {
+              "defined": {
+                "name": "AccountEventHeader"
+              }
+            }
+          },
+          {
+            "name": "bank_keys",
+            "type": {
+              "option": {
+                "vec": "pubkey"
+              }
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "docs": [
+        "Used to configure Solend banks. A simplified version of `BankConfigCompact` which omits most",
+        "values related to interest since Solend banks cannot earn interest or be borrowed against."
+      ],
+      "name": "SolendConfigCompact",
+      "type": {
+        "fields": [
+          {
+            "name": "oracle",
+            "type": "pubkey"
+          },
+          {
+            "name": "asset_weight_init",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "asset_weight_maint",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "deposit_limit",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "Either `SolendPythPull` or `SolendSwitchboardPull`"
+            ],
+            "name": "oracle_setup",
+            "type": {
+              "defined": {
+                "name": "OracleSetup"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Bank operational state - allows starting banks in paused state"
+            ],
+            "name": "operational_state",
+            "type": {
+              "defined": {
+                "name": "BankOperationalState"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Risk tier - determines if assets can be borrowed in isolation"
+            ],
+            "name": "risk_tier",
+            "type": {
+              "defined": {
+                "name": "RiskTier"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Config flags for future-proofing"
+            ],
+            "name": "config_flags",
+            "type": "u8"
+          },
+          {
+            "name": "total_asset_value_init_limit",
+            "type": "u64"
+          },
+          {
+            "name": "oracle_max_age",
+            "type": "u16"
+          },
+          {
+            "docs": [
+              "Oracle confidence threshold (0 = use default 10%)"
+            ],
+            "name": "oracle_max_confidence",
+            "type": "u32"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "SolendMinimalReserve",
+      "repr": {
+        "kind": "c",
+        "packed": true
+      },
+      "serialization": "bytemuck",
+      "type": {
+        "fields": [
+          {
+            "docs": [
+              "Last slot when supply and rates updated"
+            ],
+            "name": "last_update_slot",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "True when marked stale"
+            ],
+            "name": "last_update_stale",
+            "type": "u8"
+          },
+          {
+            "docs": [
+              "Lending market address"
+            ],
+            "name": "lending_market",
+            "type": "pubkey"
+          },
+          {
+            "name": "liquidity_mint_pubkey",
+            "type": "pubkey"
+          },
+          {
+            "name": "liquidity_mint_decimals",
+            "type": "u8"
+          },
+          {
+            "name": "liquidity_supply_pubkey",
+            "type": "pubkey"
+          },
+          {
+            "name": "liquidity_pyth_oracle_pubkey",
+            "type": "pubkey"
+          },
+          {
+            "name": "liquidity_switchboard_oracle_pubkey",
+            "type": "pubkey"
+          },
+          {
+            "name": "liquidity_available_amount",
+            "type": "u64"
+          },
+          {
+            "name": "liquidity_borrowed_amount_wads",
+            "type": {
+              "array": [
+                "u8",
+                16
+              ]
+            }
+          },
+          {
+            "name": "liquidity_cumulative_borrow_rate_wads",
+            "type": {
+              "array": [
+                "u8",
+                16
+              ]
+            }
+          },
+          {
+            "name": "liquidity_market_price",
+            "type": {
+              "array": [
+                "u8",
+                16
+              ]
+            }
+          },
+          {
+            "name": "collateral_mint_pubkey",
+            "type": "pubkey"
+          },
+          {
+            "name": "collateral_mint_total_supply",
+            "type": "u64"
+          },
+          {
+            "name": "collateral_supply_pubkey",
+            "type": "pubkey"
+          },
+          {
+            "name": "config_optimal_utilization_rate",
+            "type": "u8"
+          },
+          {
+            "name": "config_loan_to_value_ratio",
+            "type": "u8"
+          },
+          {
+            "name": "config_liquidation_bonus",
+            "type": "u8"
+          },
+          {
+            "name": "config_liquidation_threshold",
+            "type": "u8"
+          },
+          {
+            "name": "_padding_to_fees_64",
+            "type": {
+              "array": [
+                "u8",
+                64
+              ]
+            }
+          },
+          {
+            "name": "_padding_to_fees_6",
+            "type": {
+              "array": [
+                "u8",
+                6
+              ]
+            }
+          },
+          {
+            "name": "liquidity_accumulated_protocol_fees_wads",
+            "type": {
+              "array": [
+                "u8",
+                16
+              ]
+            }
+          },
+          {
+            "name": "_padding_final_128",
+            "type": {
+              "array": [
+                "u8",
+                128
+              ]
+            }
+          },
+          {
+            "name": "_padding_final_64",
+            "type": {
+              "array": [
+                "u8",
+                64
+              ]
+            }
+          },
+          {
+            "name": "_padding_final_32",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "_padding_final_6",
+            "type": {
+              "array": [
+                "u8",
+                6
+              ]
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "SpotBalanceType",
+      "repr": {
+        "kind": "rust"
+      },
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Deposit"
+          },
+          {
+            "name": "Borrow"
+          }
+        ]
+      }
+    },
+    {
+      "docs": [
+        "Minimal representation of a spot position within a User account"
+      ],
+      "name": "SpotPosition",
+      "repr": {
+        "kind": "c"
+      },
+      "serialization": "bytemuck",
+      "type": {
+        "fields": [
+          {
+            "docs": [
+              "The scaled balance of the position.",
+              "* Precision: SPOT_BALANCE_PRECISION"
+            ],
+            "name": "scaled_balance",
+            "type": "u64"
+          },
+          {
+            "docs": [
+              "How many spot bids the user has open",
+              "* Precision: token mint precision"
+            ],
+            "name": "open_bids",
+            "type": "i64"
+          },
+          {
+            "docs": [
+              "How many spot asks the user has open",
+              "* Precision: token mint precision"
+            ],
+            "name": "open_asks",
+            "type": "i64"
+          },
+          {
+            "docs": [
+              "The cumulative deposits/borrows a user has made",
+              "* Precision: token mint precision"
+            ],
+            "name": "cumulative_deposits",
+            "type": "i64"
+          },
+          {
+            "docs": [
+              "The market index of the corresponding spot market"
+            ],
+            "name": "market_index",
+            "type": "u16"
+          },
+          {
+            "docs": [
+              "Whether the position is deposit or borrow"
+            ],
+            "name": "balance_type",
+            "type": {
+              "defined": {
+                "name": "SpotBalanceType"
+              }
+            }
+          },
+          {
+            "docs": [
+              "Number of open orders"
+            ],
+            "name": "open_orders",
+            "type": "u8"
+          },
+          {
+            "docs": [
+              "Padding"
+            ],
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                4
+              ]
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "docs": [
+        "Unique per-group. Staked Collateral banks created under a group automatically use these",
+        "settings. Groups that have not created this struct cannot create staked collateral banks. When",
+        "this struct updates, changes must be permissionlessly propagated to staked collateral banks.",
+        "Administrators can also edit the bank manually, i.e. with configure_bank, to temporarily make",
+        "changes such as raising the deposit limit for a single bank."
+      ],
+      "name": "StakedSettings",
+      "repr": {
+        "kind": "c"
+      },
+      "serialization": "bytemuck",
+      "type": {
+        "fields": [
+          {
+            "docs": [
+              "This account's own key. A PDA derived from `marginfi_group` and `STAKED_SETTINGS_SEED`"
+            ],
+            "name": "key",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "Group for which these settings apply"
+            ],
+            "name": "marginfi_group",
+            "type": "pubkey"
+          },
+          {
+            "docs": [
+              "Generally, the Pyth push oracle for SOL"
+            ],
+            "name": "oracle",
+            "type": "pubkey"
+          },
+          {
+            "name": "asset_weight_init",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "asset_weight_maint",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "deposit_limit",
+            "type": "u64"
+          },
+          {
+            "name": "total_asset_value_init_limit",
+            "type": "u64"
+          },
+          {
+            "name": "oracle_max_age",
+            "type": "u16"
+          },
+          {
+            "name": "risk_tier",
+            "type": {
+              "defined": {
+                "name": "RiskTier"
+              }
+            }
+          },
+          {
+            "name": "_pad0",
+            "type": {
+              "array": [
+                "u8",
+                5
+              ]
+            }
+          },
+          {
+            "docs": [
+              "The following values are irrelevant because staked collateral positions do not support",
+              "borrowing."
+            ],
+            "name": "_reserved0",
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          },
+          {
+            "name": "_reserved1",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "_reserved2",
+            "type": {
+              "array": [
+                "u8",
+                64
+              ]
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "StakedSettingsConfig",
+      "type": {
+        "fields": [
+          {
+            "name": "oracle",
+            "type": "pubkey"
+          },
+          {
+            "name": "asset_weight_init",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "asset_weight_maint",
+            "type": {
+              "defined": {
+                "name": "WrappedI80F48"
+              }
+            }
+          },
+          {
+            "name": "deposit_limit",
+            "type": "u64"
+          },
+          {
+            "name": "total_asset_value_init_limit",
+            "type": "u64"
+          },
+          {
+            "name": "oracle_max_age",
+            "type": "u16"
+          },
+          {
+            "docs": [
+              "WARN: You almost certainly want \"Collateral\", using Isolated risk tier makes the asset",
+              "worthless as collateral, and is generally useful only when creating a staked collateral pool",
+              "for rewards purposes only."
+            ],
+            "name": "risk_tier",
+            "type": {
+              "defined": {
+                "name": "RiskTier"
+              }
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "StakedSettingsEditConfig",
+      "type": {
+        "fields": [
+          {
+            "name": "oracle",
+            "type": {
+              "option": "pubkey"
+            }
+          },
+          {
+            "name": "asset_weight_init",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "WrappedI80F48"
+                }
+              }
+            }
+          },
+          {
+            "name": "asset_weight_maint",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "WrappedI80F48"
+                }
+              }
+            }
+          },
+          {
+            "name": "deposit_limit",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "total_asset_value_init_limit",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "oracle_max_age",
+            "type": {
+              "option": "u16"
+            }
+          },
+          {
+            "docs": [
+              "WARN: You almost certainly want \"Collateral\", using Isolated risk tier makes the asset",
+              "worthless as collateral, making all outstanding accounts eligible to be liquidated, and is",
+              "generally useful only when creating a staked collateral pool for rewards purposes only."
+            ],
+            "name": "risk_tier",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "RiskTier"
+                }
+              }
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "UserStatus",
+      "repr": {
+        "kind": "rust"
+      },
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Active"
+          },
+          {
+            "name": "BeingLiquidated"
+          },
+          {
+            "name": "Bankrupt"
+          },
+          {
+            "name": "ReduceOnly"
+          },
+          {
+            "name": "AdvancedLp"
+          },
+          {
+            "name": "ProtectedMakerOrders"
+          }
+        ]
+      }
+    },
+    {
+      "docs": [
+        "Tracks deleverage withdrawal limits to protect against compromised risk admin"
+      ],
+      "name": "WithdrawWindowCache",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "fields": [
+          {
+            "docs": [
+              "Maximum USD value that can be withdrawn per day via deleverage (0 = no limit)"
+            ],
+            "name": "daily_limit",
+            "type": "u32"
+          },
+          {
+            "docs": [
+              "USD value withdrawn today via deleverage (approximate, rounded)"
+            ],
+            "name": "withdrawn_today",
+            "type": "u32"
+          },
+          {
+            "docs": [
+              "Unix timestamp of the last daily counter reset"
+            ],
+            "name": "last_daily_reset_timestamp",
+            "type": "i64"
+          }
+        ],
+        "kind": "struct"
+      }
+    },
+    {
+      "name": "WrappedI80F48",
+      "repr": {
+        "align": 8,
+        "kind": "c"
+      },
+      "serialization": "bytemuck",
+      "type": {
+        "fields": [
+          {
+            "name": "value",
+            "type": {
+              "array": [
+                "u8",
+                16
+              ]
+            }
+          }
+        ],
+        "kind": "struct"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Updates the bundled IDL to match the on-chain program version `mrgn-0.1.8-rc3` which was deployed to mainnet on **March 27, 2026**.

## Problem

The SDK was failing with a Borsh decode error when fetching Marginfi accounts:
```
TypeError: Cannot read properties of null (reading 'property')
    at Union.decode (buffer-layout/lib/Layout.js:1692)
```

**Root Cause**: The SDK's IDL (0.1.7) didn't recognize the new account types added in the 0.1.8 on-chain program update:
- `Order` - new stop-loss/take-profit order account
- `ExecuteOrderRecord` - ephemeral account for order execution
- `Lending` - appears to be a new lending account type

When `AccountClient.all()` fetches all program accounts, it tries to decode them all using the old IDL and crashes on the new account types.

## Solution

1. Added `marginfi_0.1.8.json` - the IDL fetched from the on-chain program using `anchor idl fetch MFv2hWf31Z9kbCa1snEPYctwafyhdvnV7FZnsebVacA --provider.cluster mainnet`
2. Updated `index.ts` to export the 0.1.8 IDL

## Verification

```bash
# Fetch IDL from on-chain program
anchor idl fetch MFv2hWf31Z9kbCa1snEPYctwafyhdvnV7FZnsebVacA --provider.cluster mainnet

# The fetched IDL has 15 account types vs 12 in 0.1.7:
# New accounts: Order, ExecuteOrderRecord, Lending
```

## Known Issues

⚠️ **TypeScript types need regeneration**: The `marginfi-types_0.1.7.ts` file needs to be regenerated from the new IDL. This requires:

1. Building the marginfi-v2 Rust program with Anchor (in the `0dotxyz/marginfi-v2` repo)
2. Anchor will generate updated TypeScript types automatically
3. The types export in `index.ts` should be updated to use the new types

Currently using `as unknown as MarginfiIdlType` to bypass type checking until types are regenerated.

## Testing

The agent was tested with:
- QuickNode RPC ✅
- Helius RPC ✅  
- Both showed same BORSH_DECODE error before this fix

After this change, the `AccountClient.all()` should no longer crash on new account types.

## Checklist

- [x] IDL JSON updated to 0.1.8
- [ ] TypeScript types regenerated (needs Anchor build in marginfi-v2 repo)
- [ ] Version bump to 6.5.0 (maintainers will do this on release)