### PR TITLE
fix(marginfi-client-v2): cap PythLegacy confidence interval at MAX_CONFIDENCE_INTERVAL_RATIO

### DIFF
--- a/packages/marginfi-client-v2/src/services/price/utils/compute.utils.ts
+++ b/packages/marginfi-client-v2/src/services/price/utils/compute.utils.ts
@@ -59,7 +59,7 @@ function parseOraclePriceData(oracleSetup: OracleSetup, rawData: Buffer, fixedPr
       const pythConfidenceRealtimeCapped = capConfidenceInterval(
         pythPriceRealtime,
         pythConfidenceRealtime,
-        PYTH_PRICE_CONF_INTERVALS
+        MAX_CONFIDENCE_INTERVAL_RATIO
       );
       const pythLowestPriceRealtime = pythPriceRealtime.minus(pythConfidenceRealtimeCapped);
       const pythHighestPriceRealtime = pythPriceRealtime.plus(pythConfidenceRealtimeCapped);
@@ -71,7 +71,7 @@ function parseOraclePriceData(oracleSetup: OracleSetup, rawData: Buffer, fixedPr
       const pythConfIntervalWeightedCapped = capConfidenceInterval(
         pythPriceWeighted,
         pythConfIntervalWeighted,
-        PYTH_PRICE_CONF_INTERVALS
+        MAX_CONFIDENCE_INTERVAL_RATIO
       );
       const pythLowestPrice = pythPriceWeighted.minus(pythConfIntervalWeightedCapped);
       const pythHighestPrice = pythPriceWeighted.plus(pythConfIntervalWeightedCapped);


### PR DESCRIPTION
## What

For `OracleSetup.PythLegacy` banks the price confidence interval is effectively not capped. `parseOraclePriceData` passes `PYTH_PRICE_CONF_INTERVALS` (2.12) as the cap ratio to `capConfidenceInterval`, instead of the `MAX_CONFIDENCE_INTERVAL_RATIO` (0.05) that every other oracle path uses.

## Why

`capConfidenceInterval(price, confidence, maxConfidence)` returns `min(confidence, price * maxConfidence)`, so the third argument is the fraction of price the confidence is capped at. The PythLegacy branch passes `PYTH_PRICE_CONF_INTERVALS`:

```ts
const pythConfidenceRealtimeCapped = capConfidenceInterval(
  pythPriceRealtime,
  pythConfidenceRealtime,
  PYTH_PRICE_CONF_INTERVALS // 2.12
);
```

`PYTH_PRICE_CONF_INTERVALS` is the standard deviation multiplier already applied to the raw confidence a few lines above; it is not a cap ratio. Using it as the cap makes the ceiling `price * 2.12` (212 percent of price), which the confidence never reaches, so the interval is uncapped for legacy Pyth banks. Every other branch in this function (PythPushOracle, SwitchboardV2, SwitchboardPull) passes `MAX_CONFIDENCE_INTERVAL_RATIO` (0.05).

The effect is a wider low and high price band than intended. Example at price 100 with a published confidence of 8, so the scaled confidence is `8 * 2.12 = 16.96`:

- current: `min(16.96, 100 * 2.12) = 16.96`, lowest price 83.04
- fixed:   `min(16.96, 100 * 0.05) = 5`, lowest price 95.00

So the SDK values PythLegacy collateral about 12 percent below what the 5 percent cap gives, and over weights liabilities symmetrically.

## Change

Pass `MAX_CONFIDENCE_INTERVAL_RATIO` as the cap in both PythLegacy `capConfidenceInterval` calls, matching the other oracle paths. The `PYTH_PRICE_CONF_INTERVALS` multiplier on the raw confidence is unchanged.
